### PR TITLE
Fix: read Supabase env vars with direct import.meta.env access

### DIFF
--- a/packages/utils/src/supabaseClient.ts
+++ b/packages/utils/src/supabaseClient.ts
@@ -1,23 +1,31 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-// Vite injects import.meta.env at build time. We read the *public* URL and
-// *anon* key only — the service-role key must never be bundled into the
-// frontend.
-type ViteEnv = {
-  VITE_SUPABASE_URL?: string;
-  VITE_SUPABASE_ANON_KEY?: string;
-};
+declare global {
+  interface ImportMetaEnv {
+    readonly VITE_SUPABASE_URL?: string;
+    readonly VITE_SUPABASE_ANON_KEY?: string;
+  }
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
 
-const readEnv = (): ViteEnv => {
-  const meta = import.meta as unknown as { env?: ViteEnv };
-  return meta.env ?? {};
-};
+// Vite replaces direct `import.meta.env.VITE_*` property reads with string
+// literals at build time. The direct access pattern below is REQUIRED for
+// that static replacement — going through a helper like `env[key]` leaves
+// the references in the bundle as runtime lookups against an empty object
+// and breaks the GitHub Pages build. See Vite docs on env variables.
+//
+// Only the public URL and anon key are read here. The service-role key
+// must never be bundled into the frontend.
 
-const requireEnv = (key: keyof ViteEnv): string => {
-  const value = readEnv()[key];
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+const requireValue = (name: string, value: string | undefined): string => {
   if (!value || value.trim() === "") {
     throw new Error(
-      `Missing ${key}. Define it in your .env.local (dev) or repo secrets ` +
+      `Missing ${name}. Define it in your .env.local (dev) or repo secrets ` +
         `(GitHub Actions) before building the app.`
     );
   }
@@ -28,8 +36,8 @@ let cachedClient: SupabaseClient | null = null;
 
 export const getSupabaseClient = (): SupabaseClient => {
   if (cachedClient) return cachedClient;
-  const url = requireEnv("VITE_SUPABASE_URL");
-  const anonKey = requireEnv("VITE_SUPABASE_ANON_KEY");
+  const url = requireValue("VITE_SUPABASE_URL", SUPABASE_URL);
+  const anonKey = requireValue("VITE_SUPABASE_ANON_KEY", SUPABASE_ANON_KEY);
 
   cachedClient = createClient(url, anonKey, {
     auth: {
@@ -42,9 +50,7 @@ export const getSupabaseClient = (): SupabaseClient => {
   return cachedClient;
 };
 
-export const isSupabaseConfigured = (): boolean => {
-  const env = readEnv();
-  return Boolean(env.VITE_SUPABASE_URL && env.VITE_SUPABASE_ANON_KEY);
-};
+export const isSupabaseConfigured = (): boolean =>
+  Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
 export type { SupabaseClient };


### PR DESCRIPTION
Vite replaces `import.meta.env.VITE_FOO` with string literals at build time only when the property is accessed directly. The previous helper that did `const meta = import.meta; meta.env[key]` left the reads as runtime lookups, so the GitHub Pages bundle shipped with undefined values even when the Actions secrets were set — producing a blank page once Stage 2 added <AuthProvider>, which calls getSupabaseClient() on mount and throws when the URL/key are missing.

Switch to direct `import.meta.env.VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` reads and declare an ambient ImportMetaEnv interface so both @ilm/utils and downstream consumers typecheck without pulling in vite/client types.