### PR TITLE
Deploy account + supply + funding apps to Pages

### DIFF
--- a/.github/workflows/deploy-protocol-manager-pages.yml
+++ b/.github/workflows/deploy-protocol-manager-pages.yml
@@ -45,12 +45,38 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
+      - name: Build Supply Manager for Pages
+        run: npm run build -w @ilm/supply-manager
+        env:
+          VITE_BASE_PATH: /ILM/supply-manager/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
+      - name: Build Funding Manager for Pages
+        run: npm run build -w @ilm/funding-manager
+        env:
+          VITE_BASE_PATH: /ILM/funding-manager/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
+      - name: Build Account for Pages
+        run: npm run build -w @ilm/account
+        env:
+          VITE_BASE_PATH: /ILM/account/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
       - name: Assemble Pages artifact
         run: |
           rm -rf .pages-dist
-          mkdir -p .pages-dist/project-manager
+          mkdir -p .pages-dist/project-manager .pages-dist/supply-manager .pages-dist/funding-manager .pages-dist/account
           cp -R apps/protocol-manager/dist/. .pages-dist/
           cp -R apps/project-manager/dist/. .pages-dist/project-manager/
+          cp -R apps/supply-manager/dist/. .pages-dist/supply-manager/
+          cp -R apps/funding-manager/dist/. .pages-dist/funding-manager/
+          cp -R apps/account/dist/. .pages-dist/account/
+          # SPA fallback for /account/join/<uuid> and any future client-side routes
+          cp .pages-dist/account/index.html .pages-dist/account/404.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
The Pages workflow only built protocol-manager and project-manager, so /ILM/account/, /ILM/supply-manager/, and /ILM/funding-manager/ returned 404 even though the AppSwitcher linked to them.

Also copies account/index.html to account/404.html so the Pages server-side 404 fallback serves the SPA, letting
/ILM/account/join/<uuid> resolve client-side instead of 404ing.