### PR TITLE
Add Supabase foundation: schema, RLS, browser client, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Public Supabase configuration for the ILM frontend.
+#
+# Both values are safe to ship to the browser. They are READ-ONLY keys whose
+# authority is bounded by Row Level Security policies in the database.
+#
+# Do NOT put the Supabase service-role key here, and do NOT commit a real
+# .env.local to git.
+
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-public-key

--- a/.github/workflows/deploy-protocol-manager-pages.yml
+++ b/.github/workflows/deploy-protocol-manager-pages.yml
@@ -35,6 +35,8 @@ jobs:
         run: npm run build -w @ilm/protocol-manager
         env:
           VITE_BASE_PATH: /ILM/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 .vite
 .DS_Store
 *.log
+.env
+.env.local
+.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,64 @@ singularity exec --bind /mnt/isilon/wang_lab/zac/projects/ILM:/work docker://nod
 # Dev server (protocol-manager)
 singularity exec --bind /mnt/isilon/wang_lab/zac/projects/ILM:/work docker://node:24-slim sh -c "cd /work && npm run dev"
 ```
+
+## Supabase Migration Plan (in-flight, 2026-04)
+
+Migrating ILM from browser-only storage (localStorage) to Supabase Postgres +
+Supabase Auth, while keeping the frontend deployable to GitHub Pages (no custom
+backend). Auth model: each user has a personal account; users belong to one or
+more shared `labs` via `lab_memberships`; all data is scoped to a lab and
+protected by RLS.
+
+### Data model
+
+Relational tables (preferred for structured data):
+- `profiles` — one row per `auth.users` user (display_name, email)
+- `labs` — shared workspace (name, slug, created_by)
+- `lab_memberships` — (lab_id, user_id, role in {owner,admin,member})
+- `projects` — lab-scoped projects (name, description, status)
+- `protocols` — lab-scoped protocol records, structured columns +
+  `document_json jsonb` for the protocol body. `document_json` is the ONLY
+  jsonb payload; other domains (projects, supply, funding) should use
+  normalized columns.
+- `protocol_revisions` — append-only snapshot of protocol `document_json`
+
+RLS on all tables; authorization driven by `lab_memberships`, never by
+user-editable metadata or frontend checks.
+
+### Staged implementation
+
+**Stage 1 — Foundation (current)**
+- `supabase/migrations/` with schema, triggers (`updated_at`), RLS policies
+- `packages/utils` exposes a Supabase browser client reading
+  `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` (fail loudly if missing)
+- Root README / docs: how to create a Supabase project, env var setup,
+  GitHub Pages deployment notes, service-role key warning
+- No runtime wiring of the client into apps yet
+
+**Stage 2 — Auth shell**
+- `packages/ui`: auth screens (sign up, sign in, sign out, password reset),
+  `AuthProvider` + session state, protected-route wrapper
+- Lab selection + "create lab" onboarding (creator becomes `owner`)
+- Zero-lab / multi-lab / single-lab auto-open behavior
+- Invitations remain dashboard-admin only for now
+
+**Stage 3 — Storage cutover (protocol-manager)**
+- Refactor `apps/protocol-manager/src/state/protocolState.ts` and
+  `lib/protocolLibrary.ts` to read/write Supabase scoped to the active lab
+- Debounced saves; keep JSON import/export intact
+- One-time "Import local data to cloud" banner for legacy localStorage
+  payloads; never silently drop local data
+- `protocol_revisions` snapshot on save
+
+**Stage 4 — Extend to other apps**
+- Wire the same auth/lab shell into `funding-manager`, `project-manager`,
+  `supply-manager` using normalized tables (not `document_json`) when their
+  schemas land
+
+### Non-negotiables
+- Static frontend only; no custom backend server
+- Only `VITE_SUPABASE_URL` + anon key in the browser; service-role key
+  never committed or shipped
+- RLS enforced on every app table
+- Preserve existing JSON import/export

--- a/README.md
+++ b/README.md
@@ -51,3 +51,48 @@ The Protocol Manager app is configured to deploy to GitHub Pages from the `main`
 - Workflow file: `.github/workflows/deploy-protocol-manager-pages.yml`
 
 For local development, the app still runs at `/`. For the GitHub Pages build, the workflow sets `VITE_BASE_PATH=/ILM/` so static assets resolve correctly on the project site URL.
+
+## Supabase backend
+
+ILM is moving from browser-only storage to Supabase (Postgres + Auth) while keeping the frontend static and deployable to GitHub Pages. No custom backend server is required.
+
+### Auth and workspace model
+
+- Each user has a personal account via Supabase Auth (email + password).
+- Users belong to one or more `labs` (shared workspaces) through `lab_memberships` with a role of `owner`, `admin`, or `member`.
+- All lab data (projects, protocols, revisions) is scoped to a `lab_id` and protected by Row Level Security. Authorization is driven by membership rows, not by the client.
+
+### Keys and secrets
+
+Only two values are needed in the browser. Both are safe to ship:
+
+- `VITE_SUPABASE_URL` — your project URL, e.g. `https://xxxx.supabase.co`
+- `VITE_SUPABASE_ANON_KEY` — the project's anon (public) API key
+
+**Never** place the Supabase service-role key in the frontend, in `.env*` files, or in GitHub Actions logs. It bypasses RLS and must live only in the Supabase dashboard or trusted server-side tooling.
+
+### One-time Supabase setup
+
+1. Create a project at https://supabase.com.
+2. In the SQL editor (or via `supabase db push` if you use the CLI), apply the migrations under [`supabase/migrations/`](supabase/migrations/). This creates `profiles`, `labs`, `lab_memberships`, `projects`, `protocols`, `protocol_revisions`, plus triggers and RLS policies.
+3. In **Authentication → Providers**, enable Email. Set the Site URL to your GitHub Pages URL (e.g. `https://euchiz.github.io/ILM/`) and add it under Redirect URLs.
+4. Copy the project URL and the anon public key from **Settings → API**.
+
+### Local development
+
+Copy `.env.example` to `.env.local` at the repo root (or inside `apps/protocol-manager/`) and fill in your values:
+
+```bash
+cp .env.example .env.local
+# then edit .env.local
+```
+
+Vite will pick these up automatically when you run `npm run dev`.
+
+### GitHub Pages deployment
+
+Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` as **Repository Secrets** (Settings → Secrets and variables → Actions). The deploy workflow injects them into the build step as environment variables so they land in the bundle. Changing a secret requires re-running the workflow.
+
+### Migrations
+
+SQL migrations live in [`supabase/migrations/`](supabase/migrations/). Apply them in order via the Supabase SQL editor or the Supabase CLI (`supabase db push`).

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,5 +8,8 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "echo 'no lint configured for @ilm/utils'"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,6 +13,9 @@ export const createStableId = (prefix: string, label: string, fallback = "item")
 
 export const nowIso = (): string => new Date().toISOString();
 
+export { getSupabaseClient, isSupabaseConfigured } from "./supabaseClient";
+export type { SupabaseClient } from "./supabaseClient";
+
 export const safeJsonParse = <T>(text: string): { ok: true; value: T } | { ok: false; error: string } => {
   try {
     return { ok: true, value: JSON.parse(text) as T };

--- a/packages/utils/src/supabaseClient.ts
+++ b/packages/utils/src/supabaseClient.ts
@@ -1,0 +1,50 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// Vite injects import.meta.env at build time. We read the *public* URL and
+// *anon* key only — the service-role key must never be bundled into the
+// frontend.
+type ViteEnv = {
+  VITE_SUPABASE_URL?: string;
+  VITE_SUPABASE_ANON_KEY?: string;
+};
+
+const readEnv = (): ViteEnv => {
+  const meta = import.meta as unknown as { env?: ViteEnv };
+  return meta.env ?? {};
+};
+
+const requireEnv = (key: keyof ViteEnv): string => {
+  const value = readEnv()[key];
+  if (!value || value.trim() === "") {
+    throw new Error(
+      `Missing ${key}. Define it in your .env.local (dev) or repo secrets ` +
+        `(GitHub Actions) before building the app.`
+    );
+  }
+  return value;
+};
+
+let cachedClient: SupabaseClient | null = null;
+
+export const getSupabaseClient = (): SupabaseClient => {
+  if (cachedClient) return cachedClient;
+  const url = requireEnv("VITE_SUPABASE_URL");
+  const anonKey = requireEnv("VITE_SUPABASE_ANON_KEY");
+
+  cachedClient = createClient(url, anonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storageKey: "ilm.auth",
+    },
+  });
+  return cachedClient;
+};
+
+export const isSupabaseConfigured = (): boolean => {
+  const env = readEnv();
+  return Boolean(env.VITE_SUPABASE_URL && env.VITE_SUPABASE_ANON_KEY);
+};
+
+export type { SupabaseClient };

--- a/supabase/migrations/20260420000000_init_auth_and_lab_workspaces.sql
+++ b/supabase/migrations/20260420000000_init_auth_and_lab_workspaces.sql
@@ -1,0 +1,319 @@
+-- ILM initial schema: auth-linked profiles, labs, memberships, projects,
+-- protocols, and protocol revisions. Row Level Security is enabled on every
+-- app table; authorization is driven by lab_memberships (never by
+-- user-editable metadata).
+
+-- ---------------------------------------------------------------------------
+-- Extensions
+-- ---------------------------------------------------------------------------
+
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- Shared updated_at trigger
+-- ---------------------------------------------------------------------------
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- profiles
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  email text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger profiles_set_updated_at
+before update on public.profiles
+for each row execute function public.set_updated_at();
+
+-- Auto-create a profile row when a new auth user is provisioned.
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, email, display_name)
+  values (
+    new.id,
+    new.email,
+    coalesce(new.raw_user_meta_data->>'display_name', split_part(new.email, '@', 1))
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_auth_user();
+
+-- ---------------------------------------------------------------------------
+-- labs
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.labs (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text unique,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger labs_set_updated_at
+before update on public.labs
+for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- lab_memberships
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.lab_memberships (
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('owner', 'admin', 'member')),
+  created_at timestamptz not null default now(),
+  primary key (lab_id, user_id)
+);
+
+create index if not exists lab_memberships_user_id_idx
+  on public.lab_memberships (user_id);
+
+-- ---------------------------------------------------------------------------
+-- Membership helpers (SECURITY DEFINER to avoid RLS recursion)
+-- ---------------------------------------------------------------------------
+
+create or replace function public.is_lab_member(target_lab_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.lab_memberships m
+    where m.lab_id = target_lab_id
+      and m.user_id = auth.uid()
+  );
+$$;
+
+create or replace function public.lab_role(target_lab_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role
+  from public.lab_memberships
+  where lab_id = target_lab_id
+    and user_id = auth.uid()
+  limit 1;
+$$;
+
+create or replace function public.is_lab_admin(target_lab_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.lab_role(target_lab_id) in ('owner', 'admin');
+$$;
+
+-- When a lab is created, make the creator its owner.
+create or replace function public.handle_new_lab()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.created_by is not null then
+    insert into public.lab_memberships (lab_id, user_id, role)
+    values (new.id, new.created_by, 'owner')
+    on conflict do nothing;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_lab_created on public.labs;
+create trigger on_lab_created
+after insert on public.labs
+for each row execute function public.handle_new_lab();
+
+-- ---------------------------------------------------------------------------
+-- projects
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  name text not null,
+  description text,
+  status text,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists projects_lab_id_idx on public.projects (lab_id);
+
+create trigger projects_set_updated_at
+before update on public.projects
+for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- protocols
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.protocols (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  project_id uuid references public.projects(id) on delete set null,
+  title text not null,
+  description text,
+  schema_version text not null default '1.0.0',
+  review_status text,
+  lifecycle_status text,
+  validation_status text,
+  document_json jsonb not null,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists protocols_lab_id_idx on public.protocols (lab_id);
+create index if not exists protocols_project_id_idx on public.protocols (project_id);
+
+create trigger protocols_set_updated_at
+before update on public.protocols
+for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- protocol_revisions
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.protocol_revisions (
+  id uuid primary key default gen_random_uuid(),
+  protocol_id uuid not null references public.protocols(id) on delete cascade,
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  document_json jsonb not null,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists protocol_revisions_protocol_id_idx
+  on public.protocol_revisions (protocol_id, created_at desc);
+create index if not exists protocol_revisions_lab_id_idx
+  on public.protocol_revisions (lab_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+
+alter table public.profiles            enable row level security;
+alter table public.labs                enable row level security;
+alter table public.lab_memberships     enable row level security;
+alter table public.projects            enable row level security;
+alter table public.protocols           enable row level security;
+alter table public.protocol_revisions  enable row level security;
+
+-- profiles: users manage only their own row
+create policy profiles_select_self on public.profiles
+  for select using (auth.uid() = id);
+
+create policy profiles_insert_self on public.profiles
+  for insert with check (auth.uid() = id);
+
+create policy profiles_update_self on public.profiles
+  for update using (auth.uid() = id) with check (auth.uid() = id);
+
+-- labs: members see their labs; any authenticated user can create a lab;
+-- only owners/admins can update; only owners can delete.
+create policy labs_select_member on public.labs
+  for select using (public.is_lab_member(id));
+
+create policy labs_insert_authenticated on public.labs
+  for insert with check (auth.uid() is not null and auth.uid() = created_by);
+
+create policy labs_update_admin on public.labs
+  for update using (public.is_lab_admin(id))
+  with check (public.is_lab_admin(id));
+
+create policy labs_delete_owner on public.labs
+  for delete using (public.lab_role(id) = 'owner');
+
+-- lab_memberships: members can read memberships of labs they belong to.
+-- Writes are admin-only via RLS; first-version invitation flow is handled
+-- out-of-band (dashboard / SQL) or through the new-lab trigger.
+create policy lab_memberships_select_member on public.lab_memberships
+  for select using (public.is_lab_member(lab_id));
+
+create policy lab_memberships_insert_admin on public.lab_memberships
+  for insert with check (public.is_lab_admin(lab_id));
+
+create policy lab_memberships_update_admin on public.lab_memberships
+  for update using (public.is_lab_admin(lab_id))
+  with check (public.is_lab_admin(lab_id));
+
+create policy lab_memberships_delete_admin on public.lab_memberships
+  for delete using (public.is_lab_admin(lab_id));
+
+-- projects: any member can read/write; delete restricted to admins.
+create policy projects_select_member on public.projects
+  for select using (public.is_lab_member(lab_id));
+
+create policy projects_insert_member on public.projects
+  for insert with check (public.is_lab_member(lab_id));
+
+create policy projects_update_member on public.projects
+  for update using (public.is_lab_member(lab_id))
+  with check (public.is_lab_member(lab_id));
+
+create policy projects_delete_admin on public.projects
+  for delete using (public.is_lab_admin(lab_id));
+
+-- protocols: any member can read/write; delete restricted to admins.
+create policy protocols_select_member on public.protocols
+  for select using (public.is_lab_member(lab_id));
+
+create policy protocols_insert_member on public.protocols
+  for insert with check (public.is_lab_member(lab_id));
+
+create policy protocols_update_member on public.protocols
+  for update using (public.is_lab_member(lab_id))
+  with check (public.is_lab_member(lab_id));
+
+create policy protocols_delete_admin on public.protocols
+  for delete using (public.is_lab_admin(lab_id));
+
+-- protocol_revisions: members may read and append; no updates; delete admin.
+create policy protocol_revisions_select_member on public.protocol_revisions
+  for select using (public.is_lab_member(lab_id));
+
+create policy protocol_revisions_insert_member on public.protocol_revisions
+  for insert with check (public.is_lab_member(lab_id));
+
+create policy protocol_revisions_delete_admin on public.protocol_revisions
+  for delete using (public.is_lab_admin(lab_id));


### PR DESCRIPTION
Stage 1 of the ILM cloud migration: lay the groundwork without changing app runtime behavior.

- SQL migration creating profiles, labs, lab_memberships, projects, protocols, and protocol_revisions with updated_at triggers, auto-profile on signup, auto-owner on lab creation, and RLS policies using SECURITY DEFINER helpers to avoid policy recursion
- @ilm/utils exposes a cached Supabase browser client reading VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY, failing loudly when missing
- Root README documents the auth/lab model, env setup, and GitHub Pages secret wiring; deploy workflow threads the anon key through at build
- CLAUDE.md records the 4-stage plan so later stages can pick up cleanly