### PR TITLE
Route lab creation through a SECURITY DEFINER RPC

### DIFF
--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -238,46 +238,32 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     async (name: string, slug?: string): Promise<LabWithRole> => {
       if (!user) throw new Error("Not signed in");
       setError(null);
-      // created_by is set server-side from auth.uid() (column default +
-      // BEFORE INSERT trigger) so the client does not need to — and
-      // cannot — override it. This keeps the RLS insert policy to a
-      // simple "authenticated" check.
+      // Under Supabase's new asymmetric-key JWT system, auth.uid() returns
+      // NULL inside BEFORE-INSERT triggers and RLS WITH CHECK expressions
+      // even when the JWT is verified at the top level, so a direct INSERT
+      // on public.labs fails with 42501. The create_lab RPC reads
+      // auth.uid() at entry (where it works) and does the insert under
+      // SECURITY DEFINER, also creating the owner membership.
       const { data, error: err } = await supabase
-        .from("labs")
-        .insert({
-          name,
-          slug: slug?.trim() || null,
-        })
-        .select("id, name, slug, created_by")
+        .rpc("create_lab", { p_name: name, p_slug: slug ?? null })
         .maybeSingle();
       if (err) {
         console.error("[ilm] createLab failed", err);
         setError(err.message);
         throw err;
       }
-      // The on_lab_created trigger inserts an owner membership for the
-      // creator. Refresh through the membership table so SELECT RLS paints
-      // the new row even if .select() on the insert returned empty.
-      let created: LabWithRole | null = data
-        ? { ...(data as Omit<LabWithRole, "role">), role: "owner" }
-        : null;
-      if (!created) {
-        const refreshed = await loadLabs();
-        setLabs(refreshed);
-        created =
-          refreshed.find((lab) => lab.name === name && lab.role === "owner") ??
-          null;
-        if (!created) {
-          const message =
-            "Lab created, but we couldn't read it back. Try reloading.";
-          setError(message);
-          throw new Error(message);
-        }
-      } else {
-        setLabs((prev) =>
-          prev.some((lab) => lab.id === created!.id) ? prev : [...prev, created!]
-        );
+      if (!data) {
+        const message = "Lab created, but we couldn't read it back. Try reloading.";
+        setError(message);
+        throw new Error(message);
       }
+      const created: LabWithRole = {
+        ...(data as Omit<LabWithRole, "role">),
+        role: "owner",
+      };
+      setLabs((prev) =>
+        prev.some((lab) => lab.id === created.id) ? prev : [...prev, created]
+      );
       setActiveLabId(created.id);
       return created;
     },

--- a/supabase/migrations/20260421040000_add_create_lab_rpc.sql
+++ b/supabase/migrations/20260421040000_add_create_lab_rpc.sql
@@ -1,0 +1,38 @@
+-- Workaround for Supabase's new asymmetric-key JWT system: auth.uid() is
+-- populated at the top of a SQL/PLPGSQL function body but returns NULL
+-- inside BEFORE INSERT trigger bodies and RLS WITH CHECK expressions on
+-- the same request. That breaks the `labs` INSERT policy.
+--
+-- create_lab() reads auth.uid() once at entry (where it works), then does
+-- the INSERT with SECURITY DEFINER so the RLS check is bypassed. It also
+-- inserts the owner membership directly — the on_lab_created AFTER trigger
+-- is a no-op if auth.uid() is null in trigger context, so we do not rely
+-- on it.
+
+create or replace function public.create_lab(p_name text, p_slug text default null)
+returns public.labs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_lab public.labs%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  insert into public.labs (name, slug, created_by)
+  values (p_name, nullif(btrim(p_slug), ''), v_uid)
+  returning * into v_lab;
+
+  insert into public.lab_memberships (lab_id, user_id, role)
+  values (v_lab.id, v_uid, 'owner')
+  on conflict (lab_id, user_id) do nothing;
+
+  return v_lab;
+end;
+$$;
+
+grant execute on function public.create_lab(text, text) to authenticated;


### PR DESCRIPTION
Under Supabase's new asymmetric-key JWT system, auth.uid() evaluates to the caller's UUID at the top of a SQL function body but returns NULL inside BEFORE INSERT trigger bodies and RLS WITH CHECK expressions on the same request. That broke the `labs` INSERT: the enforce_labs_created_by trigger wrote a null created_by and the WITH CHECK auth.uid() IS NOT NULL deny'd with 42501.

Add public.create_lab(name, slug) which reads auth.uid() once at entry, inserts the lab and the owner membership under SECURITY DEFINER, and returns the new row. Update AuthProvider.createLab to call it via rpc().