### PR TITLE
Let the database set created_by from auth.uid() on labs

### DIFF
--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -238,12 +238,15 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     async (name: string, slug?: string): Promise<LabWithRole> => {
       if (!user) throw new Error("Not signed in");
       setError(null);
+      // created_by is set server-side from auth.uid() (column default +
+      // BEFORE INSERT trigger) so the client does not need to — and
+      // cannot — override it. This keeps the RLS insert policy to a
+      // simple "authenticated" check.
       const { data, error: err } = await supabase
         .from("labs")
         .insert({
           name,
           slug: slug?.trim() || null,
-          created_by: user.id,
         })
         .select("id, name, slug, created_by")
         .maybeSingle();

--- a/supabase/migrations/20260421000000_relax_labs_insert_policy.sql
+++ b/supabase/migrations/20260421000000_relax_labs_insert_policy.sql
@@ -1,0 +1,35 @@
+-- Relax the labs INSERT policy so creation only requires an authenticated
+-- session. The previous policy compared `auth.uid() = created_by`, which
+-- fails if the client sends `created_by` as any value other than exactly the
+-- text form of auth.uid() for that request — an error-prone coupling.
+--
+-- Instead:
+--   * Default `created_by` to `auth.uid()` at the column level
+--   * Force `created_by` to `auth.uid()` via a BEFORE INSERT trigger (so a
+--     user cannot impersonate another user by sending their id)
+--   * Simplify the RLS check to `auth.uid() is not null`
+
+alter table public.labs
+  alter column created_by set default auth.uid();
+
+create or replace function public.enforce_labs_created_by()
+returns trigger
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  new.created_by = auth.uid();
+  return new;
+end;
+$$;
+
+drop trigger if exists enforce_labs_created_by on public.labs;
+create trigger enforce_labs_created_by
+before insert on public.labs
+for each row execute function public.enforce_labs_created_by();
+
+drop policy if exists labs_insert_authenticated on public.labs;
+create policy labs_insert_authenticated on public.labs
+  for insert
+  with check (auth.uid() is not null);


### PR DESCRIPTION
The original INSERT policy (`auth.uid() = created_by`) failed with "new row violates row-level security policy for table \"labs\"" for clients that sent a user id the session didn't exactly match at the PostgREST layer. Switch to the Supabase-idiomatic pattern:

* default labs.created_by to auth.uid() at the column level
* a BEFORE INSERT trigger overwrites created_by with auth.uid() so a client cannot impersonate another user
* the RLS insert check is simplified to "authenticated"

The client no longer sends created_by on insert, removing the client/db coupling that was the source of the failure.