### PR TITLE
Stage 2: add auth shell with lab workspace picker

### DIFF
--- a/apps/protocol-manager/src/main.tsx
+++ b/apps/protocol-manager/src/main.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { AuthGate } from "@ilm/ui";
 import { App } from "./App";
+import "@ilm/ui/auth.css";
 import "./styles.css";
 
 const rootElement = document.getElementById("root");
@@ -13,6 +15,8 @@ const page = rootElement.dataset.page === "protocol-manager" ? "protocol-manager
 
 createRoot(rootElement).render(
   <React.StrictMode>
-    <App page={page} />
+    <AuthGate>
+      <App page={page} />
+    </AuthGate>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,6 +1428,10 @@
     "packages/ui": {
       "name": "@ilm/ui",
       "version": "0.1.0",
+      "dependencies": {
+        "@ilm/utils": "file:../utils",
+        "@supabase/supabase-js": "^2.45.0"
+      },
       "peerDependencies": {
         "react": "^18.3.1"
       }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,12 @@
   "types": "src/index.tsx",
   "exports": {
     ".": "./src/index.tsx",
-    "./tokens.css": "./src/tokens.css"
+    "./tokens.css": "./src/tokens.css",
+    "./auth.css": "./src/auth/auth.css"
+  },
+  "dependencies": {
+    "@ilm/utils": "file:../utils",
+    "@supabase/supabase-js": "^2.45.0"
   },
   "peerDependencies": {
     "react": "^18.3.1"

--- a/packages/ui/src/auth/AuthGate.tsx
+++ b/packages/ui/src/auth/AuthGate.tsx
@@ -1,0 +1,34 @@
+import type { PropsWithChildren } from "react";
+import { AuthProvider, useAuth } from "./AuthProvider";
+import { AuthScreen } from "./AuthScreen";
+import { LabPicker } from "./LabPicker";
+
+const AuthGateInner = ({ children }: PropsWithChildren) => {
+  const { status, activeLab } = useAuth();
+
+  if (status === "loading") {
+    return (
+      <div className="ilm-auth-screen">
+        <div className="ilm-auth-card">
+          <p className="ilm-auth-note">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "signed-out") {
+    return <AuthScreen />;
+  }
+
+  if (!activeLab) {
+    return <LabPicker />;
+  }
+
+  return <>{children}</>;
+};
+
+export const AuthGate = ({ children }: PropsWithChildren) => (
+  <AuthProvider>
+    <AuthGateInner>{children}</AuthGateInner>
+  </AuthProvider>
+);

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -1,0 +1,285 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { getSupabaseClient } from "@ilm/utils";
+import type { LabWithRole, Profile } from "./types";
+
+type AuthStatus = "loading" | "signed-out" | "signed-in";
+
+type AuthContextValue = {
+  status: AuthStatus;
+  session: Session | null;
+  user: User | null;
+  profile: Profile | null;
+  labs: LabWithRole[];
+  activeLab: LabWithRole | null;
+  error: string | null;
+
+  // Auth actions
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string, displayName?: string) => Promise<{ needsEmailConfirmation: boolean }>;
+  signOut: () => Promise<void>;
+  sendPasswordReset: (email: string, redirectTo?: string) => Promise<void>;
+
+  // Lab actions
+  selectLab: (labId: string) => void;
+  createLab: (name: string, slug?: string) => Promise<LabWithRole>;
+  refreshLabs: () => Promise<void>;
+};
+
+const ACTIVE_LAB_STORAGE_KEY = "ilm.activeLabId";
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const useAuth = (): AuthContextValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside <AuthProvider>");
+  }
+  return ctx;
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : "Unexpected error";
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const supabase = useMemo(() => getSupabaseClient(), []);
+  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [session, setSession] = useState<Session | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [labs, setLabs] = useState<LabWithRole[]>([]);
+  const [activeLabId, setActiveLabId] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return window.localStorage.getItem(ACTIVE_LAB_STORAGE_KEY);
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const user = session?.user ?? null;
+
+  // Persist active lab selection
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (activeLabId) {
+      window.localStorage.setItem(ACTIVE_LAB_STORAGE_KEY, activeLabId);
+    } else {
+      window.localStorage.removeItem(ACTIVE_LAB_STORAGE_KEY);
+    }
+  }, [activeLabId]);
+
+  const loadProfile = useCallback(
+    async (userId: string): Promise<Profile | null> => {
+      const { data, error: err } = await supabase
+        .from("profiles")
+        .select("id, display_name, email")
+        .eq("id", userId)
+        .maybeSingle();
+      if (err) throw err;
+      return (data as Profile) ?? null;
+    },
+    [supabase]
+  );
+
+  const loadLabs = useCallback(async (): Promise<LabWithRole[]> => {
+    // lab_memberships RLS: only rows for labs the user belongs to
+    const { data, error: err } = await supabase
+      .from("lab_memberships")
+      .select("role, labs:lab_id(id, name, slug, created_by)")
+      .order("created_at", { ascending: true });
+    if (err) throw err;
+
+    type LabRow = Omit<LabWithRole, "role">;
+    type Row = { role: LabWithRole["role"]; labs: LabRow | LabRow[] | null };
+    return ((data as unknown as Row[]) ?? [])
+      .map((row) => {
+        const lab = Array.isArray(row.labs) ? row.labs[0] : row.labs;
+        return lab ? { ...lab, role: row.role } : null;
+      })
+      .filter((row): row is LabWithRole => row !== null);
+  }, [supabase]);
+
+  const refreshAll = useCallback(
+    async (nextSession: Session | null) => {
+      setSession(nextSession);
+      if (!nextSession?.user) {
+        setProfile(null);
+        setLabs([]);
+        setStatus("signed-out");
+        return;
+      }
+      try {
+        const [nextProfile, nextLabs] = await Promise.all([
+          loadProfile(nextSession.user.id),
+          loadLabs(),
+        ]);
+        setProfile(nextProfile);
+        setLabs(nextLabs);
+        setStatus("signed-in");
+      } catch (err) {
+        setError(errorMessage(err));
+        setStatus("signed-in");
+      }
+    },
+    [loadLabs, loadProfile]
+  );
+
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (mountedRef.current) return;
+    mountedRef.current = true;
+
+    let cancelled = false;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (cancelled) return;
+      refreshAll(data.session);
+    });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      refreshAll(nextSession);
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.subscription.unsubscribe();
+    };
+  }, [refreshAll, supabase]);
+
+  // Auto-select lab: if exactly one lab and none selected, pick it. If selected
+  // lab is no longer in the list, clear the selection.
+  useEffect(() => {
+    if (status !== "signed-in") return;
+    if (labs.length === 0) {
+      if (activeLabId) setActiveLabId(null);
+      return;
+    }
+    if (!activeLabId && labs.length === 1) {
+      setActiveLabId(labs[0].id);
+      return;
+    }
+    if (activeLabId && !labs.some((lab) => lab.id === activeLabId)) {
+      setActiveLabId(labs.length === 1 ? labs[0].id : null);
+    }
+  }, [activeLabId, labs, status]);
+
+  const activeLab = useMemo(
+    () => labs.find((lab) => lab.id === activeLabId) ?? null,
+    [activeLabId, labs]
+  );
+
+  const signIn = useCallback(
+    async (email: string, password: string) => {
+      setError(null);
+      const { error: err } = await supabase.auth.signInWithPassword({ email, password });
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [supabase]
+  );
+
+  const signUp = useCallback(
+    async (email: string, password: string, displayName?: string) => {
+      setError(null);
+      const { data, error: err } = await supabase.auth.signUp({
+        email,
+        password,
+        options: displayName ? { data: { display_name: displayName } } : undefined,
+      });
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+      // Supabase returns a session if email confirmation is disabled; otherwise
+      // session is null until confirmation.
+      return { needsEmailConfirmation: !data.session };
+    },
+    [supabase]
+  );
+
+  const signOut = useCallback(async () => {
+    setError(null);
+    const { error: err } = await supabase.auth.signOut();
+    if (err) {
+      setError(err.message);
+      throw err;
+    }
+    setActiveLabId(null);
+  }, [supabase]);
+
+  const sendPasswordReset = useCallback(
+    async (email: string, redirectTo?: string) => {
+      setError(null);
+      const { error: err } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: redirectTo ?? (typeof window !== "undefined" ? window.location.href : undefined),
+      });
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [supabase]
+  );
+
+  const refreshLabs = useCallback(async () => {
+    const next = await loadLabs();
+    setLabs(next);
+  }, [loadLabs]);
+
+  const createLab = useCallback(
+    async (name: string, slug?: string): Promise<LabWithRole> => {
+      if (!user) throw new Error("Not signed in");
+      setError(null);
+      const { data, error: err } = await supabase
+        .from("labs")
+        .insert({
+          name,
+          slug: slug?.trim() || null,
+          created_by: user.id,
+        })
+        .select("id, name, slug, created_by")
+        .single();
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+      // The on_lab_created trigger adds an owner membership automatically.
+      const created: LabWithRole = { ...(data as Omit<LabWithRole, "role">), role: "owner" };
+      setLabs((prev) => [...prev, created]);
+      setActiveLabId(created.id);
+      return created;
+    },
+    [supabase, user]
+  );
+
+  const selectLab = useCallback((labId: string) => {
+    setActiveLabId(labId);
+  }, []);
+
+  const value: AuthContextValue = {
+    status,
+    session,
+    user,
+    profile,
+    labs,
+    activeLab,
+    error,
+    signIn,
+    signUp,
+    signOut,
+    sendPasswordReset,
+    selectLab,
+    createLab,
+    refreshLabs,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/packages/ui/src/auth/AuthScreen.tsx
+++ b/packages/ui/src/auth/AuthScreen.tsx
@@ -1,0 +1,123 @@
+import { useState, type FormEvent } from "react";
+import { useAuth } from "./AuthProvider";
+
+type Mode = "sign-in" | "sign-up" | "reset";
+
+const modeLabels: Record<Mode, string> = {
+  "sign-in": "Sign in",
+  "sign-up": "Create account",
+  reset: "Reset password",
+};
+
+export const AuthScreen = () => {
+  const { signIn, signUp, sendPasswordReset, error } = useAuth();
+  const [mode, setMode] = useState<Mode>("sign-in");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [localMessage, setLocalMessage] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setLocalMessage(null);
+    setLocalError(null);
+    setSubmitting(true);
+    try {
+      if (mode === "sign-in") {
+        await signIn(email.trim(), password);
+      } else if (mode === "sign-up") {
+        const { needsEmailConfirmation } = await signUp(
+          email.trim(),
+          password,
+          displayName.trim() || undefined
+        );
+        if (needsEmailConfirmation) {
+          setLocalMessage("Check your email to confirm your account before signing in.");
+        }
+      } else {
+        await sendPasswordReset(email.trim());
+        setLocalMessage("Password reset email sent. Check your inbox.");
+      }
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="ilm-auth-screen">
+      <div className="ilm-auth-card">
+        <h1 className="ilm-auth-title">Integrated Lab Manager</h1>
+        <nav className="ilm-auth-tabs" aria-label="Auth mode">
+          {(["sign-in", "sign-up", "reset"] as Mode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={`ilm-auth-tab${m === mode ? " ilm-auth-tab-active" : ""}`}
+              onClick={() => {
+                setMode(m);
+                setLocalMessage(null);
+                setLocalError(null);
+              }}
+            >
+              {modeLabels[m]}
+            </button>
+          ))}
+        </nav>
+
+        <form onSubmit={handleSubmit} className="ilm-auth-form">
+          {mode === "sign-up" && (
+            <label className="ilm-auth-field">
+              <span>Display name</span>
+              <input
+                type="text"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                autoComplete="name"
+              />
+            </label>
+          )}
+
+          <label className="ilm-auth-field">
+            <span>Email</span>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+            />
+          </label>
+
+          {mode !== "reset" && (
+            <label className="ilm-auth-field">
+              <span>Password</span>
+              <input
+                type="password"
+                required
+                minLength={8}
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete={mode === "sign-in" ? "current-password" : "new-password"}
+              />
+            </label>
+          )}
+
+          <button type="submit" className="ilm-auth-submit" disabled={submitting}>
+            {submitting ? "Working…" : modeLabels[mode]}
+          </button>
+
+          {(localError || error) && (
+            <p className="ilm-auth-error" role="alert">
+              {localError ?? error}
+            </p>
+          )}
+          {localMessage && <p className="ilm-auth-note">{localMessage}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/auth/LabPicker.tsx
+++ b/packages/ui/src/auth/LabPicker.tsx
@@ -1,0 +1,107 @@
+import { useState, type FormEvent } from "react";
+import { slugify } from "@ilm/utils";
+import { useAuth } from "./AuthProvider";
+
+export const LabPicker = () => {
+  const { labs, selectLab, createLab, signOut, profile, user } = useAuth();
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const handleCreate = async (event: FormEvent) => {
+    event.preventDefault();
+    setErr(null);
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setErr("Lab name is required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createLab(trimmed, slug.trim() || slugify(trimmed));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to create lab");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const emptyState = labs.length === 0;
+  const displayName = profile?.display_name ?? user?.email ?? "";
+
+  return (
+    <div className="ilm-auth-screen">
+      <div className="ilm-auth-card ilm-lab-picker">
+        <div className="ilm-lab-picker-header">
+          <div>
+            <h1 className="ilm-auth-title">Choose a lab workspace</h1>
+            {displayName && <p className="ilm-auth-hint">Signed in as {displayName}</p>}
+          </div>
+          <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+
+        {emptyState ? (
+          <p className="ilm-auth-note">
+            You aren't a member of any labs yet. Create one below to get started.
+          </p>
+        ) : (
+          <ul className="ilm-lab-list">
+            {labs.map((lab) => (
+              <li key={lab.id}>
+                <button
+                  type="button"
+                  className="ilm-lab-list-item"
+                  onClick={() => selectLab(lab.id)}
+                >
+                  <span className="ilm-lab-list-name">{lab.name}</span>
+                  <span className="ilm-lab-list-meta">{lab.role}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <form onSubmit={handleCreate} className="ilm-auth-form">
+          <h2 className="ilm-lab-section-title">Create a new lab</h2>
+          <label className="ilm-auth-field">
+            <span>Lab name</span>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                if (!slugTouched) {
+                  setSlug(slugify(event.target.value));
+                }
+              }}
+            />
+          </label>
+          <label className="ilm-auth-field">
+            <span>Slug (optional)</span>
+            <input
+              type="text"
+              value={slug}
+              onChange={(event) => {
+                setSlug(event.target.value);
+                setSlugTouched(true);
+              }}
+            />
+          </label>
+          <button type="submit" className="ilm-auth-submit" disabled={submitting}>
+            {submitting ? "Creating…" : "Create lab"}
+          </button>
+          {err && (
+            <p className="ilm-auth-error" role="alert">
+              {err}
+            </p>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/auth/auth.css
+++ b/packages/ui/src/auth/auth.css
@@ -1,0 +1,187 @@
+.ilm-auth-screen {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background: var(--ilm-color-bg, #f6f7f9);
+}
+
+.ilm-auth-card {
+  width: 100%;
+  max-width: 26rem;
+  background: var(--ilm-color-surface, #ffffff);
+  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.ilm-auth-title {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.ilm-auth-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--ilm-color-border, #e2e5ea);
+}
+
+.ilm-auth-tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: var(--ilm-color-text-muted, #64748b);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.ilm-auth-tab-active {
+  color: var(--ilm-color-text, #0f172a);
+  border-bottom-color: var(--ilm-color-accent, #2563eb);
+  font-weight: 600;
+}
+
+.ilm-auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.ilm-auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+}
+
+.ilm-auth-field span {
+  color: var(--ilm-color-text-muted, #64748b);
+  font-weight: 500;
+}
+
+.ilm-auth-field input {
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  background: var(--ilm-color-surface, #ffffff);
+  color: var(--ilm-color-text, #0f172a);
+}
+
+.ilm-auth-field input:focus {
+  outline: 2px solid var(--ilm-color-accent, #2563eb);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.ilm-auth-submit {
+  appearance: none;
+  border: 0;
+  background: var(--ilm-color-accent, #2563eb);
+  color: #ffffff;
+  padding: 0.6rem 0.9rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.25rem;
+}
+
+.ilm-auth-submit:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.ilm-auth-error {
+  color: #b91c1c;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.ilm-auth-note {
+  color: var(--ilm-color-text-muted, #64748b);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.ilm-auth-hint {
+  color: var(--ilm-color-text-muted, #64748b);
+  font-size: 0.8rem;
+  margin: 0.25rem 0 0;
+}
+
+.ilm-text-button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ilm-color-accent, #2563eb);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.ilm-text-button:hover {
+  text-decoration: underline;
+}
+
+.ilm-lab-picker {
+  max-width: 32rem;
+}
+
+.ilm-lab-picker-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.ilm-lab-section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0.25rem 0 -0.25rem;
+}
+
+.ilm-lab-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ilm-lab-list-item {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  background: var(--ilm-color-surface, #ffffff);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-align: left;
+}
+
+.ilm-lab-list-item:hover {
+  border-color: var(--ilm-color-accent, #2563eb);
+}
+
+.ilm-lab-list-name {
+  font-weight: 500;
+  color: var(--ilm-color-text, #0f172a);
+}
+
+.ilm-lab-list-meta {
+  font-size: 0.8rem;
+  color: var(--ilm-color-text-muted, #64748b);
+  text-transform: capitalize;
+}

--- a/packages/ui/src/auth/index.ts
+++ b/packages/ui/src/auth/index.ts
@@ -1,0 +1,5 @@
+export { AuthProvider, useAuth } from "./AuthProvider";
+export { AuthGate } from "./AuthGate";
+export { AuthScreen } from "./AuthScreen";
+export { LabPicker } from "./LabPicker";
+export type { Profile, Lab, LabWithRole, LabMembership, MembershipRole } from "./types";

--- a/packages/ui/src/auth/types.ts
+++ b/packages/ui/src/auth/types.ts
@@ -1,0 +1,22 @@
+export type MembershipRole = "owner" | "admin" | "member";
+
+export type Profile = {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+};
+
+export type Lab = {
+  id: string;
+  name: string;
+  slug: string | null;
+  created_by: string | null;
+};
+
+export type LabMembership = {
+  lab_id: string;
+  user_id: string;
+  role: MembershipRole;
+};
+
+export type LabWithRole = Lab & { role: MembershipRole };

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,5 +1,7 @@
 import type { PropsWithChildren } from "react";
 
+export * from "./auth";
+
 export const Panel = ({ title, children }: PropsWithChildren<{ title: string }>) => (
   <section className="ilm-panel">
     <h2 className="ilm-panel-title">{title}</h2>


### PR DESCRIPTION
Introduces an AuthGate wrapper that sits above the app shell and drives the signed-out / lab-selection / signed-in flow off Supabase Auth.

- AuthProvider holds session, profile, labs (with role), activeLab; hooks up supabase.auth.onAuthStateChange and loads profile + memberships on sign-in. Active lab id persists to localStorage so returning users land back in their workspace.
- Auto-select single lab on sign-in; clear stored selection if the user is no longer a member.
- AuthScreen: email + password sign-in, sign-up with optional display name, and password reset via resetPasswordForEmail.
- LabPicker: pick an existing lab or create a new one (creator becomes owner via the on_lab_created SQL trigger). Handles zero-lab, single- lab, and multi-lab cases.
- protocol-manager wraps <App> in <AuthGate> and pulls in auth.css.

No storage cutover yet — protocols and projects still read/write localStorage. That's Stage 3.