### PR TITLE
Account shell: membership, join requests, share links

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: "false"
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/apps/account/index.html
+++ b/apps/account/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Account · ILM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/account/package.json
+++ b/apps/account/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ilm/account",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --pretty false",
+    "lint": "echo 'no lint configured for @ilm/account'"
+  },
+  "dependencies": {
+    "@ilm/ui": "file:../../packages/ui",
+    "@ilm/utils": "file:../../packages/utils",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}

--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AppSwitcher,
+  AuthScreen,
+  LabJoinRequestsPanel,
+  LabMembersPanel,
+  LabPicker,
+  LabSettingsPanel,
+  LabShareLinkPanel,
+  cancelLabJoin,
+  lookupLabById,
+  requestLabJoin,
+  useAuth,
+  type LabLookupResult,
+} from "@ilm/ui";
+
+const APP_BASE_URL = import.meta.env.BASE_URL || "/";
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
+
+const parseJoinLabId = (pathname: string, base: string): string | null => {
+  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+  const pathBase = pathname.startsWith(normalizedBase) ? pathname.slice(normalizedBase.length) : pathname;
+  const segments = pathBase.split("/").filter(Boolean);
+  if (segments[0] === "join" && segments[1]) {
+    return segments[1];
+  }
+  return null;
+};
+
+const isUuid = (value: string): boolean =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+
+const AccountDashboard = () => {
+  const { profile, user, signOut } = useAuth();
+  const signedInLabel = profile?.display_name ?? user?.email ?? "Signed in";
+  return (
+    <div className="acct-shell">
+      <header className="acct-topbar">
+        <div>
+          <p style={{ margin: 0, color: "#60606b", fontSize: "0.85rem" }}>{signedInLabel}</p>
+          <h1>Account & Lab Settings</h1>
+        </div>
+        <div className="acct-topbar-actions">
+          <AppSwitcher currentApp="home" baseUrl={APP_BASE_URL} />
+          <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+      </header>
+      <div className="acct-sections">
+        <LabSettingsPanel />
+        <LabMembersPanel />
+        <LabJoinRequestsPanel />
+        <LabShareLinkPanel baseUrl={APP_BASE_URL} />
+      </div>
+    </div>
+  );
+};
+
+const JoinScreen = ({ labId }: { labId: string }) => {
+  const { status, labs, selectLab, signOut, profile, user } = useAuth();
+  const [lookup, setLookup] = useState<LabLookupResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
+
+  const refreshLookup = useCallback(async () => {
+    if (status !== "signed-in") return;
+    setLoading(true);
+    setError(null);
+    try {
+      if (!isUuid(labId)) {
+        setError("That share link doesn't point to a valid lab id.");
+        setLookup(null);
+        return;
+      }
+      const result = await lookupLabById(labId);
+      if (!result) {
+        setError("This lab could not be found. The link may be outdated.");
+        setLookup(null);
+        return;
+      }
+      setLookup(result);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId, status]);
+
+  useEffect(() => {
+    void refreshLookup();
+  }, [refreshLookup]);
+
+  if (status === "loading") {
+    return (
+      <div className="ilm-auth-screen">
+        <div className="ilm-auth-card">
+          <p className="ilm-auth-note">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "signed-out") {
+    return <AuthScreen />;
+  }
+
+  const alreadyMember = lookup?.already_member ?? labs.some((l) => l.id === labId);
+  const hasPending = (lookup?.has_pending_request ?? false) || pendingRequestId !== null;
+  const labName = lookup?.name ?? "this lab";
+
+  const handleOpenLab = () => {
+    selectLab(labId);
+    window.location.assign(APP_BASE_URL);
+  };
+
+  const handleRequest = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const id = await requestLabJoin(labId, message.trim() || undefined);
+      setPendingRequestId(id);
+      await refreshLookup();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!pendingRequestId) {
+      await refreshLookup();
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await cancelLabJoin(pendingRequestId);
+      setPendingRequestId(null);
+      await refreshLookup();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const displayName = profile?.display_name ?? user?.email ?? "";
+
+  return (
+    <div className="ilm-auth-screen">
+      <div className="ilm-auth-card">
+        <div className="ilm-lab-picker-header">
+          <div>
+            <h1 className="ilm-auth-title">Join a lab</h1>
+            {displayName && <p className="ilm-auth-hint">Signed in as {displayName}</p>}
+          </div>
+          <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+
+        {loading ? (
+          <p className="ilm-auth-note">Looking up lab…</p>
+        ) : error ? (
+          <p className="ilm-auth-error" role="alert">{error}</p>
+        ) : alreadyMember ? (
+          <>
+            <p className="ilm-auth-note">
+              You're already a member of <strong>{labName}</strong>.
+            </p>
+            <button type="button" className="ilm-auth-submit" onClick={handleOpenLab}>
+              Open {labName}
+            </button>
+          </>
+        ) : hasPending ? (
+          <>
+            <p className="ilm-auth-note">
+              Your request to join <strong>{labName}</strong> is pending admin approval.
+            </p>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <button type="button" className="ilm-text-button" onClick={() => void refreshLookup()}>
+                Refresh
+              </button>
+              {pendingRequestId ? (
+                <button type="button" className="ilm-text-button" disabled={submitting} onClick={() => void handleCancel()}>
+                  {submitting ? "Cancelling…" : "Cancel request"}
+                </button>
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="ilm-auth-note">
+              Request to join <strong>{labName}</strong>. A lab admin will review and approve.
+            </p>
+            <label className="ilm-auth-field">
+              <span>Message (optional)</span>
+              <textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder="Introduce yourself — who you are and why you want to join"
+                rows={3}
+              />
+            </label>
+            <button
+              type="button"
+              className="ilm-auth-submit"
+              disabled={submitting}
+              onClick={() => void handleRequest()}
+            >
+              {submitting ? "Submitting…" : "Request to join"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const SignedInShell = () => {
+  const { activeLab } = useAuth();
+  if (!activeLab) {
+    return <LabPicker />;
+  }
+  return <AccountDashboard />;
+};
+
+export const App = () => {
+  const { status } = useAuth();
+  const joinLabId = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return parseJoinLabId(window.location.pathname, APP_BASE_URL);
+  }, []);
+
+  if (joinLabId) {
+    return <JoinScreen labId={joinLabId} />;
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="ilm-auth-screen">
+        <div className="ilm-auth-card">
+          <p className="ilm-auth-note">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "signed-out") {
+    return <AuthScreen />;
+  }
+
+  return <SignedInShell />;
+};

--- a/apps/account/src/main.tsx
+++ b/apps/account/src/main.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { AuthProvider } from "@ilm/ui";
+import { App } from "./App";
+import "@ilm/ui/auth.css";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Could not find root element for Account.");
+}
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -1,0 +1,59 @@
+:root {
+  color-scheme: light;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f5f6f8;
+  color: #1a1a1f;
+}
+
+.acct-shell {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.acct-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.acct-topbar h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.acct-topbar p {
+  margin: 0;
+  color: #60606b;
+}
+
+.acct-topbar-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.acct-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.acct-back-link {
+  font-size: 0.9rem;
+  color: #3b3be0;
+  text-decoration: none;
+}
+
+.acct-back-link:hover {
+  text-decoration: underline;
+}

--- a/apps/account/src/vite-env.d.ts
+++ b/apps/account/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/account/tsconfig.json
+++ b/apps/account/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/apps/account/vite.config.ts
+++ b/apps/account/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+const base = process.env.VITE_BASE_PATH ?? "/";
+
+export default defineConfig({
+  base,
+  server: { port: 5178 },
+});

--- a/apps/funding-manager/src/App.tsx
+++ b/apps/funding-manager/src/App.tsx
@@ -1,9 +1,10 @@
-import { AppSwitcher, LabMembersPanel, useAuth } from "@ilm/ui";
+import { AccountLinkCard, AppSwitcher, useAuth } from "@ilm/ui";
+import "@ilm/ui/auth.css";
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
 export const App = () => {
-  const { activeLab, profile, signOut } = useAuth();
+  const { activeLab, profile } = useAuth();
 
   return (
     <main className="manager-shell">
@@ -17,9 +18,6 @@ export const App = () => {
         </div>
         <div className="manager-header-actions">
           <AppSwitcher currentApp="funding-manager" baseUrl={APP_BASE_URL} />
-          <button type="button" className="manager-ghost-button" onClick={() => void signOut()}>
-            Sign out
-          </button>
         </div>
       </header>
 
@@ -73,7 +71,7 @@ export const App = () => {
         </article>
 
         <div className="manager-card manager-card-hero manager-admin-stack">
-          <LabMembersPanel />
+          <AccountLinkCard baseUrl={APP_BASE_URL} />
         </div>
       </section>
     </main>

--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   AppSwitcher,
-  LabSettingsPanel,
   ProjectLeadsPanel,
   SubmissionHistoryLink,
+  appUrl,
   useAuth,
   listLabMembers,
   type LabMemberRecord,
@@ -462,7 +462,8 @@ const NewProjectModal = ({
 // ---------------------------------------------------------------------------
 
 export const App = () => {
-  const { activeLab, profile, user, signOut } = useAuth();
+  const { activeLab, profile, user } = useAuth();
+  const accountHref = appUrl("account/", APP_BASE_URL);
   const isAdmin = activeLab?.role === "owner" || activeLab?.role === "admin";
   const workspace = useProjectWorkspace(activeLab?.id ?? null, user?.id ?? null, isAdmin);
   const {
@@ -1465,7 +1466,6 @@ export const App = () => {
 
           {viewSubTab === "personnel" ? (
             <div className="pm-personnel-body">
-              <LabSettingsPanel />
               <ProjectLeadsPanel projectId={activeProject.id} title="Project leads" />
               <section className="pm-panel-section">
                 <div className="pm-panel-section-head">
@@ -1612,7 +1612,11 @@ export const App = () => {
           >
             + New project
           </button>
-          <section className="pm-side-account">
+          <a
+            href={accountHref}
+            className="pm-side-account"
+            title="Open account & lab settings"
+          >
             <div className="pm-side-account-head">
               <strong>{signedInLabel}</strong>
               <span>{profile?.email}</span>
@@ -1621,10 +1625,8 @@ export const App = () => {
               <span>{activeLab?.name ?? "No lab"}</span>
               <span>{activeLab?.role ?? "member"}</span>
             </div>
-            <button type="button" className="pm-side-account-action" onClick={() => void signOut()}>
-              Log out
-            </button>
-          </section>
+            <span className="pm-side-account-action">Manage account →</span>
+          </a>
         </div>
       </aside>
 

--- a/apps/project-manager/src/styles.css
+++ b/apps/project-manager/src/styles.css
@@ -144,6 +144,15 @@ a { color: inherit; }
   padding: 0.8rem 0.9rem;
   display: grid;
   gap: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.pm-side-account:hover,
+.pm-side-account:focus-visible {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.2);
+  outline: none;
 }
 .pm-side-account-head { display: grid; gap: 0.1rem; }
 .pm-side-account-head strong { font-size: 0.88rem; color: var(--pm-ink); }

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
-import { AppSwitcher, SubmissionHistoryLink, useAuth } from "@ilm/ui";
+import { AppSwitcher, SubmissionHistoryLink, appUrl, useAuth } from "@ilm/ui";
 import type { ProtocolBlock, ProtocolDocument, ProtocolSection, ProtocolStep } from "@ilm/types";
 import { getSupabaseClient, nowIso, safeJsonParse } from "@ilm/utils";
 import { AI_IMPORT_INSTRUCTIONS_TEXT } from "@ilm/ai-import";
@@ -257,7 +257,8 @@ const buildProjectGroups = (protocols: PublishedProtocolRecord[]): ProjectGroup[
 };
 
 export const App = ({ page }: AppProps) => {
-  const { activeLab, profile, status: authStatus, signOut, user } = useAuth();
+  const { activeLab, profile, status: authStatus, user } = useAuth();
+  const accountHref = appUrl("account/", APP_BASE_URL);
   const supabase = useMemo(() => getSupabaseClient(), []);
   const previewRef = useRef<HTMLDivElement | null>(null);
   const mainGridRef = useRef<HTMLDivElement | null>(null);
@@ -2473,7 +2474,12 @@ export const App = ({ page }: AppProps) => {
                   <span>New Protocol</span>
                 </button>
 
-                <section className="protocol-side-account" aria-label="Signed-in account and lab context">
+                <a
+                  href={accountHref}
+                  className="protocol-side-account"
+                  aria-label="Open account and lab settings"
+                  title="Open account & lab settings"
+                >
                   <div className="protocol-side-account-header">
                     <span className="material-symbols-outlined protocol-side-account-icon" aria-hidden="true">
                       account_circle
@@ -2486,10 +2492,8 @@ export const App = ({ page }: AppProps) => {
                     <span>{activeLab?.name ?? "No active lab"}</span>
                     <span>{activeLab?.role ?? "member"}</span>
                   </div>
-                  <button type="button" className="protocol-side-account-action" onClick={() => void signOut()}>
-                    Log out
-                  </button>
-                </section>
+                  <span className="protocol-side-account-action">Manage account →</span>
+                </a>
               </div>
             </aside>
 

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -1490,6 +1490,22 @@ label {
   border: 1px solid #d2d7cc;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.88);
+  color: inherit;
+  text-decoration: none;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.protocol-side-account:hover,
+.protocol-side-account:focus-visible {
+  background: rgba(255, 255, 255, 1);
+  border-color: #9da99a;
+  outline: none;
+}
+.protocol-side-account-action {
+  display: inline-block;
+  padding: 0.4rem 0.55rem;
+  background: rgba(247, 249, 245, 0.9);
+  border: 1px solid #d2d7cc;
+  text-align: center;
 }
 
 .protocol-side-account-header {

--- a/apps/supply-manager/src/App.tsx
+++ b/apps/supply-manager/src/App.tsx
@@ -1,9 +1,10 @@
-import { AppSwitcher, LabMembersPanel, useAuth } from "@ilm/ui";
+import { AccountLinkCard, AppSwitcher, useAuth } from "@ilm/ui";
+import "@ilm/ui/auth.css";
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
 export const App = () => {
-  const { activeLab, profile, signOut } = useAuth();
+  const { activeLab, profile } = useAuth();
 
   return (
     <main className="manager-shell">
@@ -17,9 +18,6 @@ export const App = () => {
         </div>
         <div className="manager-header-actions">
           <AppSwitcher currentApp="supply-manager" baseUrl={APP_BASE_URL} />
-          <button type="button" className="manager-ghost-button" onClick={() => void signOut()}>
-            Sign out
-          </button>
         </div>
       </header>
 
@@ -73,7 +71,7 @@ export const App = () => {
         </article>
 
         <div className="manager-card manager-card-hero manager-admin-stack">
-          <LabMembersPanel />
+          <AccountLinkCard baseUrl={APP_BASE_URL} />
         </div>
       </section>
     </main>

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 
 ## Foundation
 
-- **Monorepo**: npm workspaces with apps (`funding-manager`, `project-manager`, `protocol-manager`, `supply-manager`) and shared packages (`@ilm/ai-import`, `@ilm/types`, `@ilm/ui`, `@ilm/utils`, `@ilm/validation`).
+- **Monorepo**: npm workspaces with apps (`account`, `funding-manager`, `project-manager`, `protocol-manager`, `supply-manager`) and shared packages (`@ilm/ai-import`, `@ilm/types`, `@ilm/ui`, `@ilm/utils`, `@ilm/validation`).
 - **Supabase backend**: Postgres schema under `supabase/migrations/`, Supabase Auth for identity, RLS on every app table.
 - **Static deploy**: GitHub Pages, no custom backend server; only `VITE_SUPABASE_URL` + anon key ship to the browser.
 
@@ -15,8 +15,17 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - Email/password sign-up, sign-in, sign-out, password reset.
 - `AuthProvider` + protected-route wrapper; `activeLabId` persisted to `localStorage` and rehydrated on load.
 - Lab roles: `owner` / `admin` / `member`. `is_lab_member`, `is_lab_admin`, `is_lab_owner`, `lab_role`, `is_project_lead` helpers in SQL.
-- Owner-only RPCs `promote_member_to_admin` / `demote_admin_to_member`; shared `LabSettingsPanel` exposes them (currently mounted inside the project Personnel tab).
-- Invite-by-email RPC (`invite_member_to_lab`) and `LabMembersPanel` exist in `@ilm/ui` but are **not yet mounted** in any production app surface.
+- Owner-only RPCs `promote_member_to_admin` / `demote_admin_to_member`.
+- Invite-by-email RPC (`invite_member_to_lab`) surfaced via `LabMembersPanel`.
+- **Self-serve join flow**: `lab_join_requests` table + `request_lab_join` / `approve_lab_join` / `reject_lab_join` / `cancel_lab_join` / `lookup_lab_by_id` RPCs. Rejection requires a comment; one pending request per user per lab.
+- **LabPicker empty state**: create-new-lab or paste-invite-link.
+
+## Account shell (`apps/account`)
+
+- Dedicated app at `/account/`, reachable by clicking the login status box in any other app.
+- Dashboard mounts `LabSettingsPanel` (owner promote/demote), `LabMembersPanel` (invite + remove), `LabJoinRequestsPanel` (approve/reject pending requests with required comment), and `LabShareLinkPanel` (copyable `/account/join/<uuid>` URL).
+- Join-by-link route at `/account/join/<lab-uuid>`: signed-out users see auth shell; signed-in members get "Open this lab"; non-members see lab name preview + "Request to join" form with optional message and self-cancel.
+- Shared `AccountLinkCard` in `@ilm/ui` renders the login status box consistently across placeholder apps (`funding-manager`, `supply-manager`).
 
 ## Protocol Manager (Stage 3b — production)
 
@@ -37,7 +46,7 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - Per-draft `submission_history` with a link in the view tab nav (drafts only).
 - Recycle bin for published projects; withdraw for drafts.
 - Experiments link to protocols; `completedAt >= startedAt` is validated client-side.
-- Personnel tab sorts roster by display name; shows `LabSettingsPanel` (owner-only) and `ProjectLeadsPanel`.
+- Personnel tab shows `ProjectLeadsPanel` and the roster. Lab-wide owner settings now live in the Account app.
 
 ## Audit & security
 
@@ -46,7 +55,5 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 
 ## Known gaps (see `next-stage.md`)
 
-- No top-level Lab Settings surface — owners with no projects can't reach `LabSettingsPanel`.
-- Admins cannot invite members through any mounted UI (RPC exists).
-- Registered users cannot request to join a lab — no self-serve onboarding.
 - `funding-manager` and `supply-manager` are auth-shell stubs with no schema or adapter.
+- Share-link token is a raw lab UUID; a rotatable HMAC token is a deferred follow-up.

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,63 +4,37 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage: Membership & admin surfaces
+## Stage: Funding Manager schema + adapter
 
-**Why now.** `LabSettingsPanel` and `LabMembersPanel` already exist in `@ilm/ui`, but neither is reachable from a top-level surface. Owners can't promote admins without first creating a project; admins cannot invite members at all; and a signed-up user with zero memberships is stuck — there is no way to join an existing lab.
+**Why now.** With membership surfaces shipped in the Account app, the remaining auth-shell stubs (`funding-manager`, `supply-manager`) are the biggest gap. Funding first because it's a cleaner domain model (grants / budgets / allocations / expenses) and because project-manager already has experimental expense fields that funding should take over.
 
-Ship this before starting `funding-manager` / `supply-manager` schemas, because those apps will inherit the same membership gaps and duplicating the fix across four apps gets expensive.
+### Backend
 
-### Decisions already made
+New migration `YYYYMMDDHHMMSS_funding_manager.sql`:
 
-- **Discoverability**: **share-link-only**, no public lab directory. Labs are not listed anywhere. Users get in via a pasted invite/share link.
-- **Lab identity**: internal UUID is the join key on the backend. The share link embeds the UUID (or a signed token). Display name is free-form and non-unique — labs can pick any name. Nothing user-facing asks people to memorize or type a lab id.
-- **Approval required**: all join requests require admin-or-owner approval. Owners can still invite by email (already in the RPC layer).
-
-### Backend (new migration)
-
-`supabase/migrations/YYYYMMDDHHMMSS_lab_join_requests.sql`
-
-- New table `lab_join_requests`:
-  - `id uuid pk default gen_random_uuid()`
-  - `lab_id uuid not null references labs(id) on delete cascade`
-  - `user_id uuid not null references auth.users(id) on delete cascade`
-  - `message text`
-  - `status text not null check (status in ('pending','approved','rejected','cancelled')) default 'pending'`
-  - `created_at timestamptz default now()`
-  - `reviewed_by uuid references auth.users(id)`
-  - `reviewed_at timestamptz`
-  - `unique(lab_id, user_id) where status = 'pending'` (one open request per user per lab)
-- RLS:
-  - The requester can SELECT/INSERT/UPDATE (cancel) their own pending row.
-  - Lab admins + owners can SELECT all rows for their lab.
-- RPCs (all `security definer`, strict check inside):
-  - `request_lab_join(p_lab_id uuid, p_message text)` — creates a pending request; fails if already a member or a pending request exists.
-  - `approve_lab_join(p_request_id uuid)` — admin/owner only; inserts `lab_membership` with role `member`, marks request approved, writes audit row.
-  - `reject_lab_join(p_request_id uuid, p_comment text)` — admin/owner only; comment required.
-  - `cancel_lab_join(p_request_id uuid)` — requester only.
-  - `lookup_lab_by_token(p_token text) returns (id, name)` — validates a signed token and returns minimal lab info for the join-screen preview. (Token format TBD — simplest is HMAC of lab_id with a shared secret stored via Postgres config; fallback is just `lab_id` as the "token" since it's a UUID.)
+- `grants` (lab_id, funder, title, amount, start_date, end_date, status, notes)
+- `budgets` (grant_id, fiscal_year, amount)
+- `allocations` (budget_id, project_id, amount, status: proposed/committed/declined)
+- `expenses` (allocation_id, amount, category, occurred_on, description, submitted_by)
+- RLS modeled on `projects`: lab-scoped, read for members, write for admins + project leads.
+- RPCs: `propose_allocation`, `commit_allocation`, `decline_allocation` (admin-only), `submit_expense`, `approve_expense`, `reject_expense`.
+- `audit_log` entries on commit / decline / approve / reject.
 
 ### Frontend
 
-1. **Top-level Lab Settings surface** (shared shell). A new route/screen accessible from a button in the top bar next to `AppSwitcher`, visible when `activeLab?.role` is `admin` or `owner`. Mounts:
-   - `LabSettingsPanel` (owner-only promote/demote).
-   - `LabMembersPanel` (admin+owner invite-by-email, pending invitations, remove member).
-   - **New** `LabJoinRequestsPanel` — list of pending join requests with Approve / Reject (comment required) buttons.
-   - **New** `LabShareLinkPanel` — "Share this link" copyable URL containing the lab's UUID or token; owner/admin only.
-2. **Join-by-link screen** on the auth shell. When a signed-in user with a lab membership visits the link, offer "Open this lab" (no-op if already a member). When a signed-in user with no membership for that lab visits, show `lookup_lab_by_token` preview + a "Request to join" form with optional message. When a signed-out user visits, preserve the link through sign-in/sign-up then resume.
-3. **Empty state for zero-lab users.** Replace the current "create a lab" prompt with a two-option card: "Create a new lab" or "I have an invite link" (paste the URL).
-4. Remove `LabSettingsPanel` from the project Personnel tab once the top-level surface ships — Personnel keeps only `ProjectLeadsPanel` and the roster.
+- `apps/funding-manager` adapter + hooks mirroring `useProjectWorkspace`.
+- Screens: Grants overview, Budget drill-down, Allocation queue (admin review), Expense ledger.
+- Reuse `SubmissionHistoryLink`, `LabMembersPanel` removed from the app (lives in Account shell now).
 
-### Tradeoffs to weigh before implementing
+### Tradeoffs
 
-- **Token format.** Raw UUID in the URL is simplest but leaks the id permanently. A signed token rotatable from Lab Settings is safer but adds ~30 lines of SQL. Recommend raw UUID for v1, rotation as a follow-up if anyone complains.
-- **Self-cancel of pending request.** Nice to have. One checkbox of extra UI. Include in v1.
-- **Email invite vs. share link.** Keep both — email invites are still the right fit for "I know Alice's address," share links are the right fit for "here's the Slack channel." The backend already has invite-by-email; just surface it.
+- **Scope.** A first pass can ship grants + budgets + allocations and defer expenses. Recommend doing the full loop so expense approval surfaces the audit pattern before supply-manager copies it.
+- **Source of truth for committed dollars.** Allocations vs. expenses: commit-at-allocation keeps budgets tidy; commit-at-expense is more accurate but churns dashboards. Recommend commit-at-allocation with expense = actuals.
 
 ---
 
 ## After this stage
 
-- **Stage 4b (funding-manager)** — schema design + adapter + UI; reuse the auth/lab/settings shell built above.
-- **Stage 4c (supply-manager)** — same treatment.
+- **Stage 4c (supply-manager)** — schema design + adapter + UI; reuse funding's audit pattern for order/receive transitions.
+- **Rotatable share-link token**. Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in `LabShareLinkPanel` would make leaked links revocable.
 - **Deferred housekeeping**: fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,22 @@
         "packages/*"
       ]
     },
+    "apps/account": {
+      "name": "@ilm/account",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ilm/ui": "file:../../packages/ui",
+        "@ilm/utils": "file:../../packages/utils",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "typescript": "^5.7.2",
+        "vite": "^5.4.11"
+      }
+    },
     "apps/funding-manager": {
       "name": "@ilm/funding-manager",
       "version": "0.1.0",
@@ -582,6 +598,10 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@ilm/account": {
+      "resolved": "apps/account",
+      "link": true
     },
     "node_modules/@ilm/ai-import": {
       "resolved": "packages/ai-import",

--- a/packages/ui/src/AccountLinkCard.tsx
+++ b/packages/ui/src/AccountLinkCard.tsx
@@ -1,0 +1,35 @@
+import { useAuth } from "./auth/AuthProvider";
+import { appUrl } from "./AppSwitcher";
+
+// A clickable account summary that links to the shared Account shell.
+// Renders the signed-in user's name + active-lab info; clicking opens
+// `<site-root>/account/` where lab settings, members, join requests,
+// and share links live.
+export const AccountLinkCard = ({
+  baseUrl,
+  className,
+}: {
+  baseUrl: string;
+  className?: string;
+}) => {
+  const { profile, user, activeLab } = useAuth();
+  const label = profile?.display_name ?? user?.email ?? "Signed in";
+  const href = appUrl("account/", baseUrl);
+  return (
+    <a
+      href={href}
+      className={className ? `ilm-account-link ${className}` : "ilm-account-link"}
+      title="Open account & lab settings"
+    >
+      <span className="ilm-account-link-head">
+        <strong>{label}</strong>
+        <span>{profile?.email ?? ""}</span>
+      </span>
+      <span className="ilm-account-link-meta">
+        <span>{activeLab?.name ?? "No lab"}</span>
+        <span>{activeLab?.role ?? "member"}</span>
+      </span>
+      <span className="ilm-account-link-cta">Manage account →</span>
+    </a>
+  );
+};

--- a/packages/ui/src/AppSwitcher.tsx
+++ b/packages/ui/src/AppSwitcher.tsx
@@ -1,4 +1,10 @@
-export type AppId = "home" | "protocol-manager" | "project-manager" | "supply-manager" | "funding-manager";
+export type AppId =
+  | "home"
+  | "protocol-manager"
+  | "project-manager"
+  | "supply-manager"
+  | "funding-manager"
+  | "account";
 
 type AppLink = {
   id: AppId;
@@ -14,7 +20,15 @@ const APP_LINKS: AppLink[] = [
   { id: "funding-manager", label: "Funding", href: "funding-manager/" },
 ];
 
-const APP_ROOT_SEGMENTS = new Set(APP_LINKS.map((link) => link.href).filter(Boolean));
+// Root segments recognized when walking back to the site root. Includes apps
+// that aren't rendered in the nav (e.g. "account/") so siblings still resolve.
+const APP_ROOT_SEGMENTS = new Set<string>([
+  "protocol-manager/",
+  "project-manager/",
+  "supply-manager/",
+  "funding-manager/",
+  "account/",
+]);
 
 const resolveSiteRoot = (baseUrl: string) => {
   const base = baseUrl.trim() || "/";
@@ -29,6 +43,8 @@ const resolveSiteRoot = (baseUrl: string) => {
 };
 
 const buildAppUrl = (href: string, baseUrl: string) => new URL(href || ".", resolveSiteRoot(baseUrl)).toString();
+
+export const appUrl = (href: string, baseUrl: string) => buildAppUrl(href, baseUrl);
 
 export const AppSwitcher = ({
   currentApp,

--- a/packages/ui/src/admin/LabJoinRequestsPanel.tsx
+++ b/packages/ui/src/admin/LabJoinRequestsPanel.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import {
+  approveLabJoin,
+  listLabJoinRequests,
+  rejectLabJoin,
+  type LabJoinRequestRecord,
+} from "./api";
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+
+export const LabJoinRequestsPanel = ({ title = "Join Requests" }: { title?: string }) => {
+  const { activeLab, refreshLabs } = useAuth();
+  const labId = activeLab?.id ?? null;
+  const canManage = activeLab?.role === "owner" || activeLab?.role === "admin";
+  const [requests, setRequests] = useState<LabJoinRequestRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyRequestId, setBusyRequestId] = useState<string | null>(null);
+  const [rejectOpen, setRejectOpen] = useState<string | null>(null);
+  const [rejectComment, setRejectComment] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!labId || !canManage) {
+      setRequests([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setRequests(await listLabJoinRequests(labId, "pending"));
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [canManage, labId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleApprove = async (request: LabJoinRequestRecord) => {
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await approveLabJoin(request.id);
+      await load();
+      await refreshLabs();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  const openReject = (request: LabJoinRequestRecord) => {
+    setRejectOpen(request.id);
+    setRejectComment("");
+  };
+
+  const handleReject = async (request: LabJoinRequestRecord) => {
+    const comment = rejectComment.trim();
+    if (!comment) {
+      setError("A comment is required to reject a request.");
+      return;
+    }
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await rejectLabJoin(request.id, comment);
+      setRejectOpen(null);
+      setRejectComment("");
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  if (!canManage) return null;
+
+  return (
+    <section className="ilm-admin-card">
+      <div className="ilm-admin-header">
+        <div>
+          <h2>{title}</h2>
+          <p className="ilm-auth-note">
+            Approve or reject people who asked to join via the lab's share link.
+          </p>
+        </div>
+        <span className="ilm-admin-pill">{requests.length} pending</span>
+      </div>
+
+      {error ? <p className="ilm-auth-error">{error}</p> : null}
+
+      {loading ? (
+        <p className="ilm-admin-empty">Loading join requests…</p>
+      ) : requests.length === 0 ? (
+        <p className="ilm-admin-empty">No pending join requests.</p>
+      ) : (
+        <ul className="ilm-admin-list">
+          {requests.map((request) => {
+            const busy = busyRequestId === request.id;
+            const label = request.display_name || request.email || request.user_id;
+            const rejecting = rejectOpen === request.id;
+            return (
+              <li className="ilm-admin-list-item" key={request.id}>
+                <div className="ilm-admin-list-copy">
+                  <strong>{label}</strong>
+                  <span>{request.email || "No email available"}</span>
+                  <small>Requested {formatDate(request.created_at)}</small>
+                  {request.message ? (
+                    <p className="ilm-admin-helper" style={{ marginTop: "0.4rem" }}>
+                      “{request.message}”
+                    </p>
+                  ) : null}
+                </div>
+                <div className="ilm-admin-actions">
+                  {rejecting ? (
+                    <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem", minWidth: "14rem" }}>
+                      <textarea
+                        value={rejectComment}
+                        onChange={(event) => setRejectComment(event.target.value)}
+                        placeholder="Reason (required)"
+                        rows={2}
+                      />
+                      <div style={{ display: "flex", gap: "0.4rem" }}>
+                        <button
+                          type="button"
+                          className="ilm-text-button"
+                          disabled={busy}
+                          onClick={() => void handleReject(request)}
+                        >
+                          Confirm reject
+                        </button>
+                        <button
+                          type="button"
+                          className="ilm-text-button"
+                          disabled={busy}
+                          onClick={() => {
+                            setRejectOpen(null);
+                            setRejectComment("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        className="ilm-text-button"
+                        disabled={busy}
+                        onClick={() => void handleApprove(request)}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        className="ilm-text-button"
+                        disabled={busy}
+                        onClick={() => openReject(request)}
+                      >
+                        Reject
+                      </button>
+                    </>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/packages/ui/src/admin/LabShareLinkPanel.tsx
+++ b/packages/ui/src/admin/LabShareLinkPanel.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from "react";
+import { useAuth } from "../auth/AuthProvider";
+
+const resolveSiteRoot = (baseUrl: string) => {
+  if (typeof window === "undefined") return "/";
+  const base = baseUrl.trim() || "/";
+  const withLeadingSlash = base.startsWith("/") ? base : `/${base}`;
+  const normalized = withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+  const url = new URL(normalized, window.location.origin);
+  const knownAppRoots = ["protocol-manager/", "project-manager/", "supply-manager/", "funding-manager/", "account/"];
+  const matchedAppRoot = knownAppRoots.find((segment) => url.pathname.endsWith(segment));
+  const root = matchedAppRoot ? new URL("../", url) : url;
+  return root.toString();
+};
+
+export const buildLabShareUrl = (labId: string, baseUrl: string): string => {
+  const root = resolveSiteRoot(baseUrl);
+  return new URL(`account/join/${labId}`, root).toString();
+};
+
+export const LabShareLinkPanel = ({
+  baseUrl,
+  title = "Lab Share Link",
+}: {
+  baseUrl: string;
+  title?: string;
+}) => {
+  const { activeLab } = useAuth();
+  const canManage = activeLab?.role === "owner" || activeLab?.role === "admin";
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = useMemo(() => {
+    if (!activeLab) return "";
+    return buildLabShareUrl(activeLab.id, baseUrl);
+  }, [activeLab, baseUrl]);
+
+  if (!canManage || !activeLab) return null;
+
+  const handleCopy = async () => {
+    if (!shareUrl || typeof navigator === "undefined" || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <section className="ilm-admin-card">
+      <div className="ilm-admin-header">
+        <div>
+          <h2>{title}</h2>
+          <p className="ilm-auth-note">
+            Share this link with teammates. Visitors will need to sign in and request approval before they become members.
+          </p>
+        </div>
+      </div>
+      <div className="ilm-admin-field-row" style={{ alignItems: "center" }}>
+        <input
+          type="text"
+          readOnly
+          value={shareUrl}
+          onFocus={(event) => event.currentTarget.select()}
+          style={{ flex: 1 }}
+        />
+        <button type="button" className="ilm-text-button" onClick={() => void handleCopy()}>
+          {copied ? "Copied!" : "Copy link"}
+        </button>
+      </div>
+    </section>
+  );
+};

--- a/packages/ui/src/admin/api.ts
+++ b/packages/ui/src/admin/api.ts
@@ -31,6 +31,29 @@ export type ProjectLeadRecord = {
   user_id: string;
 };
 
+export type LabJoinRequestStatus = "pending" | "approved" | "rejected" | "cancelled";
+
+export type LabJoinRequestRecord = {
+  id: string;
+  lab_id: string;
+  user_id: string;
+  display_name: string | null;
+  email: string | null;
+  message: string | null;
+  status: LabJoinRequestStatus;
+  review_comment: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+};
+
+export type LabLookupResult = {
+  id: string;
+  name: string;
+  already_member: boolean;
+  has_pending_request: boolean;
+};
+
 const client = () => getSupabaseClient();
 
 export const listLabMembers = async (labId: string): Promise<LabMemberRecord[]> => {
@@ -124,5 +147,52 @@ export const demoteAdminToMember = async (labId: string, userId: string) => {
     p_lab_id: labId,
     p_user_id: userId,
   });
+  if (error) throw error;
+};
+
+export const lookupLabById = async (labId: string): Promise<LabLookupResult | null> => {
+  const { data, error } = await client()
+    .rpc("lookup_lab_by_id", { p_lab_id: labId })
+    .maybeSingle();
+  if (error) throw error;
+  return (data as LabLookupResult) ?? null;
+};
+
+export const requestLabJoin = async (labId: string, message?: string): Promise<string> => {
+  const { data, error } = await client().rpc("request_lab_join", {
+    p_lab_id: labId,
+    p_message: message ?? null,
+  });
+  if (error) throw error;
+  return data as string;
+};
+
+export const listLabJoinRequests = async (
+  labId: string,
+  status: LabJoinRequestStatus | null = "pending"
+): Promise<LabJoinRequestRecord[]> => {
+  const { data, error } = await client().rpc("list_lab_join_requests", {
+    p_lab_id: labId,
+    p_status: status,
+  });
+  if (error) throw error;
+  return (data as LabJoinRequestRecord[]) ?? [];
+};
+
+export const approveLabJoin = async (requestId: string) => {
+  const { error } = await client().rpc("approve_lab_join", { p_request_id: requestId });
+  if (error) throw error;
+};
+
+export const rejectLabJoin = async (requestId: string, comment: string) => {
+  const { error } = await client().rpc("reject_lab_join", {
+    p_request_id: requestId,
+    p_comment: comment,
+  });
+  if (error) throw error;
+};
+
+export const cancelLabJoin = async (requestId: string) => {
+  const { error } = await client().rpc("cancel_lab_join", { p_request_id: requestId });
   if (error) throw error;
 };

--- a/packages/ui/src/admin/index.ts
+++ b/packages/ui/src/admin/index.ts
@@ -1,20 +1,31 @@
 export { LabMembersPanel } from "./LabMembersPanel";
+export { LabJoinRequestsPanel } from "./LabJoinRequestsPanel";
+export { LabShareLinkPanel, buildLabShareUrl } from "./LabShareLinkPanel";
 export { ProjectLeadsPanel } from "./ProjectLeadsPanel";
 export {
+  approveLabJoin,
   assignProjectLead,
+  cancelLabJoin,
   demoteAdminToMember,
   inviteMemberToLab,
   listLabInvitations,
+  listLabJoinRequests,
   listLabMembers,
   listProjectLeads,
   listProjects,
+  lookupLabById,
   promoteMemberToAdmin,
+  rejectLabJoin,
   removeLabMember,
+  requestLabJoin,
   revokeProjectLead,
   updateLabMemberRole,
 } from "./api";
 export type {
   LabInvitationRecord,
+  LabJoinRequestRecord,
+  LabJoinRequestStatus,
+  LabLookupResult,
   LabMemberRecord,
   ProjectLeadRecord,
   ProjectRecord,

--- a/packages/ui/src/auth/LabPicker.tsx
+++ b/packages/ui/src/auth/LabPicker.tsx
@@ -2,11 +2,23 @@ import { useState, type FormEvent } from "react";
 import { slugify } from "@ilm/utils";
 import { useAuth } from "./AuthProvider";
 
+type Mode = "choose" | "create" | "join";
+
+const extractLabIdFromInput = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  // Accept a raw UUID or a share URL that ends with …/join/<uuid>.
+  const uuidMatch = trimmed.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  return uuidMatch ? uuidMatch[0] : null;
+};
+
 export const LabPicker = () => {
   const { labs, selectLab, createLab, signOut, profile, user } = useAuth();
+  const [mode, setMode] = useState<Mode>(labs.length === 0 ? "choose" : "choose");
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [slugTouched, setSlugTouched] = useState(false);
+  const [linkInput, setLinkInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -33,6 +45,34 @@ export const LabPicker = () => {
     }
   };
 
+  const handleJoin = (event: FormEvent) => {
+    event.preventDefault();
+    setErr(null);
+    const labId = extractLabIdFromInput(linkInput);
+    if (!labId) {
+      setErr("Paste an invite link or a lab id.");
+      return;
+    }
+    // Navigate to the join-by-link screen in the Account app. The current app
+    // may or may not be the Account app — either way, a sibling-app URL works.
+    const baseHref = typeof window !== "undefined" ? window.location.href : "/";
+    const base = new URL(baseHref);
+    // Walk up the base URL to the site root: remove a trailing "<app>/" segment.
+    const pathSegments = base.pathname.split("/").filter(Boolean);
+    const knownApps = new Set([
+      "protocol-manager",
+      "project-manager",
+      "supply-manager",
+      "funding-manager",
+      "account",
+    ]);
+    if (pathSegments.length > 0 && knownApps.has(pathSegments[pathSegments.length - 1])) {
+      pathSegments.pop();
+    }
+    const rootPath = pathSegments.length > 0 ? `/${pathSegments.join("/")}/` : "/";
+    window.location.assign(new URL(`${rootPath}account/join/${labId}`, base.origin).toString());
+  };
+
   const emptyState = labs.length === 0;
   const displayName = profile?.display_name ?? user?.email ?? "";
 
@@ -49,11 +89,7 @@ export const LabPicker = () => {
           </button>
         </div>
 
-        {emptyState ? (
-          <p className="ilm-auth-note">
-            You aren't a member of any labs yet. Create one below to get started.
-          </p>
-        ) : (
+        {!emptyState ? (
           <ul className="ilm-lab-list">
             {labs.map((lab) => (
               <li key={lab.id}>
@@ -68,44 +104,99 @@ export const LabPicker = () => {
               </li>
             ))}
           </ul>
-        )}
+        ) : null}
 
-        <form onSubmit={handleCreate} className="ilm-auth-form">
-          <h2 className="ilm-lab-section-title">Create a new lab</h2>
-          <label className="ilm-auth-field">
-            <span>Lab name</span>
-            <input
-              type="text"
-              required
-              value={name}
-              onChange={(event) => {
-                setName(event.target.value);
-                if (!slugTouched) {
-                  setSlug(slugify(event.target.value));
-                }
-              }}
-            />
-          </label>
-          <label className="ilm-auth-field">
-            <span>Slug (optional)</span>
-            <input
-              type="text"
-              value={slug}
-              onChange={(event) => {
-                setSlug(event.target.value);
-                setSlugTouched(true);
-              }}
-            />
-          </label>
-          <button type="submit" className="ilm-auth-submit" disabled={submitting}>
-            {submitting ? "Creating…" : "Create lab"}
-          </button>
-          {err && (
-            <p className="ilm-auth-error" role="alert">
-              {err}
-            </p>
-          )}
-        </form>
+        {mode === "choose" ? (
+          <div className="ilm-auth-form">
+            {emptyState ? (
+              <p className="ilm-auth-note">
+                You aren't a member of any labs yet. Create a new lab or join an existing one.
+              </p>
+            ) : null}
+            <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+              <button type="button" className="ilm-auth-submit" onClick={() => setMode("create")}>
+                Create a new lab
+              </button>
+              <button type="button" className="ilm-text-button" onClick={() => setMode("join")}>
+                I have an invite link
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {mode === "create" ? (
+          <form onSubmit={handleCreate} className="ilm-auth-form">
+            <h2 className="ilm-lab-section-title">Create a new lab</h2>
+            <label className="ilm-auth-field">
+              <span>Lab name</span>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(event) => {
+                  setName(event.target.value);
+                  if (!slugTouched) {
+                    setSlug(slugify(event.target.value));
+                  }
+                }}
+              />
+            </label>
+            <label className="ilm-auth-field">
+              <span>Slug (optional)</span>
+              <input
+                type="text"
+                value={slug}
+                onChange={(event) => {
+                  setSlug(event.target.value);
+                  setSlugTouched(true);
+                }}
+              />
+            </label>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <button type="submit" className="ilm-auth-submit" disabled={submitting}>
+                {submitting ? "Creating…" : "Create lab"}
+              </button>
+              <button type="button" className="ilm-text-button" onClick={() => setMode("choose")}>
+                Back
+              </button>
+            </div>
+            {err && (
+              <p className="ilm-auth-error" role="alert">
+                {err}
+              </p>
+            )}
+          </form>
+        ) : null}
+
+        {mode === "join" ? (
+          <form onSubmit={handleJoin} className="ilm-auth-form">
+            <h2 className="ilm-lab-section-title">Join an existing lab</h2>
+            <p className="ilm-auth-hint">Paste the share link (or lab id) your admin sent you.</p>
+            <label className="ilm-auth-field">
+              <span>Invite link or lab id</span>
+              <input
+                type="text"
+                required
+                value={linkInput}
+                onChange={(event) => setLinkInput(event.target.value)}
+                placeholder="https://…/account/join/<uuid>"
+              />
+            </label>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <button type="submit" className="ilm-auth-submit">
+                Continue
+              </button>
+              <button type="button" className="ilm-text-button" onClick={() => setMode("choose")}>
+                Back
+              </button>
+            </div>
+            {err && (
+              <p className="ilm-auth-error" role="alert">
+                {err}
+              </p>
+            )}
+          </form>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/ui/src/auth/auth.css
+++ b/packages/ui/src/auth/auth.css
@@ -479,3 +479,43 @@
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
+
+/* Account link card — shared account/lab-settings entry point */
+.ilm-account-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.6);
+  color: inherit;
+  text-decoration: none;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.ilm-account-link:hover,
+.ilm-account-link:focus-visible {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+.ilm-account-link-head {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+.ilm-account-link-head span {
+  font-size: 0.82rem;
+  color: var(--rl-muted, #6d736a);
+}
+.ilm-account-link-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: var(--rl-muted, #6d736a);
+}
+.ilm-account-link-cta {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  color: #3b3be0;
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -2,7 +2,8 @@ import type { PropsWithChildren } from "react";
 
 export * from "./auth";
 export * from "./admin";
-export { AppSwitcher, type AppId } from "./AppSwitcher";
+export { AppSwitcher, appUrl, type AppId } from "./AppSwitcher";
+export { AccountLinkCard } from "./AccountLinkCard";
 export { SubmissionHistoryLink, type SubmissionHistoryEntry } from "./SubmissionHistoryLink";
 export { LabSettingsPanel } from "./admin/LabSettingsPanel";
 

--- a/supabase/migrations/20260426000000_lab_join_requests.sql
+++ b/supabase/migrations/20260426000000_lab_join_requests.sql
@@ -1,0 +1,338 @@
+-- Lab join requests — self-serve onboarding via share link.
+--
+-- Users paste a lab share link (containing the lab UUID), request to join,
+-- and an admin/owner approves or rejects. Complements invite-by-email, which
+-- stays the right fit for "I know Alice's address."
+
+-- ---------------------------------------------------------------------------
+-- Table
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.lab_join_requests (
+  id           uuid primary key default gen_random_uuid(),
+  lab_id       uuid not null references public.labs(id) on delete cascade,
+  user_id      uuid not null references auth.users(id) on delete cascade,
+  message      text,
+  status       text not null default 'pending'
+                 check (status in ('pending', 'approved', 'rejected', 'cancelled')),
+  review_comment text,
+  reviewed_by  uuid references auth.users(id) on delete set null,
+  reviewed_at  timestamptz,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+create unique index if not exists lab_join_requests_one_pending_idx
+  on public.lab_join_requests (lab_id, user_id)
+  where status = 'pending';
+
+create index if not exists lab_join_requests_lab_status_idx
+  on public.lab_join_requests (lab_id, status);
+
+drop trigger if exists lab_join_requests_set_updated_at on public.lab_join_requests;
+create trigger lab_join_requests_set_updated_at
+before update on public.lab_join_requests
+for each row execute function public.set_updated_at();
+
+alter table public.lab_join_requests enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+
+drop policy if exists lab_join_requests_select_self on public.lab_join_requests;
+create policy lab_join_requests_select_self on public.lab_join_requests
+  for select using (user_id = auth.uid());
+
+drop policy if exists lab_join_requests_select_admin on public.lab_join_requests;
+create policy lab_join_requests_select_admin on public.lab_join_requests
+  for select using (public.is_lab_admin(lab_id));
+
+-- Writes are only allowed via RPCs (which run security definer). Deny direct DML.
+drop policy if exists lab_join_requests_no_insert on public.lab_join_requests;
+create policy lab_join_requests_no_insert on public.lab_join_requests
+  for insert with check (false);
+
+drop policy if exists lab_join_requests_no_update on public.lab_join_requests;
+create policy lab_join_requests_no_update on public.lab_join_requests
+  for update using (false) with check (false);
+
+drop policy if exists lab_join_requests_no_delete on public.lab_join_requests;
+create policy lab_join_requests_no_delete on public.lab_join_requests
+  for delete using (false);
+
+-- ---------------------------------------------------------------------------
+-- RPCs
+-- ---------------------------------------------------------------------------
+
+-- lookup_lab_by_id — share-link preview. Any authenticated user can resolve a
+-- lab UUID to its display name, so the join screen can show "Request to join
+-- <Lab Name>?" even when the caller isn't a member yet. No other fields leak.
+create or replace function public.lookup_lab_by_id(p_lab_id uuid)
+returns table (
+  id uuid,
+  name text,
+  already_member boolean,
+  has_pending_request boolean
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  return query
+  select
+    l.id,
+    l.name,
+    exists (
+      select 1 from public.lab_memberships m
+      where m.lab_id = l.id and m.user_id = v_uid
+    ) as already_member,
+    exists (
+      select 1 from public.lab_join_requests r
+      where r.lab_id = l.id and r.user_id = v_uid and r.status = 'pending'
+    ) as has_pending_request
+  from public.labs l
+  where l.id = p_lab_id;
+end;
+$$;
+
+grant execute on function public.lookup_lab_by_id(uuid) to authenticated;
+
+-- request_lab_join — create a pending request.
+create or replace function public.request_lab_join(
+  p_lab_id uuid,
+  p_message text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_request_id uuid;
+  v_lab_exists boolean;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select exists(select 1 from public.labs where id = p_lab_id) into v_lab_exists;
+  if not v_lab_exists then
+    raise exception 'lab not found' using errcode = '22023';
+  end if;
+
+  if exists (
+    select 1 from public.lab_memberships
+    where lab_id = p_lab_id and user_id = v_uid
+  ) then
+    raise exception 'already a member of this lab' using errcode = '22023';
+  end if;
+
+  if exists (
+    select 1 from public.lab_join_requests
+    where lab_id = p_lab_id and user_id = v_uid and status = 'pending'
+  ) then
+    raise exception 'a pending request already exists' using errcode = '22023';
+  end if;
+
+  insert into public.lab_join_requests (lab_id, user_id, message)
+  values (p_lab_id, v_uid, nullif(trim(coalesce(p_message, '')), ''))
+  returning id into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+grant execute on function public.request_lab_join(uuid, text) to authenticated;
+
+-- list_lab_join_requests — admin view of pending/recent join requests.
+create or replace function public.list_lab_join_requests(
+  p_lab_id uuid,
+  p_status text default 'pending'
+)
+returns table (
+  id uuid,
+  lab_id uuid,
+  user_id uuid,
+  display_name text,
+  email text,
+  message text,
+  status text,
+  review_comment text,
+  reviewed_by uuid,
+  reviewed_at timestamptz,
+  created_at timestamptz
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_lab_admin(p_lab_id) then
+    raise exception 'only lab admins can view join requests' using errcode = '42501';
+  end if;
+
+  return query
+  select
+    r.id,
+    r.lab_id,
+    r.user_id,
+    p.display_name,
+    p.email,
+    r.message,
+    r.status,
+    r.review_comment,
+    r.reviewed_by,
+    r.reviewed_at,
+    r.created_at
+  from public.lab_join_requests r
+  left join public.profiles p on p.id = r.user_id
+  where r.lab_id = p_lab_id
+    and (p_status is null or r.status = p_status)
+  order by r.created_at desc;
+end;
+$$;
+
+grant execute on function public.list_lab_join_requests(uuid, text) to authenticated;
+
+-- approve_lab_join — admin/owner only; inserts membership with role='member'.
+create or replace function public.approve_lab_join(p_request_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_lab_id uuid;
+  v_user_id uuid;
+  v_status text;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select lab_id, user_id, status
+    into v_lab_id, v_user_id, v_status
+  from public.lab_join_requests
+  where id = p_request_id;
+
+  if v_lab_id is null then
+    raise exception 'request not found' using errcode = '22023';
+  end if;
+  if not public.is_lab_admin(v_lab_id) then
+    raise exception 'only lab admins can approve requests' using errcode = '42501';
+  end if;
+  if v_status <> 'pending' then
+    raise exception 'request is not pending' using errcode = '22023';
+  end if;
+
+  insert into public.lab_memberships (lab_id, user_id, role)
+  values (v_lab_id, v_user_id, 'member')
+  on conflict (lab_id, user_id) do nothing;
+
+  update public.lab_join_requests
+    set status = 'approved',
+        reviewed_by = v_uid,
+        reviewed_at = now()
+  where id = p_request_id;
+end;
+$$;
+
+grant execute on function public.approve_lab_join(uuid) to authenticated;
+
+-- reject_lab_join — admin/owner only; comment required.
+create or replace function public.reject_lab_join(
+  p_request_id uuid,
+  p_comment text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_lab_id uuid;
+  v_status text;
+  v_comment text := nullif(trim(coalesce(p_comment, '')), '');
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if v_comment is null then
+    raise exception 'a comment is required to reject a request' using errcode = '22023';
+  end if;
+
+  select lab_id, status into v_lab_id, v_status
+  from public.lab_join_requests
+  where id = p_request_id;
+
+  if v_lab_id is null then
+    raise exception 'request not found' using errcode = '22023';
+  end if;
+  if not public.is_lab_admin(v_lab_id) then
+    raise exception 'only lab admins can reject requests' using errcode = '42501';
+  end if;
+  if v_status <> 'pending' then
+    raise exception 'request is not pending' using errcode = '22023';
+  end if;
+
+  update public.lab_join_requests
+    set status = 'rejected',
+        review_comment = v_comment,
+        reviewed_by = v_uid,
+        reviewed_at = now()
+  where id = p_request_id;
+end;
+$$;
+
+grant execute on function public.reject_lab_join(uuid, text) to authenticated;
+
+-- cancel_lab_join — requester only.
+create or replace function public.cancel_lab_join(p_request_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_user_id uuid;
+  v_status text;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select user_id, status into v_user_id, v_status
+  from public.lab_join_requests
+  where id = p_request_id;
+
+  if v_user_id is null then
+    raise exception 'request not found' using errcode = '22023';
+  end if;
+  if v_user_id <> v_uid then
+    raise exception 'only the requester can cancel' using errcode = '42501';
+  end if;
+  if v_status <> 'pending' then
+    raise exception 'request is not pending' using errcode = '22023';
+  end if;
+
+  update public.lab_join_requests
+    set status = 'cancelled'
+  where id = p_request_id;
+end;
+$$;
+
+grant execute on function public.cancel_lab_join(uuid) to authenticated;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "apps/protocol-manager" },
     { "path": "apps/project-manager" },
     { "path": "apps/supply-manager" },
-    { "path": "apps/funding-manager" }
+    { "path": "apps/funding-manager" },
+    { "path": "apps/account" }
   ]
 }


### PR DESCRIPTION
## Summary

- Ships the next-stage plan: **Membership & admin surfaces** in a new `apps/account` shell, reachable by clicking the login status box in any app.
- Adds a self-serve **share-link join flow** (`lab_join_requests` + RPCs), complementing the existing invite-by-email. Rejection requires a comment; one pending request per user per lab; requester can self-cancel.
- Shared `AccountLinkCard` + `appUrl` helper keep cross-app navigation consistent. LabPicker empty state now offers **create-new-lab** or **paste-invite-link**.

## What's in this PR

**Backend**
- `supabase/migrations/20260426000000_lab_join_requests.sql` — table, RLS (self-select, admin-select, RPC-only writes), and 6 RPCs: `lookup_lab_by_id`, `request_lab_join`, `list_lab_join_requests`, `approve_lab_join`, `reject_lab_join`, `cancel_lab_join`. Applied against the live project via Supabase MCP.

**Account shell** (`apps/account`, new Vite app)
- Dashboard at `/account/` mounts `LabSettingsPanel`, `LabMembersPanel`, `LabJoinRequestsPanel`, `LabShareLinkPanel`.
- Join-by-link route at `/account/join/<lab-uuid>` handles signed-out → auth → resume, already-member (open lab), and non-member (request + optional message + self-cancel).

**Shared UI (`@ilm/ui`)**
- `AccountLinkCard` — the shared login status box that links to `/account/`.
- `LabJoinRequestsPanel`, `LabShareLinkPanel`.
- `AppSwitcher` recognizes `account/` as a sibling app; new `appUrl` helper exported for apps.
- `LabPicker` refactored with a two-mode empty state (create vs. paste link).

**App wiring**
- `project-manager` + `protocol-manager`: bespoke account boxes converted into `<a>` → `/account/`, inline log-out removed (now on Account dashboard), hover/focus CSS added.
- `project-manager` Personnel tab: `LabSettingsPanel` removed (lives in Account shell now).
- `supply-manager` + `funding-manager`: bespoke `LabMembersPanel` + sign-out replaced with `AccountLinkCard`.

## Design notes for the reviewer

- **Token format is raw lab UUID** (per next-stage tradeoff). A rotatable HMAC token is tracked as a follow-up in `docs/next-stage.md`.
- **Writes go through SECURITY DEFINER RPCs** — `lab_join_requests` has policies that deny direct insert/update/delete so all state transitions run through the RPCs' strict checks.
- **`lookup_lab_by_id`** intentionally leaks only `{id, name, already_member, has_pending_request}` for authenticated callers, so the join screen can preview the lab without granting any table access.

## Test plan

- [x] `npm run typecheck` — clean across all 10 workspaces
- [x] `npm run build` — clean across all apps + packages
- [ ] Manual: sign up fresh user → paste share link → admin approves → lab appears
- [ ] Manual: admin rejects with comment → requester sees rejection state
- [ ] Manual: requester self-cancels before admin reviews
- [ ] Manual: click login status box in protocol-manager / project-manager / supply-manager / funding-manager → lands on `/account/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)