### PR TITLE
Scaffold ILM monorepo and add Protocol Manager frontend foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,351 +1,44 @@
 # Integrated Lab Manager
 
-**Integrated Lab Manager** is a modular, extensible platform for organizing scientific lab operations in a structured, software-native way.
+Integrated Lab Manager is a modular monorepo for structured lab operations software.
 
-It is designed to unify several categories of lab work that are often scattered across documents, spreadsheets, ad hoc notes, and disconnected tools, including:
+## Current status
 
-- wet-lab protocol design
-- supply and reagent management
-- project planning and tracking
-- funding and budget organization
-- experiment-associated documentation
-- future AI-assisted data structuring and workflow support
+The first implemented module is **Protocol Manager**, a browser-based protocol designer for wet-lab workflows with structured JSON storage.
 
-The long-term goal is to provide a cohesive environment for managing the informational and operational side of research labs while keeping the system flexible, transparent, and friendly to both humans and machines.
-
----
-
-## Vision
-
-Modern labs often rely on fragmented workflows:
-
-- protocols live in Word documents, PDFs, or notebooks
-- reagent inventories live in spreadsheets
-- project plans live in slides, notes, or task boards
-- budgets and funding records live elsewhere
-- structured reuse across these systems is limited
-- AI assistance is difficult because most information is unstructured
-
-Integrated Lab Manager aims to address this by treating core lab workflows as **structured, interoperable objects** rather than isolated documents.
-
-The platform is intended to evolve into a unified lab operations framework where protocols, supplies, projects, timelines, and resources can eventually connect to each other through shared data structures and modular interfaces.
-
----
-
-## Current focus
-
-The first major module is:
-
-### ProtoWeave — visual wet-lab protocol designer
-A browser-based visual editor for building wet-lab protocols with structured JSON storage and AI-assisted import/export workflows.
-
-ProtoWeave allows users to create protocols using:
-
-- sections and subsections
-- ordered steps
-- preparation and QC steps
-- optional branches
-- reaction recipe blocks
-- timeline blocks
-- caution/note blocks
-- external references and links
-
-This module serves as the first foundational component of the broader platform.
-
----
-
-## Planned platform modules
-
-The larger project is intended to grow into a modular system with components such as:
-
-### 1. Protocol Designer
-Structured authoring, editing, validation, reuse, and AI-assisted import of wet-lab protocols.
-
-### 2. Lab Supply & Reagent Management
-Inventory tracking for reagents, consumables, kits, and instruments, with future support for stock levels, vendors, storage locations, and ordering workflows.
-
-### 3. Project Management
-Tracking research projects, milestones, tasks, dependencies, and associated protocols or resources.
-
-### 4. Funding & Budget Management
-Organization of grants, budgets, spending categories, deadlines, and project-linked funding sources.
-
-### 5. Experiment / Workflow Planning
-Structured descriptions of experiments and operational plans that may eventually connect protocols, timelines, reagents, personnel, and deliverables.
-
-### 6. AI-Assisted Import / Structuring
-Tools to transform unstructured lab content into standardized data formats that can be edited and managed inside the platform.
-
----
-
-## Design philosophy
-
-Integrated Lab Manager is being built around several core principles:
-
-### Structured over ad hoc
-Lab information should be represented as explicit structured data where possible, not only as free text.
-
-### Modular by design
-Different functional areas should be implemented as modules that can evolve independently while still fitting into a larger shared architecture.
-
-### Human-readable and machine-readable
-Stored data should be understandable to users and easy for software or AI systems to validate, transform, and reuse.
-
-### Static-first where practical
-Early modules should work without requiring complex backend infrastructure whenever possible.
-
-### Extensible data model
-The system should support future expansion without breaking earlier content or forcing rigid assumptions too early.
-
-### Scientist-friendly UX
-The interface should prioritize clarity, low friction, and practical scientific workflows over flashy or overly abstract design.
-
----
-
-## Why this project exists
-
-Most lab management workflows are handled through a patchwork of:
-
-- office documents
-- spreadsheets
-- personal notes
-- task trackers
-- vendor portals
-- internal memory
-
-This makes it difficult to:
-
-- standardize procedures
-- reuse structured information
-- validate content
-- keep protocols and logistics connected
-- support AI tools in a reliable way
-
-Integrated Lab Manager is intended to provide a foundation for gradually moving these workflows into a more coherent and structured environment.
-
----
-
-## Repository scope
-
-This repository is intended to host the broader Integrated Lab Manager codebase.
-
-At the current stage, the primary emphasis is on building and refining the protocol-design subsystem first, while keeping the repository architecture ready for future modules.
-
-This means the repo should support:
-
-- clear separation of modules
-- shared type definitions where appropriate
-- reusable UI patterns
-- reusable data validation utilities
-- future expansion without large rewrites
-
----
-
-## Proposed repository structure
+## Monorepo layout
 
 ```text
 integrated-lab-manager/
 ├─ apps/
-│  ├─ protocol-designer/          # Current dev module
-│  ├─ supply-manager/             # future
-│  ├─ project-manager/            # future
-│  └─ funding-manager/            # future
+│  ├─ protocol-manager/      # implemented in this phase
+│  ├─ supply-manager/        # placeholder
+│  ├─ project-manager/       # placeholder
+│  └─ funding-manager/       # placeholder
 ├─ packages/
-│  ├─ ui/                         # shared UI components
-│  ├─ types/                      # shared TypeScript types
-│  ├─ validation/                 # shared schema/validation helpers
-│  ├─ utils/                      # shared utilities
-│  └─ ai-import/                  # shared AI import helpers/prompts
-├─ docs/
-│  ├─ architecture/
-│  ├─ schemas/
-│  ├─ product-specs/
-│  └─ examples/
+│  ├─ ai-import/             # AI import instructions + helpers
+│  ├─ types/                 # shared protocol TypeScript model
+│  ├─ validation/            # validation + normalization helpers
+│  ├─ utils/                 # ids + generic utility helpers
+│  └─ ui/                    # shared lightweight UI primitives
 ├─ examples/
-│  └─ protocols/
-├─ README.md
-└─ LICENSE
-````
-
-This structure is only a recommended direction and may evolve as the platform grows.
-
----
-
-## Future integration ideas across modules
-
-Over time, the platform may support links such as:
-
-* protocols referencing required reagents from inventory
-* projects referencing associated protocols
-* funding records referencing supported projects
-* experiments referencing both protocols and reagent usage
-* purchasing tied to inventory status and project budgets
-* AI-assisted conversion of legacy documents into structured records
-
-These are future directions rather than current commitments.
-
----
+│  └─ protocols/             # example protocol JSON files
+└─ docs/
+```
 
 ## Technical direction
 
-The project is intended to favor:
+- TypeScript across repo
+- React + Vite for Protocol Manager
+- static frontend-first architecture
+- canonical protocol JSON model with schema versioning and extension support
+- localStorage persistence (autosave) for the first release
 
-* **TypeScript-first development**
-* **strong data models**
-* **schema validation**
-* **component modularity**
-* **frontend architectures that can start simple and scale later**
+## Getting started
 
-For the protocol designer specifically, the current preferred stack is:
+```bash
+npm install
+npm run dev
+```
 
-* React
-* TypeScript
-* Vite
-* static deployment compatible with GitHub Pages
-* local storage for early persistence
-* structured JSON as canonical storage format
-
-As the broader project grows, some modules may eventually require backend services, but the architecture should avoid introducing unnecessary complexity too early.
-
----
-
-## AI compatibility
-
-A central design goal of Integrated Lab Manager is to make structured scientific content easier to generate, inspect, validate, and refine with AI assistance.
-
-This includes:
-
-* well-defined schemas
-* explicit controlled vocabularies where useful
-* portable import/export formats
-* repairable validation workflows
-* copyable AI import instructions for converting existing lab materials into structured formats
-
-AI is intended to assist with structuring and transformation, not replace scientific judgment.
-
----
-
-## Status
-
-This repository is currently in an early design and prototyping stage.
-
-Current emphasis:
-
-* defining the product architecture
-* designing the protocol data model
-* building the first editor module
-* establishing reusable schema and validation patterns
-* keeping the larger platform direction in mind from the beginning
-
----
-
-## Early roadmap
-
-### Phase 1
-
-Build the protocol designer module:
-
-* structured protocol data model
-* visual editor
-* JSON import/export
-* validation
-* AI-assisted import instructions
-* protocol preview
-
-### Phase 2
-
-Stabilize shared platform architecture:
-
-* shared UI package
-* shared type definitions
-* shared validation utilities
-* documentation of schema conventions
-
-### Phase 3
-
-Add additional operational modules:
-
-* supply/reagent management
-* project management
-* funding/budget organization
-
-### Phase 4
-
-Explore cross-module linking:
-
-* protocol-to-reagent links
-* project-to-protocol links
-* budget/project associations
-* experiment/workflow integration
-
----
-
-## Intended users
-
-This project is meant for:
-
-* academic labs
-* small research teams
-* computational/experimental hybrid labs
-* trainees and scientists who want more structured lab workflows
-* groups exploring AI-assisted scientific operations
-
----
-
-## Development priorities
-
-When building this repository, prioritize:
-
-1. clean data models
-2. modular architecture
-3. maintainable code
-4. scientist-friendly UX
-5. portability of stored data
-6. extensibility without overengineering
-
----
-
-## Contributing philosophy
-
-At this stage, contributions should align with the core design goals:
-
-* preserve modularity
-* avoid unnecessary complexity
-* keep schemas explicit and readable
-* prefer extensible structures over hard-coded assumptions
-* document new modules and interfaces clearly
-
-As the project matures, contribution guidelines can be formalized further.
-
----
-
-## Naming note
-
-**Integrated Lab Manager** is the umbrella platform name.
-
-The initial protocol-design submodule is currently referred to as:
-
-**Protocol Manager**
-*A visual, structured, AI-compatible wet-lab protocol designer.*
-
-This naming allows the broader repository to grow without forcing the protocol tool to carry the entire platform identity.
-
----
-
-## Long-term aspiration
-
-The long-term aspiration is to build a practical, extensible platform where structured scientific operations can be authored, organized, and gradually connected across the daily work of a research lab.
-
-Rather than replacing every existing tool immediately, Integrated Lab Manager aims to provide a strong structured foundation that can expand over time.
-
----
-
-## License
-
-Apache 2.0
-
----
-
-## Contact / notes
-
-This repository is currently under active design and prototyping. Documentation, schemas, and module boundaries are expected to evolve as the system takes shape.
+Then open the local URL shown by Vite.

--- a/apps/funding-manager/README.md
+++ b/apps/funding-manager/README.md
@@ -1,0 +1,3 @@
+# Funding Manager (Placeholder)
+
+Reserved for future budget and funding tracking module.

--- a/apps/project-manager/README.md
+++ b/apps/project-manager/README.md
@@ -1,0 +1,3 @@
+# Project Manager (Placeholder)
+
+Reserved for future project and milestone management module.

--- a/apps/protocol-manager/README.md
+++ b/apps/protocol-manager/README.md
@@ -1,0 +1,38 @@
+# Protocol Manager
+
+Protocol Manager is the first app in Integrated Lab Manager.
+
+## Purpose
+
+A scientist-friendly visual editor for building structured wet-lab protocols as portable, AI-compatible JSON.
+
+## Features in this phase
+
+- section/subsection/step outline editing
+- typed step kinds (`action`, `preparation`, `qc`, `optional`, `pause`, `cleanup`, `analysis`)
+- specialized block editors for:
+  - recipe
+  - timeline
+  - qc
+  - caution
+  - link
+- live preview panel
+- import/export panel with JSON validation
+- AI-assisted import instructions panel
+- localStorage autosave
+
+## Scripts
+
+```bash
+npm run dev
+npm run build
+npm run typecheck
+```
+
+## Data model principles
+
+- canonical JSON format
+- stable IDs
+- schema versioning (`1.0.0`)
+- content/presentation separation
+- unknown future data preserved under `extensions`

--- a/apps/protocol-manager/index.html
+++ b/apps/protocol-manager/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Protocol Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/protocol-manager/package.json
+++ b/apps/protocol-manager/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ilm/protocol-manager",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --pretty false",
+    "lint": "echo 'no lint configured for @ilm/protocol-manager'"
+  },
+  "dependencies": {
+    "@ilm/ai-import": "file:../../packages/ai-import",
+    "@ilm/types": "file:../../packages/types",
+    "@ilm/ui": "file:../../packages/ui",
+    "@ilm/utils": "file:../../packages/utils",
+    "@ilm/validation": "file:../../packages/validation",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from "react";
+import { Panel } from "@ilm/ui";
+import type { ProtocolDocument } from "@ilm/types";
+import { safeJsonParse, nowIso } from "@ilm/utils";
+import { normalizeProtocolDocument, validateProtocolDocument } from "@ilm/validation";
+import { createDefaultProtocol } from "./lib/defaultProtocol";
+import { EditorPanel } from "./components/EditorPanel";
+import { ImportExportPanel } from "./components/ImportExportPanel";
+import { OutlinePanel } from "./components/OutlinePanel";
+import { PreviewPanel } from "./components/PreviewPanel";
+import { addBlockToStep, addSection, addStep, type Selection } from "./state/protocolState";
+
+const STORAGE_KEY = "ilm.protocol-manager.document";
+
+export const App = () => {
+  const [doc, setDoc] = useState<ProtocolDocument>(createDefaultProtocol);
+  const [selection, setSelection] = useState<Selection>({ type: "protocol" });
+  const [jsonText, setJsonText] = useState("");
+  const [status, setStatus] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+    const parsed = safeJsonParse<unknown>(stored);
+    if (!parsed.ok) {
+      setStatus([`Could not parse autosaved document: ${parsed.error}`]);
+      return;
+    }
+    const result = validateProtocolDocument(parsed.value);
+    if (result.success && result.data) {
+      setDoc(normalizeProtocolDocument(result.data));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(doc, null, 2));
+  }, [doc]);
+
+  const exportedJson = useMemo(() => JSON.stringify(doc, null, 2), [doc]);
+
+  const importParsed = (value: unknown) => {
+    const result = validateProtocolDocument(value);
+    if (!result.success || !result.data) {
+      setStatus(["Import failed validation", ...result.errors]);
+      return;
+    }
+    const normalized = normalizeProtocolDocument(result.data);
+    setDoc({ ...normalized, protocol: { ...normalized.protocol, updatedAt: nowIso() } });
+    setStatus(["Import successful", "Document normalized and loaded."]);
+  };
+
+  return (
+    <main>
+      <header>
+        <h1>Integrated Lab Manager — Protocol Manager</h1>
+      </header>
+      <div className="layout">
+        <Panel title="1) Outline panel">
+          <div className="button-row">
+            <button onClick={() => setDoc(addSection(doc, "New top-level section"))}>Add section</button>
+            <button
+              onClick={() => {
+                if (selection.type === "section") {
+                  setDoc(addSection(doc, "New subsection", selection.sectionId));
+                }
+              }}
+            >
+              Add subsection
+            </button>
+            <button
+              onClick={() => {
+                if (selection.type === "section") {
+                  setDoc(addStep(doc, selection.sectionId, "New step"));
+                }
+              }}
+            >
+              Add step
+            </button>
+          </div>
+          <OutlinePanel sections={doc.protocol.sections} selection={selection} onSelect={setSelection} />
+        </Panel>
+
+        <Panel title="2) Editor panel">
+          <EditorPanel
+            doc={doc}
+            selectedStep={selection.type === "step" ? { sectionId: selection.sectionId, stepId: selection.stepId } : null}
+            onDocChange={(nextDoc) => setDoc({ ...nextDoc, protocol: { ...nextDoc.protocol, updatedAt: nowIso() } })}
+            onAddBlock={(type) => {
+              if (selection.type !== "step") return;
+              setDoc(addBlockToStep(doc, selection.sectionId, selection.stepId, type));
+            }}
+          />
+        </Panel>
+
+        <Panel title="3) Preview panel">
+          <PreviewPanel doc={doc} />
+        </Panel>
+
+        <Panel title="4) Import / export panel">
+          <ImportExportPanel
+            jsonText={jsonText || exportedJson}
+            setJsonText={setJsonText}
+            onImportText={() => {
+              const parsed = safeJsonParse<unknown>(jsonText);
+              if (!parsed.ok) {
+                setStatus([`Invalid JSON: ${parsed.error}`]);
+                return;
+              }
+              importParsed(parsed.value);
+            }}
+            onFileUpload={async (file) => {
+              const text = await file.text();
+              setJsonText(text);
+              const parsed = safeJsonParse<unknown>(text);
+              if (!parsed.ok) {
+                setStatus([`Invalid uploaded JSON: ${parsed.error}`]);
+                return;
+              }
+              importParsed(parsed.value);
+            }}
+            onCopyExport={async () => {
+              await navigator.clipboard.writeText(exportedJson);
+              setStatus(["Exported JSON copied to clipboard."]);
+            }}
+            status={status}
+          />
+        </Panel>
+      </div>
+    </main>
+  );
+};

--- a/apps/protocol-manager/src/components/EditorPanel.tsx
+++ b/apps/protocol-manager/src/components/EditorPanel.tsx
@@ -1,0 +1,132 @@
+import type { BlockType, ProtocolBlock, ProtocolDocument, ProtocolStep, StepKind } from "@ilm/types";
+import { findSection, mapStep, updateProtocol } from "../state/protocolState";
+
+interface EditorPanelProps {
+  doc: ProtocolDocument;
+  selectedStep: { sectionId: string; stepId: string } | null;
+  onDocChange: (doc: ProtocolDocument) => void;
+  onAddBlock: (type: BlockType) => void;
+}
+
+const STEP_KINDS: StepKind[] = ["action", "preparation", "qc", "optional", "pause", "cleanup", "analysis"];
+const BLOCK_TYPES: BlockType[] = ["paragraph", "note", "caution", "qc", "recipe", "timeline", "link", "table", "fileReference", "branch"];
+
+export const EditorPanel = ({ doc, selectedStep, onDocChange, onAddBlock }: EditorPanelProps) => {
+  const section = selectedStep ? findSection(doc.protocol.sections, selectedStep.sectionId) : null;
+  const step = selectedStep ? section?.steps.find((candidate) => candidate.id === selectedStep.stepId) : null;
+
+  if (!step || !section) {
+    return (
+      <div>
+        <h3>Protocol metadata</h3>
+        <label>Title<input className="field" value={doc.protocol.title} onChange={(e) => onDocChange(updateProtocol(doc, "title", e.target.value))} /></label>
+        <label>Description<textarea className="field" rows={4} value={doc.protocol.description ?? ""} onChange={(e) => onDocChange(updateProtocol(doc, "description", e.target.value))} /></label>
+      </div>
+    );
+  }
+
+  const saveStep = (nextStep: ProtocolStep) => {
+    const nextSections = mapStep(doc.protocol.sections, section.id, step.id, () => nextStep);
+    onDocChange({ ...doc, protocol: { ...doc.protocol, sections: nextSections } });
+  };
+
+  const saveBlock = (blockId: string, block: ProtocolBlock) => {
+    saveStep({ ...step, blocks: step.blocks.map((candidate) => (candidate.id === blockId ? block : candidate)) });
+  };
+
+  return (
+    <div>
+      <h3>Step editor</h3>
+      <label>Step title<input className="field" value={step.title} onChange={(e) => saveStep({ ...step, title: e.target.value })} /></label>
+      <label>Step kind
+        <select className="field" value={step.stepKind} onChange={(e) => saveStep({ ...step, stepKind: e.target.value as StepKind })}>
+          {STEP_KINDS.map((kind) => <option value={kind} key={kind}>{kind}</option>)}
+        </select>
+      </label>
+      <label>Add block
+        <select className="field" onChange={(e) => { if (e.target.value) onAddBlock(e.target.value as BlockType); e.currentTarget.value = ""; }}>
+          <option value="">Select block type</option>
+          {BLOCK_TYPES.map((type) => <option value={type} key={type}>{type}</option>)}
+        </select>
+      </label>
+      <div style={{ display: "grid", gap: 8 }}>
+        {step.blocks.map((block) => (
+          <BlockEditor key={block.id} block={block} onChange={(next) => saveBlock(block.id, next)} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const BlockEditor = ({ block, onChange }: { block: ProtocolBlock; onChange: (block: ProtocolBlock) => void }) => {
+  if (block.type === "recipe") {
+    return (
+      <div className="card">
+        <strong>Recipe block</strong>
+        <input className="field" placeholder="Title" value={block.title ?? ""} onChange={(e) => onChange({ ...block, title: e.target.value })} />
+        {block.items.map((item, index) => (
+          <div className="grid-2" key={index}>
+            <input className="field" placeholder="Component" value={item.component} onChange={(e) => onChange({ ...block, items: block.items.map((row, rowIndex) => rowIndex === index ? { ...row, component: e.target.value } : row) })} />
+            <input className="field" placeholder="Quantity" value={item.quantity} onChange={(e) => onChange({ ...block, items: block.items.map((row, rowIndex) => rowIndex === index ? { ...row, quantity: e.target.value } : row) })} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (block.type === "timeline") {
+    return (
+      <div className="card">
+        <strong>Timeline block</strong>
+        {block.stages.map((stage, index) => (
+          <div className="grid-2" key={index}>
+            <input className="field" placeholder="Stage" value={stage.label} onChange={(e) => onChange({ ...block, stages: block.stages.map((row, rowIndex) => rowIndex === index ? { ...row, label: e.target.value } : row) })} />
+            <input className="field" placeholder="Duration" value={stage.duration} onChange={(e) => onChange({ ...block, stages: block.stages.map((row, rowIndex) => rowIndex === index ? { ...row, duration: e.target.value } : row) })} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (block.type === "qc") {
+    return (
+      <div className="card">
+        <strong>QC block</strong>
+        <input className="field" placeholder="Checkpoint" value={block.checkpoint} onChange={(e) => onChange({ ...block, checkpoint: e.target.value })} />
+        <input className="field" placeholder="Acceptance criteria" value={block.acceptanceCriteria ?? ""} onChange={(e) => onChange({ ...block, acceptanceCriteria: e.target.value })} />
+      </div>
+    );
+  }
+  if (block.type === "caution") {
+    return (
+      <div className="card">
+        <strong>Caution block</strong>
+        <select className="field" value={block.severity ?? "medium"} onChange={(e) => onChange({ ...block, severity: e.target.value as "low" | "medium" | "high" })}>
+          <option value="low">low</option>
+          <option value="medium">medium</option>
+          <option value="high">high</option>
+        </select>
+        <textarea className="field" rows={3} value={block.text} onChange={(e) => onChange({ ...block, text: e.target.value })} />
+      </div>
+    );
+  }
+  if (block.type === "link") {
+    return (
+      <div className="card">
+        <strong>Link block</strong>
+        <input className="field" placeholder="Label" value={block.label} onChange={(e) => onChange({ ...block, label: e.target.value })} />
+        <input className="field" placeholder="URL" value={block.url} onChange={(e) => onChange({ ...block, url: e.target.value })} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <strong>{block.type} block</strong>
+      <textarea
+        className="field"
+        rows={3}
+        value={(block as { text?: string }).text ?? ""}
+        onChange={(e) => onChange({ ...(block as any), text: e.target.value })}
+      />
+    </div>
+  );
+};

--- a/apps/protocol-manager/src/components/ImportExportPanel.tsx
+++ b/apps/protocol-manager/src/components/ImportExportPanel.tsx
@@ -1,0 +1,55 @@
+import { AI_IMPORT_PANEL_TITLE, AI_IMPORT_INSTRUCTIONS_TEXT } from "@ilm/ai-import";
+
+interface ImportExportPanelProps {
+  jsonText: string;
+  setJsonText: (text: string) => void;
+  onImportText: () => void;
+  onFileUpload: (file: File) => void;
+  onCopyExport: () => void;
+  status: string[];
+}
+
+export const ImportExportPanel = ({
+  jsonText,
+  setJsonText,
+  onImportText,
+  onFileUpload,
+  onCopyExport,
+  status
+}: ImportExportPanelProps) => (
+  <div style={{ display: "grid", gap: 10 }}>
+    <textarea
+      rows={12}
+      value={jsonText}
+      onChange={(event) => setJsonText(event.target.value)}
+      placeholder="Paste protocol JSON here"
+      className="field"
+    />
+    <div className="button-row">
+      <button onClick={onImportText}>Import pasted JSON</button>
+      <button onClick={onCopyExport}>Copy exported JSON</button>
+      <label className="file-input">
+        Upload JSON
+        <input
+          type="file"
+          accept="application/json"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) onFileUpload(file);
+          }}
+        />
+      </label>
+    </div>
+    {status.length > 0 && (
+      <ul className="status-list">
+        {status.map((line, idx) => (
+          <li key={idx}>{line}</li>
+        ))}
+      </ul>
+    )}
+    <div>
+      <h3>{AI_IMPORT_PANEL_TITLE}</h3>
+      <textarea readOnly rows={14} value={AI_IMPORT_INSTRUCTIONS_TEXT} className="field" />
+    </div>
+  </div>
+);

--- a/apps/protocol-manager/src/components/OutlinePanel.tsx
+++ b/apps/protocol-manager/src/components/OutlinePanel.tsx
@@ -1,0 +1,34 @@
+import type { ProtocolSection } from "@ilm/types";
+import { Tag } from "@ilm/ui";
+import type { Selection } from "../state/protocolState";
+
+interface OutlinePanelProps {
+  sections: ProtocolSection[];
+  selection: Selection;
+  onSelect: (selection: Selection) => void;
+}
+
+export const OutlinePanel = ({ sections, selection, onSelect }: OutlinePanelProps) => {
+  const renderSection = (section: ProtocolSection, level = 0) => (
+    <div key={section.id} style={{ marginLeft: level * 12, marginBottom: 8 }}>
+      <button
+        className={selection.type === "section" && selection.sectionId === section.id ? "outline-item active" : "outline-item"}
+        onClick={() => onSelect({ type: "section", sectionId: section.id })}
+      >
+        📁 {section.title}
+      </button>
+      {section.steps.map((step) => (
+        <button
+          key={step.id}
+          className={selection.type === "step" && selection.stepId === step.id ? "outline-item step active" : "outline-item step"}
+          onClick={() => onSelect({ type: "step", sectionId: section.id, stepId: step.id })}
+        >
+          ▸ {step.title} <Tag label={step.stepKind} tone={step.stepKind === "qc" ? "warning" : "info"} />
+        </button>
+      ))}
+      {section.sections.map((sub) => renderSection(sub, level + 1))}
+    </div>
+  );
+
+  return <div>{sections.map((section) => renderSection(section))}</div>;
+};

--- a/apps/protocol-manager/src/components/PreviewPanel.tsx
+++ b/apps/protocol-manager/src/components/PreviewPanel.tsx
@@ -1,0 +1,58 @@
+import type { ProtocolBlock, ProtocolDocument, ProtocolSection, ProtocolStep } from "@ilm/types";
+
+export const PreviewPanel = ({ doc }: { doc: ProtocolDocument }) => {
+  const renderBlock = (block: ProtocolBlock) => {
+    if (block.type === "paragraph") return <p>{block.text}</p>;
+    if (block.type === "note") return <p style={{ background: "#f8fafc", padding: 8 }}>📝 {block.text}</p>;
+    if (block.type === "caution") return <p style={{ borderLeft: "4px solid #ef4444", paddingLeft: 8 }}>⚠️ {block.text}</p>;
+    if (block.type === "qc")
+      return (
+        <p style={{ borderLeft: "4px solid #eab308", paddingLeft: 8 }}>
+          ✅ <strong>{block.checkpoint}</strong>
+          {block.acceptanceCriteria ? ` — ${block.acceptanceCriteria}` : ""}
+        </p>
+      );
+    if (block.type === "recipe")
+      return (
+        <div>
+          <strong>Recipe: {block.title || "Mixture"}</strong>
+          <ul>{block.items.map((item, idx) => <li key={idx}>{item.component}: {item.quantity}</li>)}</ul>
+        </div>
+      );
+    if (block.type === "timeline")
+      return (
+        <ol>
+          {block.stages.map((stage, idx) => (
+            <li key={idx}>{stage.label} — {stage.duration} {stage.temperature ? `(${stage.temperature})` : ""}</li>
+          ))}
+        </ol>
+      );
+    if (block.type === "link") return <p>🔗 <a href={block.url}>{block.label}</a></p>;
+    return <pre>{JSON.stringify(block, null, 2)}</pre>;
+  };
+
+  const renderStep = (step: ProtocolStep, index: number) => (
+    <article key={step.id} className={`preview-step kind-${step.stepKind}`}>
+      <h4>
+        {index + 1}. {step.title} <small>({step.stepKind})</small>
+      </h4>
+      {step.blocks.map((block) => <div key={block.id}>{renderBlock(block)}</div>)}
+    </article>
+  );
+
+  const renderSection = (section: ProtocolSection, path: string) => (
+    <section key={section.id} className="preview-section">
+      <h3>{path} {section.title}</h3>
+      {section.steps.map((step, index) => renderStep(step, index))}
+      {section.sections.map((sub, index) => renderSection(sub, `${path}${index + 1}.`))}
+    </section>
+  );
+
+  return (
+    <div>
+      <h2>{doc.protocol.title}</h2>
+      <p>{doc.protocol.description}</p>
+      {doc.protocol.sections.map((section, index) => renderSection(section, `${index + 1}.`))}
+    </div>
+  );
+};

--- a/apps/protocol-manager/src/lib/defaultProtocol.ts
+++ b/apps/protocol-manager/src/lib/defaultProtocol.ts
@@ -1,0 +1,96 @@
+import type {
+  CautionBlock,
+  LinkBlock,
+  ParagraphBlock,
+  ProtocolDocument,
+  ProtocolSection,
+  ProtocolStep,
+  QcBlock,
+  RecipeBlock,
+  TimelineBlock
+} from "@ilm/types";
+import { PROTOCOL_SCHEMA_VERSION } from "@ilm/types";
+import { createStableId, nowIso } from "@ilm/utils";
+
+export const createDefaultProtocol = (): ProtocolDocument => {
+  const now = nowIso();
+  const recipe: RecipeBlock = {
+    id: "block-master-mix",
+    type: "recipe",
+    title: "Master mix",
+    items: [
+      { component: "2x PCR mix", quantity: "12.5 µL" },
+      { component: "Forward primer", quantity: "0.5 µL" },
+      { component: "Reverse primer", quantity: "0.5 µL" },
+      { component: "Nuclease-free water", quantity: "10.5 µL" }
+    ]
+  };
+
+  const timeline: TimelineBlock = {
+    id: "block-pcr-cycling",
+    type: "timeline",
+    stages: [
+      { label: "Initial denaturation", duration: "3 min", temperature: "95°C" },
+      { label: "35 cycles", duration: "30 s each", details: "95°C / 58°C / 72°C" },
+      { label: "Final extension", duration: "5 min", temperature: "72°C" }
+    ]
+  };
+
+  const caution: CautionBlock = {
+    id: "block-aerosol-warning",
+    type: "caution",
+    severity: "high",
+    text: "Use separate pre-PCR and post-PCR areas to avoid contamination."
+  };
+
+  const qc: QcBlock = {
+    id: "block-gel-qc",
+    type: "qc",
+    checkpoint: "Run 5 µL product on 1.5% agarose gel",
+    acceptanceCriteria: "Single band at expected amplicon size"
+  };
+
+  const link: LinkBlock = {
+    id: "block-manufacturer-protocol",
+    type: "link",
+    label: "Enzyme datasheet",
+    url: "https://example.org/datasheet"
+  };
+
+  const intro: ParagraphBlock = {
+    id: "block-intro",
+    type: "paragraph",
+    text: "Prepare reaction mix on ice, then run amplification and verify product quality."
+  };
+
+  const steps: ProtocolStep[] = [
+    { id: "step-prepare-mix", title: "Prepare reaction mix", stepKind: "preparation", blocks: [intro, recipe, caution] },
+    { id: "step-run-program", title: "Run thermal cycler", stepKind: "action", blocks: [timeline, link] },
+    { id: "step-verify-product", title: "Check amplicon quality", stepKind: "qc", blocks: [qc] }
+  ];
+
+  const section: ProtocolSection = {
+    id: createStableId("section", "PCR setup"),
+    title: "PCR setup",
+    description: "Core amplification workflow",
+    sections: [],
+    steps
+  };
+
+  return {
+    schemaVersion: PROTOCOL_SCHEMA_VERSION,
+    protocol: {
+      id: "protocol-pcr-basic",
+      title: "Basic PCR Amplification",
+      description: "Starter template for Protocol Manager",
+      createdAt: now,
+      updatedAt: now,
+      authors: ["Integrated Lab Manager"],
+      tags: ["PCR", "DNA"],
+      metadata: { objective: "Generate target amplicon" },
+      sections: [section],
+      extensions: {}
+    },
+    extensions: {}
+  };
+};

--- a/apps/protocol-manager/src/main.tsx
+++ b/apps/protocol-manager/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/protocol-manager/src/state/protocolState.ts
+++ b/apps/protocol-manager/src/state/protocolState.ts
@@ -1,0 +1,102 @@
+import type { BlockType, ProtocolBlock, ProtocolDocument, ProtocolSection, ProtocolStep, StepKind } from "@ilm/types";
+import { createStableId } from "@ilm/utils";
+
+export type Selection =
+  | { type: "protocol" }
+  | { type: "section"; sectionId: string }
+  | { type: "step"; sectionId: string; stepId: string };
+
+export const findSection = (sections: ProtocolSection[], id: string): ProtocolSection | null => {
+  for (const section of sections) {
+    if (section.id === id) return section;
+    const nested = findSection(section.sections, id);
+    if (nested) return nested;
+  }
+  return null;
+};
+
+export const mapSections = (sections: ProtocolSection[], id: string, mapFn: (section: ProtocolSection) => ProtocolSection): ProtocolSection[] =>
+  sections.map((section) =>
+    section.id === id ? mapFn(section) : { ...section, sections: mapSections(section.sections, id, mapFn) }
+  );
+
+export const addSection = (doc: ProtocolDocument, title: string, parentId?: string): ProtocolDocument => {
+  const section: ProtocolSection = {
+    id: createStableId("section", `${title}-${Date.now()}`),
+    title: title || "New section",
+    description: "",
+    sections: [],
+    steps: []
+  };
+  if (!parentId) return { ...doc, protocol: { ...doc.protocol, sections: [...doc.protocol.sections, section] } };
+  return {
+    ...doc,
+    protocol: {
+      ...doc.protocol,
+      sections: mapSections(doc.protocol.sections, parentId, (parent) => ({ ...parent, sections: [...parent.sections, section] }))
+    }
+  };
+};
+
+export const addStep = (doc: ProtocolDocument, sectionId: string, title: string, stepKind: StepKind = "action"): ProtocolDocument => {
+  const newStep: ProtocolStep = {
+    id: createStableId("step", `${title}-${Date.now()}`),
+    title: title || "New step",
+    stepKind,
+    blocks: [{ id: createStableId("block", `paragraph-${Date.now()}`), type: "paragraph", text: "" }]
+  };
+  return {
+    ...doc,
+    protocol: {
+      ...doc.protocol,
+      sections: mapSections(doc.protocol.sections, sectionId, (section) => ({ ...section, steps: [...section.steps, newStep] }))
+    }
+  };
+};
+
+export const mapStep = (
+  sections: ProtocolSection[],
+  sectionId: string,
+  stepId: string,
+  mapFn: (step: ProtocolStep) => ProtocolStep
+): ProtocolSection[] =>
+  sections.map((section) => {
+    if (section.id === sectionId) {
+      return { ...section, steps: section.steps.map((step) => (step.id === stepId ? mapFn(step) : step)) };
+    }
+    return { ...section, sections: mapStep(section.sections, sectionId, stepId, mapFn) };
+  });
+
+export const addBlockToStep = (doc: ProtocolDocument, sectionId: string, stepId: string, blockType: BlockType): ProtocolDocument => {
+  const block = createBlock(blockType);
+  return {
+    ...doc,
+    protocol: {
+      ...doc.protocol,
+      sections: mapStep(doc.protocol.sections, sectionId, stepId, (step) => ({ ...step, blocks: [...step.blocks, block] }))
+    }
+  };
+};
+
+const createBlock = (type: BlockType): ProtocolBlock => {
+  const id = createStableId("block", `${type}-${Date.now()}`);
+  if (type === "paragraph") return { id, type, text: "" };
+  if (type === "note") return { id, type, text: "" };
+  if (type === "caution") return { id, type, text: "", severity: "medium" };
+  if (type === "qc") return { id, type, checkpoint: "", acceptanceCriteria: "" };
+  if (type === "recipe") return { id, type, title: "", items: [{ component: "", quantity: "", notes: "" }] };
+  if (type === "timeline") return { id, type, stages: [{ label: "", duration: "", temperature: "", details: "" }] };
+  if (type === "link") return { id, type, label: "", url: "https://" };
+  if (type === "table") return { id, type, columns: ["Column A"], rows: [[""]] };
+  if (type === "fileReference") return { id, type, label: "", path: "" };
+  return { id, type: "branch", condition: "", thenStepIds: [] };
+};
+
+export const updateProtocol = <T extends keyof ProtocolDocument["protocol"]>(
+  doc: ProtocolDocument,
+  key: T,
+  value: ProtocolDocument["protocol"][T]
+): ProtocolDocument => ({
+  ...doc,
+  protocol: { ...doc.protocol, [key]: value }
+});

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -1,0 +1,54 @@
+:root {
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  color: #0f172a;
+  background: #f8fafc;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; }
+main { padding: 14px; }
+header h1 { margin: 0 0 12px; font-size: 1.2rem; }
+.layout {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
+}
+
+button {
+  border: 1px solid #94a3b8;
+  background: #f1f5f9;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+label { display: grid; gap: 4px; font-size: 14px; margin-bottom: 8px; }
+.field {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 8px;
+  width: 100%;
+  font: inherit;
+}
+
+.button-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
+.outline-item {
+  border: none;
+  background: transparent;
+  display: block;
+  padding: 4px;
+  width: 100%;
+  text-align: left;
+}
+.outline-item.step { margin-left: 12px; }
+.outline-item.active { background: #dbeafe; border-radius: 6px; }
+.preview-step { border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px; margin-bottom: 10px; background: #fff; }
+.kind-qc { border-left: 4px solid #eab308; }
+.kind-preparation { border-left: 4px solid #0284c7; }
+.kind-optional { border-left: 4px solid #94a3b8; }
+.kind-pause { border-left: 4px solid #f97316; }
+.card { border: 1px solid #e2e8f0; border-radius: 8px; padding: 8px; background: #f8fafc; }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.status-list { margin: 0; padding-left: 18px; font-size: 14px; color: #1e293b; }
+.file-input input { display: none; }
+.file-input { border: 1px dashed #94a3b8; padding: 6px 10px; border-radius: 6px; cursor: pointer; }

--- a/apps/protocol-manager/tsconfig.json
+++ b/apps/protocol-manager/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/apps/protocol-manager/vite.config.ts
+++ b/apps/protocol-manager/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: { port: 5173 }
+});

--- a/apps/supply-manager/README.md
+++ b/apps/supply-manager/README.md
@@ -1,0 +1,3 @@
+# Supply Manager (Placeholder)
+
+Reserved for future inventory and reagent management module.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Docs
+
+Reserved for architecture notes, schema evolution docs, and module design records.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+Reference example data for Integrated Lab Manager modules.

--- a/examples/protocols/basic-pcr.json
+++ b/examples/protocols/basic-pcr.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0.0",
+  "protocol": {
+    "id": "protocol-basic-pcr",
+    "title": "Basic PCR Amplification",
+    "description": "Example protocol demonstrating sections, step kinds, and typed blocks.",
+    "createdAt": "2026-04-17T00:00:00.000Z",
+    "updatedAt": "2026-04-17T00:00:00.000Z",
+    "authors": ["Integrated Lab Manager"],
+    "tags": ["PCR", "Example"],
+    "metadata": {
+      "organism": "generic"
+    },
+    "sections": [
+      {
+        "id": "section-pcr-setup",
+        "title": "PCR setup",
+        "description": "Set up reaction and run program",
+        "sections": [],
+        "steps": [
+          {
+            "id": "step-prep-mix",
+            "title": "Prepare reaction mix",
+            "stepKind": "preparation",
+            "blocks": [
+              {
+                "id": "block-recipe",
+                "type": "recipe",
+                "title": "Master Mix",
+                "items": [
+                  { "component": "2x PCR mix", "quantity": "12.5 µL" },
+                  { "component": "Forward primer", "quantity": "0.5 µL" },
+                  { "component": "Reverse primer", "quantity": "0.5 µL" },
+                  { "component": "Water", "quantity": "10.5 µL" }
+                ]
+              },
+              {
+                "id": "block-caution",
+                "type": "caution",
+                "severity": "high",
+                "text": "Use aerosol-resistant tips and separated pre/post-PCR spaces."
+              }
+            ]
+          },
+          {
+            "id": "step-cycler",
+            "title": "Run thermal program",
+            "stepKind": "action",
+            "blocks": [
+              {
+                "id": "block-timeline",
+                "type": "timeline",
+                "stages": [
+                  { "label": "Initial denaturation", "duration": "3 min", "temperature": "95°C" },
+                  { "label": "35 cycles", "duration": "30 s each", "details": "95°C / 58°C / 72°C" },
+                  { "label": "Final extension", "duration": "5 min", "temperature": "72°C" }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step-gel-qc",
+            "title": "QC on agarose gel",
+            "stepKind": "qc",
+            "blocks": [
+              {
+                "id": "block-qc",
+                "type": "qc",
+                "checkpoint": "Run 5 µL product on 1.5% agarose gel",
+                "acceptanceCriteria": "Single expected-size band"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "extensions": {}
+  },
+  "extensions": {}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "integrated-lab-manager",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run --workspaces build",
+    "dev": "npm run -w @ilm/protocol-manager dev",
+    "lint": "npm run --workspaces lint",
+    "typecheck": "npm run --workspaces typecheck"
+  }
+}

--- a/packages/ai-import/README.md
+++ b/packages/ai-import/README.md
@@ -1,0 +1,3 @@
+# ai-import
+
+Shared package for Integrated Lab Manager.

--- a/packages/ai-import/package.json
+++ b/packages/ai-import/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ilm/ai-import",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@ilm/types": "file:../types"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo 'no lint configured for @ilm/ai-import'"
+  }
+}

--- a/packages/ai-import/src/index.ts
+++ b/packages/ai-import/src/index.ts
@@ -1,0 +1,19 @@
+export const AI_IMPORT_PANEL_TITLE = "Instructions for AI-assisted protocol import";
+
+export const AI_IMPORT_RULES = [
+  "Output valid JSON only. No markdown fences. No commentary.",
+  "Preserve the original procedure content as faithfully as possible.",
+  "Organize the protocol into protocol metadata, sections, subsections if needed, ordered steps, and typed blocks.",
+  "Use stepKind only from: action, preparation, qc, optional, pause, cleanup, analysis",
+  "Use block types only from: paragraph, note, caution, qc, recipe, timeline, link, table, fileReference, branch",
+  "Put reaction mixtures into recipe blocks.",
+  "Put cycling programs, incubation schedules, and multi-stage time plans into timeline blocks.",
+  "Put warnings or critical handling notes into caution blocks.",
+  "Put quality control checkpoints into qc blocks or steps with stepKind=\"qc\".",
+  "If information is missing or ambiguous, preserve it in a note block instead of inventing details.",
+  "Keep units exactly as written when possible.",
+  "Create stable human-readable IDs.",
+  "Use schemaVersion \"1.0.0\"."
+] as const;
+
+export const AI_IMPORT_INSTRUCTIONS_TEXT = AI_IMPORT_RULES.map((rule, index) => `${index + 1}. ${rule}`).join("\n");

--- a/packages/ai-import/tsconfig.json
+++ b/packages/ai-import/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,3 @@
+# types
+
+Shared package for Integrated Lab Manager.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ilm/types",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo 'no lint configured for @ilm/types'"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,134 @@
+export const PROTOCOL_SCHEMA_VERSION = "1.0.0" as const;
+
+export type StepKind =
+  | "action"
+  | "preparation"
+  | "qc"
+  | "optional"
+  | "pause"
+  | "cleanup"
+  | "analysis";
+
+export type BlockType =
+  | "paragraph"
+  | "note"
+  | "caution"
+  | "qc"
+  | "recipe"
+  | "timeline"
+  | "link"
+  | "table"
+  | "fileReference"
+  | "branch";
+
+export interface ProtocolDocument {
+  schemaVersion: typeof PROTOCOL_SCHEMA_VERSION;
+  protocol: Protocol;
+  extensions?: Record<string, unknown>;
+}
+
+export interface Protocol {
+  id: string;
+  title: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  authors: string[];
+  tags: string[];
+  metadata?: Record<string, unknown>;
+  sections: ProtocolSection[];
+  extensions?: Record<string, unknown>;
+}
+
+export interface ProtocolSection {
+  id: string;
+  title: string;
+  description?: string;
+  sections: ProtocolSection[];
+  steps: ProtocolStep[];
+  extensions?: Record<string, unknown>;
+}
+
+export interface ProtocolStep {
+  id: string;
+  title: string;
+  stepKind: StepKind;
+  blocks: ProtocolBlock[];
+  optional?: boolean;
+  extensions?: Record<string, unknown>;
+}
+
+interface BaseBlock {
+  id: string;
+  type: BlockType;
+  extensions?: Record<string, unknown>;
+}
+
+export interface ParagraphBlock extends BaseBlock {
+  type: "paragraph";
+  text: string;
+}
+
+export interface NoteBlock extends BaseBlock {
+  type: "note";
+  text: string;
+}
+
+export interface CautionBlock extends BaseBlock {
+  type: "caution";
+  severity?: "low" | "medium" | "high";
+  text: string;
+}
+
+export interface QcBlock extends BaseBlock {
+  type: "qc";
+  checkpoint: string;
+  acceptanceCriteria?: string;
+}
+
+export interface RecipeBlock extends BaseBlock {
+  type: "recipe";
+  title?: string;
+  items: { component: string; quantity: string; notes?: string }[];
+}
+
+export interface TimelineBlock extends BaseBlock {
+  type: "timeline";
+  stages: { label: string; duration: string; temperature?: string; details?: string }[];
+}
+
+export interface LinkBlock extends BaseBlock {
+  type: "link";
+  label: string;
+  url: string;
+}
+
+export interface TableBlock extends BaseBlock {
+  type: "table";
+  columns: string[];
+  rows: string[][];
+}
+
+export interface FileReferenceBlock extends BaseBlock {
+  type: "fileReference";
+  label: string;
+  path: string;
+}
+
+export interface BranchBlock extends BaseBlock {
+  type: "branch";
+  condition: string;
+  thenStepIds: string[];
+}
+
+export type ProtocolBlock =
+  | ParagraphBlock
+  | NoteBlock
+  | CautionBlock
+  | QcBlock
+  | RecipeBlock
+  | TimelineBlock
+  | LinkBlock
+  | TableBlock
+  | FileReferenceBlock
+  | BranchBlock;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,3 @@
+# ui
+
+Shared package for Integrated Lab Manager.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ilm/ui",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo 'no lint configured for @ilm/ui'"
+  }
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,22 @@
+import type { PropsWithChildren } from "react";
+
+export const Panel = ({ title, children }: PropsWithChildren<{ title: string }>) => (
+  <section style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: 12, background: "#fff" }}>
+    <h2 style={{ margin: "0 0 10px", fontSize: 16 }}>{title}</h2>
+    {children}
+  </section>
+);
+
+export const Tag = ({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "info" | "warning" | "success" }) => {
+  const colors: Record<string, string> = {
+    neutral: "#e2e8f0",
+    info: "#dbeafe",
+    warning: "#fee2e2",
+    success: "#dcfce7"
+  };
+  return (
+    <span style={{ background: colors[tone], borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 600 }}>
+      {label}
+    </span>
+  );
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,3 @@
+# utils
+
+Shared package for Integrated Lab Manager.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ilm/utils",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo 'no lint configured for @ilm/utils'"
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,22 @@
+export const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+
+export const createStableId = (prefix: string, label: string, fallback = "item"): string => {
+  const base = slugify(label || fallback) || fallback;
+  return `${prefix}-${base}`;
+};
+
+export const nowIso = (): string => new Date().toISOString();
+
+export const safeJsonParse = <T>(text: string): { ok: true; value: T } | { ok: false; error: string } => {
+  try {
+    return { ok: true, value: JSON.parse(text) as T };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Unknown JSON parse error" };
+  }
+};

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -1,0 +1,3 @@
+# validation
+
+Shared package for Integrated Lab Manager.

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ilm/validation",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@ilm/types": "file:../types",
+    "zod": "^3.24.1"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo 'no lint configured for @ilm/validation'"
+  }
+}

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -1,0 +1,131 @@
+import { PROTOCOL_SCHEMA_VERSION, type ProtocolDocument } from "@ilm/types";
+import { z } from "zod";
+
+const stepKindSchema = z.enum(["action", "preparation", "qc", "optional", "pause", "cleanup", "analysis"]);
+const blockTypeSchema = z.enum([
+  "paragraph",
+  "note",
+  "caution",
+  "qc",
+  "recipe",
+  "timeline",
+  "link",
+  "table",
+  "fileReference",
+  "branch"
+]);
+
+const extensionSchema = z.record(z.unknown()).optional();
+
+const recipeItemSchema = z.object({
+  component: z.string().min(1),
+  quantity: z.string().min(1),
+  notes: z.string().optional()
+});
+
+const timelineStageSchema = z.object({
+  label: z.string().min(1),
+  duration: z.string().min(1),
+  temperature: z.string().optional(),
+  details: z.string().optional()
+});
+
+const blockSchema = z
+  .object({
+    id: z.string().min(1),
+    type: blockTypeSchema,
+    extensions: extensionSchema
+  })
+  .and(
+    z.union([
+      z.object({ type: z.literal("paragraph"), text: z.string() }),
+      z.object({ type: z.literal("note"), text: z.string() }),
+      z.object({ type: z.literal("caution"), text: z.string(), severity: z.enum(["low", "medium", "high"]).optional() }),
+      z.object({ type: z.literal("qc"), checkpoint: z.string().min(1), acceptanceCriteria: z.string().optional() }),
+      z.object({ type: z.literal("recipe"), title: z.string().optional(), items: z.array(recipeItemSchema) }),
+      z.object({ type: z.literal("timeline"), stages: z.array(timelineStageSchema) }),
+      z.object({ type: z.literal("link"), label: z.string().min(1), url: z.string().url() }),
+      z.object({ type: z.literal("table"), columns: z.array(z.string()), rows: z.array(z.array(z.string())) }),
+      z.object({ type: z.literal("fileReference"), label: z.string().min(1), path: z.string().min(1) }),
+      z.object({ type: z.literal("branch"), condition: z.string().min(1), thenStepIds: z.array(z.string()) })
+    ])
+  );
+
+const stepSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    stepKind: stepKindSchema,
+    optional: z.boolean().optional(),
+    blocks: z.array(blockSchema),
+    extensions: extensionSchema
+  })
+);
+
+const sectionSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().optional(),
+    sections: z.array(sectionSchema),
+    steps: z.array(stepSchema),
+    extensions: extensionSchema
+  })
+);
+
+export const protocolSchema = z.object({
+  schemaVersion: z.literal(PROTOCOL_SCHEMA_VERSION),
+  protocol: z.object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().optional(),
+    createdAt: z.string().min(1),
+    updatedAt: z.string().min(1),
+    authors: z.array(z.string()),
+    tags: z.array(z.string()),
+    metadata: z.record(z.unknown()).optional(),
+    sections: z.array(sectionSchema),
+    extensions: extensionSchema
+  }),
+  extensions: extensionSchema
+});
+
+export interface ValidationResult {
+  success: boolean;
+  errors: string[];
+  data?: ProtocolDocument;
+}
+
+export const validateProtocolDocument = (input: unknown): ValidationResult => {
+  const parsed = protocolSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      errors: parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+    };
+  }
+  return { success: true, errors: [], data: parsed.data as ProtocolDocument };
+};
+
+export const normalizeProtocolDocument = (doc: ProtocolDocument): ProtocolDocument => ({
+  ...doc,
+  schemaVersion: PROTOCOL_SCHEMA_VERSION,
+  protocol: {
+    ...doc.protocol,
+    metadata: doc.protocol.metadata ?? {},
+    extensions: doc.protocol.extensions ?? {},
+    sections: doc.protocol.sections.map((section) => normalizeSection(section))
+  },
+  extensions: doc.extensions ?? {}
+});
+
+const normalizeSection = (section: ProtocolDocument["protocol"]["sections"][number]) => ({
+  ...section,
+  sections: section.sections.map((child) => normalizeSection(child)),
+  steps: section.steps.map((step) => ({
+    ...step,
+    extensions: step.extensions ?? {},
+    blocks: step.blocks.map((block) => ({ ...block, extensions: block.extensions ?? {} }))
+  })),
+  extensions: section.extensions ?? {}
+});

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/types" },
+    { "path": "packages/utils" },
+    { "path": "packages/validation" },
+    { "path": "packages/ai-import" },
+    { "path": "packages/ui" },
+    { "path": "apps/protocol-manager" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Establish a scalable TypeScript monorepo layout for Integrated Lab Manager so future modules can be added without large rewrites.
- Provide a concrete first module, Protocol Manager, as a static-first React + Vite app that stores canonical protocols as structured JSON and supports AI-assisted import guidance.
- Create small, practical shared packages (`types`, `validation`, `utils`, `ui`, `ai-import`) that encapsulate schema, validation, helpers, and the AI import prompt so they can be reused by future apps.
- Keep the initial product frontend-only with local persistence and a clear, versioned protocol data model to maximize portability and AI compatibility.

### Description
- Scaffolds monorepo layout with `apps/*` and `packages/*`, adds root `package.json`, `tsconfig` references, and `tsconfig.base.json`, and populates `README.md` and module README files for discoverability.
- Adds shared packages: `@ilm/types` (protocol schema and TypeScript types with `schemaVersion = "1.0.0"`), `@ilm/validation` (Zod-based validation and `normalizeProtocolDocument`), `@ilm/utils` (stable id, slugify, `nowIso`, safe JSON parse), `@ilm/ui` (minimal `Panel` and `Tag` primitives), and `@ilm/ai-import` (copyable AI import instructions/constants).
- Implements the Protocol Manager app under `apps/protocol-manager` (React + TypeScript + Vite) with a four-panel UI: Outline panel, Editor panel with specialized block editors (recipe, timeline, qc, caution, link), Preview panel that renders typed blocks and step kinds, and Import/Export panel that exposes AI-import instructions and validation feedback.
- Adds localStorage autosave/load (`ilm.protocol-manager.document`), stable id generation for sections/steps/blocks, import flow that runs `validateProtocolDocument` and `normalizeProtocolDocument` before loading, and an example protocol JSON at `examples/protocols/basic-pcr.json`.

### Testing
- Attempted `npm install`, but installation failed in this environment due to restricted registry access (`403 Forbidden`), so dependencies could not be resolved. 
- Attempted `npm run typecheck` to run project type checks, but it could not complete because required packages (e.g. `react`, `@types/react`, `zod`) were not installable in this environment. 
- Static checks performed: repository tree, created files, and TypeScript project references were validated locally during scaffolding; runtime UI verification was not executed because `npm install` / dev server could not run. 
- Summary: code and structure are in place and ready for dependency install and CI/typechecking in a developer environment with normal npm registry access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28dcb88148324aaa3a65561d2f922)