### PR TITLE
Adopt Rhine Lab ILM design system tokens

### DIFF
--- a/apps/protocol-manager/public/rhine-lab-wordmark.svg
+++ b/apps/protocol-manager/public/rhine-lab-wordmark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" width="320" height="80">
+  <defs>
+    
+  </defs>
+  
+  <g class="rl-mark" transform="translate(8, 14)">
+    <path d="M18 4 h12 v2 h-2 v12 l10 22 a4 4 0 0 1 -3.6 5.6 h-20.8 a4 4 0 0 1 -3.6 -5.6 l10 -22 v-12 h-2 v-2 z" fill="none" stroke="#1b1b1b" stroke-width="1.6"></path>
+    <circle cx="20" cy="34" r="2" fill="#4f6f52"></circle>
+    <circle cx="26" cy="38" r="1.3" fill="#4f6f52"></circle>
+    <path d="M12 42 h24" stroke="#4f6f52" stroke-width="1"></path>
+  </g>
+  <text class="rl-word" x="60" y="42">RHINE LAB</text>
+  <text class="rl-sub" x="60" y="58">INTEGRATED LAB MANAGER · V4.02</text>
+</svg>

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -763,8 +763,9 @@ export const App = ({ page }: AppProps) => {
       ) : (
         <main className="protocol-shell">
           <header className="protocol-topbar">
-            <button className="protocol-wordmark" type="button" onClick={openModuleHome}>
-              RHINE_PROTOCOL_V4
+            <button className="protocol-wordmark" type="button" onClick={openModuleHome} aria-label="Return to module home">
+              <span className="material-symbols-outlined protocol-wordmark-glyph" aria-hidden="true">biotech</span>
+              <span className="protocol-wordmark-text">RHINE_PROTOCOL_V4</span>
             </button>
 
             <div className="protocol-topbar-controls">
@@ -798,19 +799,19 @@ export const App = ({ page }: AppProps) => {
           <div className="protocol-body">
             <aside className="protocol-side-rail" aria-label="Protocol manager navigation">
               <button className="protocol-rail-item" type="button" onClick={openModuleHome}>
-                <span className="protocol-rail-glyph">⌂</span>
+                <span className="material-symbols-outlined protocol-rail-glyph" aria-hidden="true">dashboard</span>
                 <span>Module Home</span>
               </button>
               <button className={activeTab === "author" ? "protocol-rail-item active" : "protocol-rail-item"} type="button" onClick={() => setActiveTab("author")}>
-                <span className="protocol-rail-glyph">⚗</span>
+                <span className="material-symbols-outlined protocol-rail-glyph" aria-hidden="true">science</span>
                 <span>Sequencing</span>
               </button>
               <button className={activeTab === "preview" ? "protocol-rail-item active" : "protocol-rail-item"} type="button" onClick={() => setActiveTab("preview")}>
-                <span className="protocol-rail-glyph">◫</span>
+                <span className="material-symbols-outlined protocol-rail-glyph" aria-hidden="true">visibility</span>
                 <span>Preview</span>
               </button>
               <button className={activeTab === "transfer" ? "protocol-rail-item active" : "protocol-rail-item"} type="button" onClick={() => setActiveTab("transfer")}>
-                <span className="protocol-rail-glyph">⇅</span>
+                <span className="material-symbols-outlined protocol-rail-glyph" aria-hidden="true">swap_vert</span>
                 <span>Transfer</span>
               </button>
               <button className="protocol-rail-item protocol-rail-item-strong" type="button" onClick={handleNewProtocol}>

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -1,20 +1,21 @@
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Noto+Serif:wght@400;700;900&family=Space+Grotesk:wght@400;500;700&display=swap");
+@import "../../../packages/ui/src/tokens.css";
 
 :root {
-  color: #171717;
-  background: #f9f8f4;
-  font-family: "Space Grotesk", Arial, sans-serif;
+  color: var(--rl-ink-2);
+  background: var(--rl-paper);
+  font-family: var(--rl-font-sans);
   line-height: 1.55;
-  --ilm-ink: #1b1b1b;
-  --ilm-muted: #6d736a;
-  --ilm-line: #d6d9d2;
-  --ilm-panel: #ffffff;
-  --ilm-soft: #f1f2ee;
-  --ilm-soft-2: #e7e9e3;
-  --ilm-green: #37563b;
-  --ilm-green-soft: #dbe9d6;
-  --ilm-warn: #8a4900;
-  --ilm-warn-bg: #fbf2e4;
+  --ilm-ink: var(--rl-ink);
+  --ilm-muted: var(--rl-muted);
+  --ilm-line: var(--rl-line);
+  --ilm-panel: var(--rl-surface);
+  --ilm-soft: var(--rl-soft);
+  --ilm-soft-2: var(--rl-soft-2);
+  --ilm-green: var(--rl-green);
+  --ilm-green-2: var(--rl-green-2);
+  --ilm-green-soft: var(--rl-green-soft);
+  --ilm-warn: var(--rl-warn);
+  --ilm-warn-bg: var(--rl-warn-bg);
 }
 
 html {
@@ -1186,14 +1187,35 @@ label {
 }
 
 .protocol-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
   border: none;
   background: transparent;
   padding: 0;
-  color: var(--ilm-green);
-  font-family: "Noto Serif", Georgia, serif;
-  font-size: clamp(1.4rem, 2vw, 2rem);
+  color: var(--rl-green);
+  font-family: var(--rl-font-serif);
+  font-weight: 900;
   font-style: italic;
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  letter-spacing: 0.01em;
   transform: none;
+}
+
+.protocol-wordmark-glyph {
+  font-size: 2rem;
+  font-variation-settings: 'FILL' 0, 'wght' 200, 'GRAD' 0, 'opsz' 32;
+  color: var(--rl-green-2);
+}
+
+.protocol-wordmark-text {
+  font-family: var(--rl-font-mono);
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.92rem;
+  letter-spacing: 0.18em;
+  color: var(--rl-ink);
+  text-transform: uppercase;
 }
 
 .protocol-wordmark:hover:not(:disabled) {
@@ -1223,9 +1245,21 @@ label {
 }
 
 .protocol-primary-action {
-  border-color: var(--ilm-green);
-  background: var(--ilm-green);
-  color: white;
+  border-color: var(--rl-green-2);
+  background: var(--rl-green-2);
+  color: #fff;
+  transition: background 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.protocol-primary-action:hover:not(:disabled) {
+  background: var(--rl-green-2);
+  border-color: var(--rl-green-2);
+  box-shadow: var(--rl-shadow-glow-primary);
+  transform: none;
+}
+
+.protocol-primary-action:active:not(:disabled) {
+  transform: scale(0.97);
 }
 
 .protocol-secondary-action {
@@ -1296,7 +1330,14 @@ label {
 }
 
 .protocol-rail-glyph {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
+  font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 24;
+  color: inherit;
+  transition: transform 200ms ease;
+}
+
+.protocol-rail-item:hover .protocol-rail-glyph {
+  transform: scale(1.1);
 }
 
 .protocol-main-grid {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "main": "src/index.tsx",
   "types": "src/index.tsx",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./tokens.css": "./src/tokens.css"
+  },
   "peerDependencies": {
     "react": "^18.3.1"
   },

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -1,0 +1,330 @@
+/* ============================================================
+   Rhine Lab ILM — Colors & Type
+   Source of truth: apps/protocol-manager/src/styles.css
+                    + stitch dashboard + protocol editor
+   ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300;400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap");
+
+:root {
+  /* ---------- Surfaces ---------- */
+  --rl-paper:              #f9f8f4;   /* app canvas */
+  --rl-paper-alt:          #fbfbf8;   /* dashboard shell */
+  --rl-surface:            #ffffff;   /* elevated panels */
+  --rl-surface-2:          #f3f3f3;   /* container-low */
+  --rl-surface-3:          #e8e8e8;   /* container-high */
+  --rl-soft:               #f1f2ee;   /* Protocol Manager soft fill */
+  --rl-soft-2:             #e7e9e3;
+  --rl-lab-gray:           #f0f0f0;   /* Stitch lab-gray */
+
+  /* ---------- Ink ---------- */
+  --rl-ink:                #1b1b1b;   /* charcoal */
+  --rl-ink-2:              #171717;
+  --rl-muted:              #6d736a;
+  --rl-muted-2:            #818780;
+  --rl-outline:            #737971;
+  --rl-outline-variant:    #c2c8bf;
+  --rl-line:               #d6d9d2;
+  --rl-hairline:           #cbd1c8;
+
+  /* ---------- Brand greens ---------- */
+  --rl-green:              #37563b;   /* primary (deep) */
+  --rl-green-2:            #4f6f52;   /* primary container / glow color */
+  --rl-green-3:            #466649;   /* surface-tint */
+  --rl-green-soft:         #dbe9d6;
+  --rl-green-sec:          #54633d;   /* secondary */
+  --rl-green-sec-c:        #d5e6b5;   /* secondary-container */
+  --rl-green-fixed:        #c8ecc8;
+  --rl-green-fixed-dim:    #acd0ad;
+
+  /* ---------- Warm accents ---------- */
+  --rl-tertiary:           #794100;   /* tertiary (rust) */
+  --rl-tertiary-c:         #ffe1cb;   /* tertiary-container */
+  --rl-warn:               #8a4900;
+  --rl-warn-bg:            #fbf2e4;
+  --rl-warn-border:        #d7bca1;
+
+  /* ---------- Status ---------- */
+  --rl-error:              #ba1a1a;
+  --rl-error-c:            #ffdad6;
+  --rl-error-deep:         #93000a;
+  --rl-danger-text:        #b42318;
+  --rl-success:            #16a34a;
+  --rl-success-deep:       #304632;
+
+  /* ---------- Type scale roles ---------- */
+  --rl-fg-1:               var(--rl-ink);
+  --rl-fg-2:               #343434;
+  --rl-fg-3:               var(--rl-muted);
+  --rl-fg-4:               #9aa097;
+
+  /* ---------- Families ---------- */
+  --rl-font-serif:         "Noto Serif", Georgia, "Times New Roman", serif;
+  --rl-font-sans:          "Space Grotesk", system-ui, -apple-system, sans-serif;
+  --rl-font-mono:          "JetBrains Mono", ui-monospace, Menlo, monospace;
+  --rl-font-icon:          "Material Symbols Outlined";
+
+  /* ---------- Spacing ---------- */
+  --rl-space-1: 4px;
+  --rl-space-2: 8px;
+  --rl-space-3: 12px;
+  --rl-space-4: 16px;
+  --rl-space-5: 24px;
+  --rl-space-6: 32px;
+  --rl-space-7: 48px;
+  --rl-space-8: 64px;
+
+  /* ---------- Radii (mostly zero — chrome is sharp) ---------- */
+  --rl-radius-sharp: 0;
+  --rl-radius-soft:  14px;   /* Protocol Manager composer cards */
+  --rl-radius-soft-lg: 22px;
+  --rl-radius-pill:  999px;
+
+  /* ---------- Borders ---------- */
+  --rl-border-hairline: 0.5px solid var(--rl-outline-variant);
+  --rl-border-thin:     1px solid var(--rl-hairline);
+  --rl-border-ink:      2px solid var(--rl-ink);
+
+  /* ---------- Shadows ---------- */
+  --rl-shadow-glow-primary: 0 0 8px #4f6f52;
+  --rl-shadow-ambient:      0 0 24px rgba(79, 111, 82, 0.18);
+  --rl-shadow-float:        0 22px 48px rgba(83, 73, 56, 0.18);
+  --rl-shadow-soft:         0 12px 30px rgba(83, 73, 56, 0.08);
+  --rl-shadow-step:         0 0 15px rgba(79, 111, 82, 0.05);
+}
+
+/* ============================================================
+   Base
+   ============================================================ */
+
+html, body {
+  background: var(--rl-paper);
+  color: var(--rl-fg-1);
+  font-family: var(--rl-font-sans);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection { background: var(--rl-ink); color: #fff; }
+
+span.material-symbols-outlined,
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  font-family: var(--rl-font-icon) !important;
+  font-weight: normal !important;
+  font-style: normal !important;
+  letter-spacing: normal !important;
+  text-transform: none !important;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ============================================================
+   Semantic type roles
+   ============================================================ */
+
+.rl-display {
+  font-family: var(--rl-font-serif);
+  font-weight: 900;
+  font-size: clamp(3rem, 5.6vw, 4.7rem);
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.rl-display--italic { font-style: italic; font-weight: 900; }
+
+.rl-h1 {
+  font-family: var(--rl-font-serif);
+  font-size: clamp(2.3rem, 4vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.rl-h2 {
+  font-family: var(--rl-font-serif);
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: var(--rl-green);
+  margin: 0;
+}
+
+.rl-h3 {
+  font-family: var(--rl-font-serif);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--rl-green);
+  margin: 0;
+}
+
+.rl-body {
+  font-family: var(--rl-font-sans);
+  font-size: 0.95rem;
+  color: var(--rl-fg-1);
+  line-height: 1.6;
+}
+
+.rl-body-lg {
+  font-family: var(--rl-font-sans);
+  font-size: 1.02rem;
+  color: var(--rl-fg-2);
+  line-height: 1.9;
+}
+
+.rl-label {
+  font-family: var(--rl-font-sans);
+  font-size: 0.78rem;
+  color: var(--rl-fg-2);
+  letter-spacing: 0.02em;
+}
+
+.rl-meta {
+  font-family: var(--rl-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--rl-muted);
+}
+
+.rl-meta--tight {
+  font-family: var(--rl-font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.20em;
+  color: var(--rl-fg-4);
+}
+
+.rl-mono {
+  font-family: var(--rl-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.rl-figure {
+  font-family: var(--rl-font-serif);
+  font-weight: 900;
+  font-style: italic;
+  font-size: 2.2rem;
+  line-height: 1;
+}
+
+.rl-code-chip {
+  font-family: var(--rl-font-mono);
+  font-size: 0.75rem;
+  padding: 0.22rem 0.55rem;
+  background: var(--rl-ink);
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+/* ============================================================
+   Bracket corner accent — apply .rl-brackets to any positioned box
+   ============================================================ */
+
+.rl-brackets { position: relative; }
+.rl-brackets::before,
+.rl-brackets::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-color: var(--rl-ink);
+  border-style: solid;
+  pointer-events: none;
+}
+.rl-brackets::before { top: -1px;    left: -1px;   border-width: 2px 0 0 2px; }
+.rl-brackets::after  { right: -1px;  bottom: -1px; border-width: 0 2px 2px 0; }
+
+.rl-brackets--green::before,
+.rl-brackets--green::after { border-color: var(--rl-green-2); }
+
+.rl-brackets--hairline::before,
+.rl-brackets--hairline::after { border-width: 1px 0 0 1px; }
+.rl-brackets--hairline::after { border-width: 0 1px 1px 0; }
+
+/* ============================================================
+   Primitives
+   ============================================================ */
+
+.rl-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--rl-outline);
+  background: transparent;
+  color: var(--rl-fg-1);
+  border-radius: 0;
+  padding: 0.55rem 1rem;
+  font-family: var(--rl-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  transition: background 140ms ease, box-shadow 140ms ease, color 140ms ease;
+}
+.rl-btn:hover { background: var(--rl-lab-gray); }
+.rl-btn--primary {
+  background: var(--rl-green-2);
+  border-color: var(--rl-green-2);
+  color: #fff;
+}
+.rl-btn--primary:hover { box-shadow: var(--rl-shadow-glow-primary); background: var(--rl-green-2); }
+.rl-btn--ink {
+  background: var(--rl-ink);
+  border-color: var(--rl-ink);
+  color: #fff;
+}
+
+.rl-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 0.5px solid var(--rl-outline-variant);
+  padding: 0.55rem 0;
+  font-family: var(--rl-font-sans);
+  font-size: 0.9rem;
+  color: var(--rl-fg-1);
+}
+.rl-input:focus {
+  outline: none;
+  border-bottom-color: var(--rl-green-2);
+  box-shadow: 0 2px 0 0 var(--rl-green-2);
+}
+
+.rl-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.7rem;
+  background: var(--rl-green-sec-c);
+  color: var(--rl-success-deep);
+  font-family: var(--rl-font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.rl-chip--warn { background: var(--rl-tertiary-c); color: var(--rl-tertiary); }
+.rl-chip--error { background: var(--rl-error-c); color: var(--rl-error-deep); }
+.rl-chip--ink { background: var(--rl-ink); color: #fff; }
+
+.rl-card {
+  position: relative;
+  background: var(--rl-surface);
+  border: 1px solid rgba(27, 27, 27, 0.10);
+  padding: 1.5rem;
+}
+
+.rl-divider { height: 0; border: none; border-top: 0.5px solid var(--rl-outline-variant); }
+
+.rl-paper-grid {
+  background-image:
+    linear-gradient(#e5e7eb 1px, transparent 1px),
+    linear-gradient(90deg, #e5e7eb 1px, transparent 1px);
+  background-size: 40px 40px;
+}


### PR DESCRIPTION
Install canonical --rl-* design tokens from the design handoff bundle in packages/ui/src/tokens.css and rebase protocol-manager's --ilm-* vars on top of them so color, type, spacing, radii, and shadow tokens cascade from a single source.

- Replace ASCII rail glyphs (which violated the "no emoji, Material Symbols Outlined only" rule) with `dashboard`, `science`, `visibility`, `swap_vert` Material Symbols.
- Pair the `biotech` Material Symbol with the mono wordmark to match the spec'd logo construction.
- Add the signature phosphor `glow-primary` shadow and scale-95 press to the primary Export_Protocol action.
- Ship the reconstructed Rhine Lab wordmark SVG in the app's public/.