### PR TITLE
Stage 3b protocol manager cutover

### DIFF
--- a/apps/protocol-manager/src/components/MigrationBanner.tsx
+++ b/apps/protocol-manager/src/components/MigrationBanner.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ProtocolDocument } from "@ilm/types";
+import { safeJsonParse } from "@ilm/utils";
+import { saveDraft, submitDraft, type CloudProtocolRow } from "../lib/cloudAdapter";
+import {
+  ensureProtocolMetadata,
+  LIBRARY_STORAGE_KEY,
+  type ProtocolLibraryState,
+} from "../lib/protocolLibrary";
+
+interface MigrationBannerProps {
+  labId: string | null;
+  labName: string | null;
+  generalProjectId: string | null;
+  cloudProtocols: CloudProtocolRow[];
+  onUploaded: () => void;
+}
+
+/**
+ * Offers a one-click upload of anything stored in the legacy
+ * localStorage library that isn't already in the cloud for the active
+ * lab. Matching is done by the client-side protocol id (document.protocol.id)
+ * which is preserved on import/export, so repeat visits don't re-upload.
+ *
+ * Uploaded protocols are saved as drafts against the General project and
+ * then submitted. Because General has approval_required=false, this
+ * publishes immediately. Users who want review-gated behaviour can move
+ * them to another project afterwards.
+ */
+export const MigrationBanner = ({
+  labId,
+  labName,
+  generalProjectId,
+  cloudProtocols,
+  onUploaded,
+}: MigrationBannerProps) => {
+  const [dismissed, setDismissed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const localProtocols = useMemo<ProtocolDocument[]>(() => {
+    if (typeof window === "undefined") return [];
+    const raw = window.localStorage.getItem(LIBRARY_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = safeJsonParse<ProtocolLibraryState>(raw);
+    if (!parsed?.protocols?.length) return [];
+    return parsed.protocols;
+  }, []);
+
+  const cloudIds = useMemo(
+    () => new Set(cloudProtocols.map((row) => row.document_json?.protocol?.id).filter(Boolean) as string[]),
+    [cloudProtocols]
+  );
+
+  const pending = useMemo(
+    () => localProtocols.filter((doc) => !cloudIds.has(doc.protocol.id)),
+    [localProtocols, cloudIds]
+  );
+
+  if (dismissed || !labId || pending.length === 0) return null;
+
+  const handleUpload = async () => {
+    if (!generalProjectId) {
+      setError("No General project available in this lab — can't upload.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      for (const doc of pending) {
+        const normalized = ensureProtocolMetadata(doc);
+        const draftId = await saveDraft({
+          protocolId: null,
+          projectId: generalProjectId,
+          document: normalized,
+        });
+        await submitDraft(draftId);
+      }
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(LIBRARY_STORAGE_KEY);
+      }
+      onUploaded();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="ilm-migration-banner" role="status">
+      <div>
+        <strong>
+          {pending.length} protocol{pending.length === 1 ? "" : "s"} from this browser aren't in the cloud yet
+        </strong>
+        <span className="helper-text">
+          {" "}Upload into <em>{labName ?? "the current lab"}</em>'s General project?
+        </span>
+        {error && <div className="ilm-migration-banner-error">{error}</div>}
+      </div>
+      <div className="ilm-migration-banner-actions">
+        <button type="button" disabled={busy} onClick={handleUpload}>
+          {busy ? "Uploading…" : "Upload"}
+        </button>
+        <button type="button" className="ilm-text-button" disabled={busy} onClick={() => setDismissed(true)}>
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Effect-safe helper other components can use to react when the library
+ * storage key changes (e.g. after a successful upload we want to refresh
+ * the rest of the app's derived state).
+ */
+export const useLibraryStorageListener = (callback: () => void) => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (event: StorageEvent) => {
+      if (event.key === LIBRARY_STORAGE_KEY) callback();
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [callback]);
+};

--- a/apps/protocol-manager/src/components/RecycleBinPanel.tsx
+++ b/apps/protocol-manager/src/components/RecycleBinPanel.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  listDeletedProtocols,
+  permanentDeleteProtocol,
+  restoreProtocol,
+  type CloudProtocolRow,
+} from "../lib/cloudAdapter";
+
+interface RecycleBinPanelProps {
+  labId: string;
+  onChanged: () => void;
+}
+
+const daysLeft = (deletedAt: string): number => {
+  const deleted = new Date(deletedAt).getTime();
+  const now = Date.now();
+  return Math.max(0, Math.ceil(30 - (now - deleted) / (24 * 60 * 60 * 1000)));
+};
+
+export const RecycleBinPanel = ({ labId, onChanged }: RecycleBinPanelProps) => {
+  const [rows, setRows] = useState<CloudProtocolRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setRows(await listDeletedProtocols(labId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const runAction = async (row: CloudProtocolRow, action: "restore" | "purge") => {
+    setBusyId(row.id);
+    setError(null);
+    try {
+      if (action === "restore") {
+        await restoreProtocol(row.id);
+      } else {
+        if (!window.confirm(`Permanently delete "${row.title}"? This cannot be undone.`)) return;
+        await permanentDeleteProtocol(row.id);
+      }
+      onChanged();
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="ilm-recycle-bin">
+      <header className="ilm-recycle-bin-header">
+        <h3>Recycle bin</h3>
+        <p className="helper-text">
+          Deleted protocols stay here for 30 days. After that they're purged automatically.
+        </p>
+        <button type="button" className="ilm-text-button" onClick={() => void refresh()} disabled={loading}>
+          Refresh
+        </button>
+      </header>
+      {error && <p className="ilm-auth-error">{error}</p>}
+      {loading && <p className="helper-text">Loading…</p>}
+      {!loading && rows.length === 0 && <p className="helper-text">The bin is empty.</p>}
+      <ul className="ilm-recycle-bin-list">
+        {rows.map((row) => {
+          const busy = busyId === row.id;
+          const remaining = row.deleted_at ? daysLeft(row.deleted_at) : 0;
+          return (
+            <li key={row.id} className="ilm-recycle-bin-item">
+              <div>
+                <div className="ilm-recycle-bin-title">{row.title || "(untitled)"}</div>
+                <div className="helper-text">
+                  Deleted {row.deleted_at ? new Date(row.deleted_at).toLocaleString() : "—"}
+                  {" · "}
+                  {remaining} day{remaining === 1 ? "" : "s"} until automatic purge
+                </div>
+              </div>
+              <div className="ilm-recycle-bin-actions">
+                <button type="button" disabled={busy} onClick={() => void runAction(row, "restore")}>
+                  Restore
+                </button>
+                <button type="button" className="ilm-text-button" disabled={busy} onClick={() => void runAction(row, "purge")}>
+                  Delete permanently
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/apps/protocol-manager/src/components/SubmissionsPanel.tsx
+++ b/apps/protocol-manager/src/components/SubmissionsPanel.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  approveSubmission,
+  listSubmissions,
+  rejectSubmission,
+  withdrawSubmission,
+  type CloudSubmissionRow,
+} from "../lib/cloudAdapter";
+
+interface SubmissionsPanelProps {
+  labId: string;
+  currentUserId: string | null;
+  /** Project ids where the current user is a lead (or where they're a
+   *  lab admin — callers should union the sets). Used to show the
+   *  approve/reject buttons only where appropriate. */
+  leadProjectIds: Set<string>;
+  onPublished: () => void;
+}
+
+type StatusFilter = "pending" | "all";
+
+const STATUS_LABEL: Record<CloudSubmissionRow["status"], string> = {
+  pending: "Pending",
+  approved: "Approved",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+};
+
+export const SubmissionsPanel = ({
+  labId,
+  currentUserId,
+  leadProjectIds,
+  onPublished,
+}: SubmissionsPanelProps) => {
+  const [filter, setFilter] = useState<StatusFilter>("pending");
+  const [rows, setRows] = useState<CloudSubmissionRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [commentFor, setCommentFor] = useState<string | null>(null);
+  const [commentText, setCommentText] = useState("");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const statuses =
+        filter === "pending"
+          ? (["pending"] as const)
+          : (["pending", "approved", "rejected", "withdrawn"] as const);
+      setRows(await listSubmissions(labId, [...statuses]));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, labId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const runAction = async (row: CloudSubmissionRow, action: "approve" | "reject" | "withdraw", comment?: string) => {
+    setBusyId(row.id);
+    setError(null);
+    try {
+      if (action === "approve") {
+        await approveSubmission(row.id, comment);
+        onPublished();
+      } else if (action === "reject") {
+        await rejectSubmission(row.id, comment);
+      } else {
+        await withdrawSubmission(row.id);
+      }
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+      setCommentFor(null);
+      setCommentText("");
+    }
+  };
+
+  return (
+    <div className="ilm-submissions-panel">
+      <header className="ilm-submissions-header">
+        <h3>Review submissions</h3>
+        <div className="ilm-submissions-filter">
+          <label>
+            <input
+              type="radio"
+              name="subs-filter"
+              checked={filter === "pending"}
+              onChange={() => setFilter("pending")}
+            />
+            Pending
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="subs-filter"
+              checked={filter === "all"}
+              onChange={() => setFilter("all")}
+            />
+            All
+          </label>
+          <button type="button" className="ilm-text-button" onClick={() => void refresh()} disabled={loading}>
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {error && <p className="ilm-auth-error">{error}</p>}
+      {loading && <p className="helper-text">Loading…</p>}
+      {!loading && rows.length === 0 && <p className="helper-text">No submissions.</p>}
+
+      <ul className="ilm-submissions-list">
+        {rows.map((row) => {
+          const title = row.document_json?.protocol?.title || "(untitled)";
+          const canReview = leadProjectIds.has(row.project_id);
+          const isSubmitter = row.submitter_id === currentUserId;
+          const pending = row.status === "pending";
+          const busy = busyId === row.id;
+          const showingComment = commentFor === row.id;
+
+          return (
+            <li key={row.id} className="ilm-submissions-item">
+              <div className="ilm-submissions-item-head">
+                <div>
+                  <div className="ilm-submissions-title">{title}</div>
+                  <div className="helper-text">
+                    {STATUS_LABEL[row.status]}
+                    {" · "}
+                    submitted {new Date(row.submitted_at).toLocaleString()}
+                    {row.reviewed_at && ` · reviewed ${new Date(row.reviewed_at).toLocaleString()}`}
+                  </div>
+                </div>
+              </div>
+              {row.review_comment && (
+                <div className="ilm-submissions-comment">
+                  <em>Reviewer note:</em> {row.review_comment}
+                </div>
+              )}
+
+              {pending && (canReview || isSubmitter) && (
+                <div className="ilm-submissions-actions">
+                  {canReview && (
+                    <>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => setCommentFor(showingComment ? null : row.id)}
+                      >
+                        {showingComment ? "Hide comment" : "Review"}
+                      </button>
+                    </>
+                  )}
+                  {isSubmitter && (
+                    <button
+                      type="button"
+                      className="ilm-text-button"
+                      disabled={busy}
+                      onClick={() => void runAction(row, "withdraw")}
+                    >
+                      Withdraw
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {showingComment && canReview && pending && (
+                <div className="ilm-submissions-review">
+                  <textarea
+                    value={commentText}
+                    onChange={(event) => setCommentText(event.target.value)}
+                    placeholder="Optional comment"
+                    rows={3}
+                  />
+                  <div className="ilm-submissions-review-buttons">
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void runAction(row, "approve", commentText.trim() || undefined)}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void runAction(row, "reject", commentText.trim() || undefined)}
+                    >
+                      Reject
+                    </button>
+                  </div>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/apps/protocol-manager/src/lib/cloudAdapter.ts
+++ b/apps/protocol-manager/src/lib/cloudAdapter.ts
@@ -1,0 +1,209 @@
+import type { ProtocolDocument } from "@ilm/types";
+import { getSupabaseClient } from "@ilm/utils";
+
+/** Shape returned from public.protocols + derived fields we care about. */
+export interface CloudProtocolRow {
+  id: string;
+  lab_id: string;
+  project_id: string | null;
+  title: string;
+  document_json: ProtocolDocument;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+export interface CloudDraftRow {
+  id: string;
+  lab_id: string;
+  project_id: string | null;
+  protocol_id: string | null;
+  user_id: string;
+  document_json: ProtocolDocument;
+  updated_at: string;
+}
+
+export interface CloudProjectRow {
+  id: string;
+  lab_id: string;
+  name: string;
+  approval_required: boolean;
+}
+
+const client = () => getSupabaseClient();
+
+export async function listProjects(labId: string): Promise<CloudProjectRow[]> {
+  const { data, error } = await client()
+    .from("projects")
+    .select("id, lab_id, name, approval_required")
+    .eq("lab_id", labId)
+    .order("name");
+  if (error) throw error;
+  return (data as CloudProjectRow[]) ?? [];
+}
+
+export async function listProtocols(labId: string): Promise<CloudProtocolRow[]> {
+  const { data, error } = await client()
+    .from("protocols")
+    .select(
+      "id, lab_id, project_id, title, document_json, created_by, updated_by, created_at, updated_at, deleted_at"
+    )
+    .eq("lab_id", labId)
+    .is("deleted_at", null)
+    .order("updated_at", { ascending: false });
+  if (error) throw error;
+  return (data as CloudProtocolRow[]) ?? [];
+}
+
+export async function listDrafts(labId: string): Promise<CloudDraftRow[]> {
+  const { data, error } = await client()
+    .from("protocol_drafts")
+    .select("id, lab_id, project_id, protocol_id, user_id, document_json, updated_at")
+    .eq("lab_id", labId)
+    .order("updated_at", { ascending: false });
+  if (error) throw error;
+  return (data as CloudDraftRow[]) ?? [];
+}
+
+/**
+ * Upsert the caller's draft for an existing protocol (pass protocolId), or
+ * create/update a draft for a brand-new protocol (pass draftId or null).
+ * Returns the draft id.
+ */
+export async function saveDraft(args: {
+  protocolId: string | null;
+  projectId: string;
+  document: ProtocolDocument;
+  draftId?: string | null;
+}): Promise<string> {
+  const { data, error } = await client().rpc("save_draft", {
+    p_protocol_id: args.protocolId,
+    p_project_id: args.projectId,
+    p_document: args.document,
+    p_draft_id: args.draftId ?? null,
+  });
+  if (error) throw error;
+  return data as string;
+}
+
+export async function discardDraft(draftId: string): Promise<void> {
+  const { error } = await client().rpc("discard_draft", { p_draft_id: draftId });
+  if (error) throw error;
+}
+
+/**
+ * Submit a draft. Returns the submission id. If the target project has
+ * approval_required=false (e.g. the default General project), this also
+ * publishes immediately.
+ */
+export async function submitDraft(draftId: string): Promise<string> {
+  const { data, error } = await client().rpc("submit_draft", { p_draft_id: draftId });
+  if (error) throw error;
+  return data as string;
+}
+
+export async function approveSubmission(submissionId: string, comment?: string): Promise<string> {
+  const { data, error } = await client().rpc("approve_submission", {
+    p_submission_id: submissionId,
+    p_comment: comment ?? null,
+  });
+  if (error) throw error;
+  return data as string;
+}
+
+export async function rejectSubmission(submissionId: string, comment?: string): Promise<void> {
+  const { error } = await client().rpc("reject_submission", {
+    p_submission_id: submissionId,
+    p_comment: comment ?? null,
+  });
+  if (error) throw error;
+}
+
+export async function softDeleteProtocol(protocolId: string): Promise<void> {
+  const { error } = await client().rpc("soft_delete_protocol", { p_id: protocolId });
+  if (error) throw error;
+}
+
+export async function restoreProtocol(protocolId: string): Promise<void> {
+  const { error } = await client().rpc("restore_protocol", { p_id: protocolId });
+  if (error) throw error;
+}
+
+export async function permanentDeleteProtocol(protocolId: string): Promise<void> {
+  const { error } = await client().rpc("permanent_delete_protocol", { p_id: protocolId });
+  if (error) throw error;
+}
+
+export async function listDeletedProtocols(labId: string): Promise<CloudProtocolRow[]> {
+  const { data, error } = await client().rpc("list_deleted_protocols", { p_lab_id: labId });
+  if (error) throw error;
+  return (data as CloudProtocolRow[]) ?? [];
+}
+
+export interface CloudSubmissionRow {
+  id: string;
+  lab_id: string;
+  project_id: string;
+  protocol_id: string | null;
+  submitter_id: string | null;
+  document_json: ProtocolDocument;
+  status: "pending" | "approved" | "rejected" | "withdrawn";
+  review_comment: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  submitted_at: string;
+}
+
+export async function listSubmissions(
+  labId: string,
+  statuses: CloudSubmissionRow["status"][] = ["pending"]
+): Promise<CloudSubmissionRow[]> {
+  const { data, error } = await client()
+    .from("protocol_submissions")
+    .select(
+      "id, lab_id, project_id, protocol_id, submitter_id, document_json, status, review_comment, reviewed_by, reviewed_at, submitted_at"
+    )
+    .eq("lab_id", labId)
+    .in("status", statuses)
+    .order("submitted_at", { ascending: false });
+  if (error) throw error;
+  return (data as CloudSubmissionRow[]) ?? [];
+}
+
+export async function withdrawSubmission(submissionId: string): Promise<void> {
+  const { error } = await client().rpc("withdraw_submission", { p_submission_id: submissionId });
+  if (error) throw error;
+}
+
+export interface CloudProjectLeadRow {
+  project_id: string;
+  user_id: string;
+}
+
+export async function listProjectLeads(labId: string): Promise<CloudProjectLeadRow[]> {
+  const { data, error } = await client()
+    .from("project_leads")
+    .select("project_id, user_id, projects!inner(lab_id)")
+    .eq("projects.lab_id", labId);
+  if (error) throw error;
+  type Row = CloudProjectLeadRow & { projects?: unknown };
+  return ((data as Row[]) ?? []).map(({ project_id, user_id }) => ({ project_id, user_id }));
+}
+
+export async function assignProjectLead(projectId: string, userId: string): Promise<void> {
+  const { error } = await client().rpc("assign_project_lead", {
+    p_project_id: projectId,
+    p_user_id: userId,
+  });
+  if (error) throw error;
+}
+
+export async function revokeProjectLead(projectId: string, userId: string): Promise<void> {
+  const { error } = await client().rpc("revoke_project_lead", {
+    p_project_id: projectId,
+    p_user_id: userId,
+  });
+  if (error) throw error;
+}

--- a/apps/protocol-manager/src/lib/useCloudProtocols.ts
+++ b/apps/protocol-manager/src/lib/useCloudProtocols.ts
@@ -1,0 +1,316 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ProtocolDocument } from "@ilm/types";
+import {
+  discardDraft as rpcDiscardDraft,
+  listDrafts,
+  listProjects,
+  listProtocols,
+  saveDraft as rpcSaveDraft,
+  submitDraft as rpcSubmitDraft,
+  softDeleteProtocol as rpcSoftDeleteProtocol,
+  type CloudProjectRow,
+} from "./cloudAdapter";
+import { ensureProtocolMetadata } from "./protocolLibrary";
+
+/**
+ * Cloud-side identity for a client-side ProtocolDocument. The document's
+ * `protocol.id` (client stable key) maps to some combination of a
+ * published protocol row and/or a draft row.
+ */
+interface Binding {
+  serverProtocolId: string | null;
+  draftId: string | null;
+  projectId: string;
+  /** Local edits not yet saved to the cloud. */
+  dirty: boolean;
+  /** Save or submit in flight. */
+  busy: boolean;
+  lastError: string | null;
+  /** Last document the cloud confirmed (draft or published). Used as the
+   *  baseline to detect dirtiness vs the in-memory doc. */
+  cloudDocumentHash: string;
+}
+
+export type CloudStatus = "idle" | "loading" | "ready" | "error";
+
+export interface UseCloudProtocolsValue {
+  status: CloudStatus;
+  error: string | null;
+  protocols: ProtocolDocument[];
+  bindings: Record<string, Binding>;
+  projects: CloudProjectRow[];
+  generalProjectId: string | null;
+
+  /** Update a protocol in memory. Does NOT touch the cloud. */
+  replaceProtocol: (clientId: string, doc: ProtocolDocument) => void;
+  /** Add a new protocol locally. Persists a draft on the cloud immediately
+   *  so another device / refresh can recover it. */
+  addProtocol: (doc: ProtocolDocument, projectId?: string) => Promise<void>;
+  /** Soft-delete a published protocol (or drop a draft-only one). */
+  removeProtocol: (clientId: string) => Promise<void>;
+
+  /** Explicit save — writes the current in-memory doc to the user's draft. */
+  saveDraft: (clientId: string) => Promise<void>;
+  /** Throw away the user's draft and revert to the published version. */
+  discardDraft: (clientId: string) => Promise<void>;
+  /** Save then submit. Free-write projects publish immediately. */
+  submitDraft: (clientId: string) => Promise<string>;
+
+  /** Assign a protocol to a different project. Marks it dirty. */
+  setProject: (clientId: string, projectId: string) => void;
+  /** Reload from the server. */
+  refresh: () => Promise<void>;
+}
+
+const hashDocument = (doc: ProtocolDocument): string => {
+  // Stable-ish fingerprint: stringify with sorted top-level protocol keys is
+  // overkill here; JSON.stringify is deterministic enough for dirtiness
+  // detection against the baseline we stored.
+  return JSON.stringify(doc);
+};
+
+export function useCloudProtocols(labId: string | null): UseCloudProtocolsValue {
+  const [status, setStatus] = useState<CloudStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [protocols, setProtocols] = useState<ProtocolDocument[]>([]);
+  const [bindings, setBindings] = useState<Record<string, Binding>>({});
+  const [projects, setProjects] = useState<CloudProjectRow[]>([]);
+
+  const docsRef = useRef<Record<string, ProtocolDocument>>({});
+  const bindingsRef = useRef<Record<string, Binding>>({});
+
+  const generalProjectId = useMemo(
+    () => projects.find((p) => p.name === "General")?.id ?? null,
+    [projects]
+  );
+
+  const updateBinding = useCallback((clientId: string, patch: Partial<Binding>) => {
+    setBindings((current) => {
+      const prev = current[clientId];
+      if (!prev) return current;
+      const next = { ...prev, ...patch };
+      bindingsRef.current = { ...bindingsRef.current, [clientId]: next };
+      return { ...current, [clientId]: next };
+    });
+  }, []);
+
+  const hydrate = useCallback(async () => {
+    if (!labId) return;
+    setStatus("loading");
+    setError(null);
+    try {
+      const [cloudProtocols, cloudDrafts, cloudProjects] = await Promise.all([
+        listProtocols(labId),
+        listDrafts(labId),
+        listProjects(labId),
+      ]);
+
+      const general = cloudProjects.find((p) => p.name === "General") ?? cloudProjects[0] ?? null;
+
+      const nextDocs: ProtocolDocument[] = [];
+      const nextBindings: Record<string, Binding> = {};
+
+      for (const row of cloudProtocols) {
+        const draft = cloudDrafts.find((d) => d.protocol_id === row.id);
+        const doc = ensureProtocolMetadata(draft?.document_json ?? row.document_json);
+        nextDocs.push(doc);
+        nextBindings[doc.protocol.id] = {
+          serverProtocolId: row.id,
+          draftId: draft?.id ?? null,
+          projectId: draft?.project_id ?? row.project_id ?? general?.id ?? "",
+          dirty: false,
+          busy: false,
+          lastError: null,
+          cloudDocumentHash: hashDocument(doc),
+        };
+      }
+
+      for (const draft of cloudDrafts.filter((d) => d.protocol_id === null)) {
+        const doc = ensureProtocolMetadata(draft.document_json);
+        if (nextBindings[doc.protocol.id]) continue;
+        nextDocs.push(doc);
+        nextBindings[doc.protocol.id] = {
+          serverProtocolId: null,
+          draftId: draft.id,
+          projectId: draft.project_id ?? general?.id ?? "",
+          dirty: false,
+          busy: false,
+          lastError: null,
+          cloudDocumentHash: hashDocument(doc),
+        };
+      }
+
+      docsRef.current = Object.fromEntries(nextDocs.map((d) => [d.protocol.id, d]));
+      bindingsRef.current = nextBindings;
+      setProtocols(nextDocs);
+      setBindings(nextBindings);
+      setProjects(cloudProjects);
+      setStatus("ready");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      setStatus("error");
+    }
+  }, [labId]);
+
+  useEffect(() => {
+    if (!labId) {
+      docsRef.current = {};
+      bindingsRef.current = {};
+      setProtocols([]);
+      setBindings({});
+      setProjects([]);
+      setStatus("idle");
+      return;
+    }
+    void hydrate();
+  }, [labId, hydrate]);
+
+  const replaceProtocol = useCallback((clientId: string, doc: ProtocolDocument) => {
+    setProtocols((current) => current.map((d) => (d.protocol.id === clientId ? doc : d)));
+    docsRef.current = { ...docsRef.current, [doc.protocol.id]: doc };
+    if (clientId !== doc.protocol.id) {
+      // id renamed (duplicate flow). carry binding.
+      const binding = bindingsRef.current[clientId];
+      if (binding) {
+        const { [clientId]: _removed, ...rest } = bindingsRef.current;
+        bindingsRef.current = { ...rest, [doc.protocol.id]: binding };
+        setBindings((current) => {
+          const { [clientId]: _, ...keep } = current;
+          return { ...keep, [doc.protocol.id]: binding };
+        });
+      }
+    }
+    const binding = bindingsRef.current[doc.protocol.id];
+    if (binding) {
+      const nextDirty = hashDocument(doc) !== binding.cloudDocumentHash;
+      if (nextDirty !== binding.dirty) updateBinding(doc.protocol.id, { dirty: nextDirty });
+    }
+  }, [updateBinding]);
+
+  const addProtocol = useCallback(async (doc: ProtocolDocument, projectId?: string) => {
+    if (!labId) throw new Error("no active lab");
+    const targetProject = projectId ?? generalProjectId;
+    if (!targetProject) throw new Error("no General project available");
+
+    // Persist as a draft immediately so the new protocol survives refresh.
+    const draftId = await rpcSaveDraft({
+      protocolId: null,
+      projectId: targetProject,
+      document: doc,
+      draftId: null,
+    });
+    const binding: Binding = {
+      serverProtocolId: null,
+      draftId,
+      projectId: targetProject,
+      dirty: false,
+      busy: false,
+      lastError: null,
+      cloudDocumentHash: hashDocument(doc),
+    };
+    docsRef.current = { ...docsRef.current, [doc.protocol.id]: doc };
+    bindingsRef.current = { ...bindingsRef.current, [doc.protocol.id]: binding };
+    setProtocols((current) => [...current, doc]);
+    setBindings((current) => ({ ...current, [doc.protocol.id]: binding }));
+  }, [generalProjectId, labId]);
+
+  const removeProtocol = useCallback(async (clientId: string) => {
+    const binding = bindingsRef.current[clientId];
+    if (!binding) return;
+
+    if (binding.draftId) {
+      try { await rpcDiscardDraft(binding.draftId); } catch (_) { /* best effort */ }
+    }
+    if (binding.serverProtocolId) {
+      await rpcSoftDeleteProtocol(binding.serverProtocolId);
+    }
+
+    const { [clientId]: _doc, ...restDocs } = docsRef.current;
+    const { [clientId]: _binding, ...restBindings } = bindingsRef.current;
+    docsRef.current = restDocs;
+    bindingsRef.current = restBindings;
+    setProtocols((current) => current.filter((d) => d.protocol.id !== clientId));
+    setBindings((current) => {
+      const { [clientId]: _, ...rest } = current;
+      return rest;
+    });
+  }, []);
+
+  const saveDraftAction = useCallback(async (clientId: string) => {
+    const doc = docsRef.current[clientId];
+    const binding = bindingsRef.current[clientId];
+    if (!doc || !binding) return;
+    if (!binding.projectId) throw new Error("no project assigned");
+
+    updateBinding(clientId, { busy: true, lastError: null });
+    try {
+      const draftId = await rpcSaveDraft({
+        protocolId: binding.serverProtocolId,
+        projectId: binding.projectId,
+        document: doc,
+        draftId: binding.draftId,
+      });
+      updateBinding(clientId, {
+        draftId,
+        dirty: false,
+        busy: false,
+        cloudDocumentHash: hashDocument(doc),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      updateBinding(clientId, { busy: false, lastError: message });
+      throw err;
+    }
+  }, [updateBinding]);
+
+  const discardDraftAction = useCallback(async (clientId: string) => {
+    const binding = bindingsRef.current[clientId];
+    if (!binding?.draftId) return;
+    await rpcDiscardDraft(binding.draftId);
+    updateBinding(clientId, { draftId: null, dirty: false });
+    await hydrate();
+  }, [hydrate, updateBinding]);
+
+  const submitDraftAction = useCallback(async (clientId: string): Promise<string> => {
+    const binding = bindingsRef.current[clientId];
+    if (!binding) throw new Error("unknown protocol");
+
+    // Always save-then-submit so the cloud has the freshest bits.
+    await saveDraftAction(clientId);
+    const refreshed = bindingsRef.current[clientId];
+    if (!refreshed?.draftId) throw new Error("nothing to submit");
+
+    updateBinding(clientId, { busy: true, lastError: null });
+    try {
+      const submissionId = await rpcSubmitDraft(refreshed.draftId);
+      await hydrate();
+      return submissionId;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      updateBinding(clientId, { busy: false, lastError: message });
+      throw err;
+    }
+  }, [hydrate, saveDraftAction, updateBinding]);
+
+  const setProject = useCallback((clientId: string, projectId: string) => {
+    updateBinding(clientId, { projectId, dirty: true });
+  }, [updateBinding]);
+
+  return {
+    status,
+    error,
+    protocols,
+    bindings,
+    projects,
+    generalProjectId,
+    replaceProtocol,
+    addProtocol,
+    removeProtocol,
+    saveDraft: saveDraftAction,
+    discardDraft: discardDraftAction,
+    submitDraft: submitDraftAction,
+    setProject,
+    refresh: hydrate,
+  };
+}

--- a/docs/stage-3b-app-refactor.md
+++ b/docs/stage-3b-app-refactor.md
@@ -1,0 +1,213 @@
+# Stage 3b — App.tsx cutover plan
+
+This is the **follow-up** refactor after PR-3b's foundation lands. The
+foundation already gives us:
+
+- `apps/protocol-manager/src/lib/cloudAdapter.ts` — thin RPC wrappers.
+- `apps/protocol-manager/src/lib/useCloudProtocols.ts` — hook that owns
+  `protocols`, `bindings`, `projects`, `generalProjectId` for a given
+  `labId`, plus `replaceProtocol` / `addProtocol` / `removeProtocol` /
+  `saveDraft` / `discardDraft` / `submitDraft` / `setProject` / `refresh`.
+- `apps/protocol-manager/src/components/MigrationBanner.tsx`
+- `apps/protocol-manager/src/components/SubmissionsPanel.tsx`
+- `apps/protocol-manager/src/components/RecycleBinPanel.tsx`
+
+The next PR plugs these into `apps/protocol-manager/src/App.tsx` (~1744
+lines today). Outline below — keep each bullet small enough to verify.
+
+## 1. Replace library state source
+
+Today:
+
+```ts
+const [libraryState, setLibraryState] = useState<ProtocolLibraryState>(() => loadLibraryState());
+// plus
+useEffect(() => {
+  localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(libraryState, null, 2));
+  localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(doc, null, 2));
+}, [doc, libraryState]);
+```
+
+After:
+
+- `const { activeLab } = useAuth();`
+- `const cloud = useCloudProtocols(activeLab?.id ?? null);`
+- Derive a shim `libraryState = { protocols: cloud.protocols, activeProtocolId }` where `activeProtocolId` is persisted per-lab in
+  `localStorage.getItem('ilm.protocol-manager.activeId.' + activeLab.id)`.
+- Delete both `localStorage.setItem` calls above. `loadLibraryState`, `createInitialLibrary`, and `normalizeLibraryState` remain available for import flows.
+
+## 2. Rewire state mutators
+
+Every `setLibraryState(...)` today mutates the in-memory library
+directly. Classify each call site into:
+
+- **edit-in-place** (step/section/block edits, metadata updates): call
+  `cloud.replaceProtocol(clientId, nextDoc)`. Marks dirty.
+- **add-new** (new protocol modal, import, duplicate): call
+  `await cloud.addProtocol(nextDoc)`. Creates a server-side draft.
+- **remove** (delete button): call `await cloud.removeProtocol(clientId)`.
+  This soft-deletes any published row and drops any draft.
+- **activate** (select a protocol): update the local per-lab active-id
+  only — no cloud call.
+
+Search targets inside App.tsx:
+
+```
+grep -n setLibraryState apps/protocol-manager/src/App.tsx
+grep -n replaceActiveProtocol apps/protocol-manager/src/App.tsx
+grep -n appendProtocolToLibrary apps/protocol-manager/src/App.tsx
+```
+
+Every hit needs a decision.
+
+## 3. Header: Save / Submit / Discard
+
+Add three buttons near the protocol title. Their enabled state and label
+come from the active binding (`cloud.bindings[activeProtocolId]`).
+
+- **Save draft** — enabled when `dirty`. Calls `cloud.saveDraft(id)`.
+- **Submit for review** — enabled when `dirty` or the user has a saved
+  draft but no open submission. Calls `cloud.submitDraft(id)`. Show a
+  small toast: "Submitted" (approval-required projects) or "Published"
+  (General / free-write projects).
+- **Discard draft** — visible only when `binding.draftId`. Calls
+  `cloud.discardDraft(id)`. Reverts to the published version via
+  `cloud.refresh()`.
+
+Dirty indicator: tiny dot next to the title when `binding.dirty === true`.
+
+## 4. Project picker
+
+Current metadata UI has a free-text `project` field via
+`updateProtocolMetadata`. Replace it with a `<select>` populated from
+`cloud.projects`, bound to `binding.projectId`:
+
+```tsx
+<select
+  value={binding.projectId}
+  onChange={(e) => cloud.setProject(doc.protocol.id, e.target.value)}
+>
+  {cloud.projects.map((p) => (
+    <option key={p.id} value={p.id}>
+      {p.name}{!p.approval_required ? " (no review)" : ""}
+    </option>
+  ))}
+</select>
+```
+
+When a protocol is reassigned to an `approval_required=true` project,
+subsequent Submit clicks route through the review flow automatically
+(server decides). No client-side branching needed.
+
+Keep the legacy free-text `metadata.project` writing the selected
+project's **name** so JSON exports stay interoperable.
+
+## 5. Admin / reviews view
+
+Add a new sidebar entry (maybe "Reviews") that renders:
+
+- `<MigrationBanner …>` at the top (only while the local library key
+  still has uncloud'd rows).
+- `<SubmissionsPanel labId userId leadProjectIds onPublished=refresh />`.
+- `<RecycleBinPanel labId onChanged=refresh />`.
+
+`leadProjectIds` comes from a new small helper using
+`cloudAdapter.listProjectLeads(labId)` filtered to the current user —
+plus union with all projects where `is_lab_admin` is true (compute once
+by looking at the user's `lab_memberships.role` via the Auth context's
+`activeLab.role`).
+
+Expose a hook `useProjectLeadProjects(labId)` that returns the set, so
+the panel can stay simple.
+
+## 6. Migration banner placement
+
+Mount `<MigrationBanner>` unconditionally at the top of the Library
+sidebar (visible from any view). It self-hides if there's nothing to
+migrate or the user dismisses it.
+
+Props to supply:
+
+- `labId` / `labName` from `useAuth().activeLab`.
+- `generalProjectId` from `cloud.generalProjectId`.
+- `cloudProtocols` — either pass `cloud.protocols` mapped to the row
+  shape it expects, OR extend `useCloudProtocols` to also expose the
+  raw `CloudProtocolRow[]` so the banner has exact cloud ids. The
+  second is cleaner.
+- `onUploaded = () => void cloud.refresh()`.
+
+## 7. Styling
+
+The new components reference class names that aren't defined yet:
+
+- `ilm-migration-banner`, `ilm-migration-banner-actions`,
+  `ilm-migration-banner-error`
+- `ilm-submissions-panel`, `ilm-submissions-header`,
+  `ilm-submissions-filter`, `ilm-submissions-list`,
+  `ilm-submissions-item`, `ilm-submissions-item-head`,
+  `ilm-submissions-title`, `ilm-submissions-comment`,
+  `ilm-submissions-actions`, `ilm-submissions-review`,
+  `ilm-submissions-review-buttons`
+- `ilm-recycle-bin`, `ilm-recycle-bin-header`, `ilm-recycle-bin-list`,
+  `ilm-recycle-bin-item`, `ilm-recycle-bin-title`,
+  `ilm-recycle-bin-actions`
+
+Two options:
+
+1. Extend `packages/ui/src/auth/auth.css` with these, keeping the
+   existing `ilm-*` aesthetic.
+2. Add a new `apps/protocol-manager/src/styles/cloud.css` imported from
+   `main.tsx`.
+
+Prefer (2) — keeps `@ilm/ui` focused on auth/lab shell styling.
+
+## 8. JSON import/export
+
+- **Import**: unchanged UI. Handler switches from
+  `setLibraryState(appendProtocolToLibrary(...))` to
+  `await cloud.addProtocol(normalizedDoc)`. Imports land as drafts in the
+  General project so the user can review before submitting.
+- **Export**: unchanged. The in-memory `doc` is still the source; cloud
+  fetches have already hydrated it.
+
+## 9. Empty / error states
+
+- `cloud.status === "loading"` → spinner where the protocol list would
+  render. Don't render the editor until a doc exists (or an empty-state
+  hero with a "Create your first protocol" button).
+- `cloud.status === "error"` → banner with `cloud.error` and a Retry
+  button.
+- `activeLab === null` → `AuthGate` already shows the lab picker; this
+  branch shouldn't render.
+
+## 10. Out of scope for this refactor (follow-ups)
+
+- Realtime subscriptions (re-hydrate on explicit refresh only).
+- Diff viewer for submissions (show raw JSON panel for now when a
+  reviewer wants to inspect — SubmissionsPanel could add a collapsible
+  "View JSON" section later).
+- Project lead management UI (admins can seed via SQL editor until a UI
+  lands in Stage 4).
+- Per-protocol "who has drafts open" indicator (requires a view across
+  `protocol_drafts.user_id`).
+
+## Acceptance checklist
+
+Before merging 3b's App.tsx refactor:
+
+- [ ] `localStorage.setItem(LIBRARY_STORAGE_KEY, ...)` and
+      `localStorage.setItem(LEGACY_STORAGE_KEY, ...)` are gone from
+      App.tsx.
+- [ ] Navigating to the app with no cloud data shows an empty state and
+      a working "Create new protocol" flow that writes to
+      `protocol_drafts`.
+- [ ] Editing a field marks the binding dirty and enables Save.
+- [ ] Save in General project publishes immediately; save in any other
+      project creates a pending submission visible in the SubmissionsPanel.
+- [ ] Approve from SubmissionsPanel updates the corresponding protocol
+      and appends a revision in `protocol_revisions`.
+- [ ] Soft-delete moves a protocol to RecycleBinPanel; Restore returns
+      it; Permanent-delete removes it.
+- [ ] `typecheck` + `lint` pass across all workspaces.
+- [ ] Manual browser smoke in the deployed Pages build with a real
+      Supabase project.


### PR DESCRIPTION
## cloud-backed protocol foundation (adapter, hook, review/recycle/migration panels)

Foundation for the protocol-manager cloud cutover. No App.tsx changes yet —
those land in a follow-up PR using the plan in
`docs/stage-3b-app-refactor.md`.

- **`lib/cloudAdapter.ts`** — thin wrappers around the Stage-3a RPCs
  (`save_draft`, `submit_draft`, `approve/reject/withdraw_submission`,
  `soft_delete_protocol` / `restore_protocol` /
  `permanent_delete_protocol`, `assign/revoke_project_lead`) plus direct
  SELECTs on `protocols`, `protocol_drafts`, `projects`,
  `protocol_submissions`, `project_leads`.
- **`lib/useCloudProtocols.ts`** — React hook that hydrates per-lab
  state, tracks dirty/busy/error per protocol, and exposes
  replaceProtocol / addProtocol / removeProtocol / saveDraft /
  discardDraft / submitDraft / setProject / refresh.
- **`components/MigrationBanner.tsx`** — detects legacy
  `ilm.protocol-manager.library.v2` payloads in localStorage and offers
  a one-click upload into the active lab's General project (matched by
  `document.protocol.id` to avoid re-uploads).
- **`components/SubmissionsPanel.tsx`** — pending/all submissions list;
  approve/reject with comment for project leads; submitter can withdraw
  pending.
- **`components/RecycleBinPanel.tsx`** — soft-deleted list with
  restore/permanent-delete and a 30-day countdown.
- **`docs/stage-3b-app-refactor.md`** — concrete plan for the App.tsx
  surgery.

## Why checkpoint here

App.tsx is 1700+ lines and state mutators are everywhere; doing the
refactor on fresh context produces safer edits than pushing through.
The foundation is independently reviewable, and nothing in this PR is
wired into the app yet (so behaviour is unchanged until the follow-up).

## Reviewer notes

- Stage 3a migration (`20260422000000_review_gated_protocols.sql`) must
  already be applied.
- Styling for the new `ilm-submissions-*`, `ilm-recycle-bin-*`, and
  `ilm-migration-banner*` class names lands with the App.tsx refactor.
- No typecheck/lint regressions expected — new files are internally
  consistent and unreferenced until the refactor plugs them in.