### PR TITLE
Surface real Supabase errors and harden createLab

### DIFF
--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -246,18 +246,39 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
           created_by: user.id,
         })
         .select("id, name, slug, created_by")
-        .single();
+        .maybeSingle();
       if (err) {
+        console.error("[ilm] createLab failed", err);
         setError(err.message);
         throw err;
       }
-      // The on_lab_created trigger adds an owner membership automatically.
-      const created: LabWithRole = { ...(data as Omit<LabWithRole, "role">), role: "owner" };
-      setLabs((prev) => [...prev, created]);
+      // The on_lab_created trigger inserts an owner membership for the
+      // creator. Refresh through the membership table so SELECT RLS paints
+      // the new row even if .select() on the insert returned empty.
+      let created: LabWithRole | null = data
+        ? { ...(data as Omit<LabWithRole, "role">), role: "owner" }
+        : null;
+      if (!created) {
+        const refreshed = await loadLabs();
+        setLabs(refreshed);
+        created =
+          refreshed.find((lab) => lab.name === name && lab.role === "owner") ??
+          null;
+        if (!created) {
+          const message =
+            "Lab created, but we couldn't read it back. Try reloading.";
+          setError(message);
+          throw new Error(message);
+        }
+      } else {
+        setLabs((prev) =>
+          prev.some((lab) => lab.id === created!.id) ? prev : [...prev, created!]
+        );
+      }
       setActiveLabId(created.id);
       return created;
     },
-    [supabase, user]
+    [loadLabs, supabase, user]
   );
 
   const selectLab = useCallback((labId: string) => {

--- a/packages/ui/src/auth/AuthScreen.tsx
+++ b/packages/ui/src/auth/AuthScreen.tsx
@@ -41,7 +41,12 @@ export const AuthScreen = () => {
         setLocalMessage("Password reset email sent. Check your inbox.");
       }
     } catch (err) {
-      setLocalError(err instanceof Error ? err.message : "Failed");
+      const message =
+        (err && typeof err === "object" && "message" in err &&
+          typeof (err as { message?: unknown }).message === "string")
+          ? (err as { message: string }).message
+          : "Failed";
+      setLocalError(message);
     } finally {
       setSubmitting(false);
     }

--- a/packages/ui/src/auth/LabPicker.tsx
+++ b/packages/ui/src/auth/LabPicker.tsx
@@ -22,7 +22,12 @@ export const LabPicker = () => {
     try {
       await createLab(trimmed, slug.trim() || slugify(trimmed));
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to create lab");
+      const message =
+        (e && typeof e === "object" && "message" in e &&
+          typeof (e as { message?: unknown }).message === "string")
+          ? (e as { message: string }).message
+          : "Failed to create lab";
+      setErr(message);
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
Supabase/PostgREST errors are plain objects with a message field, not Error instances, so the `e instanceof Error` guard in AuthScreen and LabPicker swallowed them and showed the generic fallback ("Failed" / "Failed to create lab"). Switch to a duck-typed message extraction that accepts anything with a string `message`.

Also change createLab to use maybeSingle() and, if the inserted row is not visible to the RETURNING SELECT (the AFTER trigger populates lab_memberships in the same txn, but a RLS-visibility edge case would otherwise look like an error), fall back to re-fetching memberships and locating the new lab there. Log the raw Postgrest error to the console so failures show a diagnosable stack.