### PR TITLE
Auto-claim pending invitations on sign-in

### DIFF
--- a/packages/ui/src/admin/LabMembersPanel.tsx
+++ b/packages/ui/src/admin/LabMembersPanel.tsx
@@ -188,7 +188,7 @@ export const LabMembersPanel = ({
           <form className="ilm-admin-form" onSubmit={handleInvite}>
             <div className="ilm-admin-form-header">
               <h3>Invite Member</h3>
-              <span className="ilm-admin-helper">Email delivery is tracked out-of-band for now.</span>
+              <span className="ilm-admin-helper">Invited users are added automatically when they sign in with this email.</span>
             </div>
             <div className="ilm-admin-field-row">
               <label className="ilm-auth-field">

--- a/packages/ui/src/admin/api.ts
+++ b/packages/ui/src/admin/api.ts
@@ -196,3 +196,9 @@ export const cancelLabJoin = async (requestId: string) => {
   const { error } = await client().rpc("cancel_lab_join", { p_request_id: requestId });
   if (error) throw error;
 };
+
+export const claimPendingInvitations = async (): Promise<number> => {
+  const { data, error } = await client().rpc("claim_pending_invitations");
+  if (error) throw error;
+  return (data as number) ?? 0;
+};

--- a/packages/ui/src/admin/index.ts
+++ b/packages/ui/src/admin/index.ts
@@ -6,6 +6,7 @@ export {
   approveLabJoin,
   assignProjectLead,
   cancelLabJoin,
+  claimPendingInvitations,
   demoteAdminToMember,
   inviteMemberToLab,
   listLabInvitations,

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { getSupabaseClient } from "@ilm/utils";
+import { claimPendingInvitations } from "../admin/api";
 import type { LabWithRole, Profile } from "./types";
 
 type AuthStatus = "loading" | "signed-out" | "signed-in";
@@ -115,10 +116,13 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         return;
       }
       try {
-        const [nextProfile, nextLabs] = await Promise.all([
-          loadProfile(nextSession.user.id),
-          loadLabs(),
-        ]);
+        const nextProfile = await loadProfile(nextSession.user.id);
+        try {
+          await claimPendingInvitations();
+        } catch (claimErr) {
+          console.warn("[ilm] claim_pending_invitations failed", claimErr);
+        }
+        const nextLabs = await loadLabs();
         setProfile(nextProfile);
         setLabs(nextLabs);
         setStatus("signed-in");

--- a/supabase/migrations/20260427000000_claim_pending_invitations.sql
+++ b/supabase/migrations/20260427000000_claim_pending_invitations.sql
@@ -1,0 +1,51 @@
+-- Auto-claim pending lab_invitations on sign-in by email match.
+--
+-- Email delivery is out of band. When a user signs up / signs in with an
+-- email address that has one or more `pending` lab_invitations rows, convert
+-- those to actual lab_memberships and mark the invitation accepted.
+
+create or replace function public.claim_pending_invitations()
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_email text;
+  v_claimed integer := 0;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select lower(email) into v_email from auth.users where id = v_uid;
+  if v_email is null or v_email = '' then
+    return 0;
+  end if;
+
+  with matching as (
+    select id, lab_id, role
+    from public.lab_invitations
+    where status = 'pending'
+      and lower(email) = v_email
+  ),
+  inserted as (
+    insert into public.lab_memberships (lab_id, user_id, role)
+    select lab_id, v_uid, role from matching
+    on conflict (lab_id, user_id) do nothing
+    returning lab_id
+  ),
+  accepted as (
+    update public.lab_invitations
+      set status = 'accepted', updated_at = now()
+    where id in (select id from matching)
+    returning 1
+  )
+  select count(*) into v_claimed from accepted;
+
+  return v_claimed;
+end;
+$$;
+
+grant execute on function public.claim_pending_invitations() to authenticated;


### PR DESCRIPTION
## Summary
- New `claim_pending_invitations` SECURITY DEFINER RPC converts matching-email pending `lab_invitations` rows into `lab_memberships` for the calling user and marks the invitation `accepted`.
- `AuthProvider.refreshAll` calls it after loading the profile so invited users land in their lab on first sign-in — no email delivery needed.
- Updates LabMembersPanel hint to reflect the new behavior.

## Test plan
- [ ] Invite an email, sign up with that email, confirm lab appears in LabPicker without manual join-link step.
- [ ] Existing invited users on next sign-in get auto-claimed.
- [ ] Sign-in still succeeds if the RPC call throws (warning only, non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)