### PR TITLE
Fix role-management duplication and /account/join 404

### DIFF
--- a/.github/workflows/deploy-protocol-manager-pages.yml
+++ b/.github/workflows/deploy-protocol-manager-pages.yml
@@ -75,8 +75,12 @@ jobs:
           cp -R apps/supply-manager/dist/. .pages-dist/supply-manager/
           cp -R apps/funding-manager/dist/. .pages-dist/funding-manager/
           cp -R apps/account/dist/. .pages-dist/account/
-          # SPA fallback for /account/join/<uuid> and any future client-side routes
-          cp .pages-dist/account/index.html .pages-dist/account/404.html
+          # SPA fallback: GitHub Pages serves /<site>/404.html for any missing
+          # path under the site, so put the Account shell there — that's the
+          # app with client-side routes (/account/join/<uuid>). The shell
+          # reads window.location.pathname and routes accordingly; assets
+          # resolve against its configured base of /ILM/account/.
+          cp .pages-dist/account/index.html .pages-dist/404.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/packages/ui/src/admin/LabMembersPanel.tsx
+++ b/packages/ui/src/admin/LabMembersPanel.tsx
@@ -5,7 +5,6 @@ import {
   listLabInvitations,
   listLabMembers,
   removeLabMember,
-  updateLabMemberRole,
   type LabInvitationRecord,
   type LabMemberRecord,
 } from "./api";
@@ -69,21 +68,6 @@ export const LabMembersPanel = ({
     () => invitations.filter((invitation) => invitation.status === "pending"),
     [invitations]
   );
-
-  const handleRoleChange = async (member: LabMemberRecord, role: "admin" | "member") => {
-    if (!labId || member.role === "owner" || member.role === role) return;
-    setBusyUserId(member.user_id);
-    setError(null);
-    try {
-      await updateLabMemberRole(labId, member.user_id, role);
-      await load();
-      await refreshLabs();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyUserId(null);
-    }
-  };
 
   const handleRemove = async (member: LabMemberRecord) => {
     if (!labId || member.role === "owner") return;
@@ -158,26 +142,16 @@ export const LabMembersPanel = ({
                   <div className="ilm-admin-actions">
                     <span className={`ilm-admin-badge ilm-admin-badge-${member.role}`}>{member.role}</span>
                     {member.role !== "owner" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="ilm-text-button"
-                          disabled={isBusy}
-                          onClick={() => void handleRoleChange(member, member.role === "admin" ? "member" : "admin")}
-                        >
-                          {member.role === "admin" ? "Demote to member" : "Promote to admin"}
-                        </button>
-                        <button
-                          type="button"
-                          className="ilm-text-button"
-                          disabled={isBusy}
-                          onClick={() => void handleRemove(member)}
-                        >
-                          Remove
-                        </button>
-                      </>
+                      <button
+                        type="button"
+                        className="ilm-text-button"
+                        disabled={isBusy}
+                        onClick={() => void handleRemove(member)}
+                      >
+                        Remove
+                      </button>
                     ) : (
-                      <span className="ilm-admin-helper">Owner role is fixed here</span>
+                      <span className="ilm-admin-helper">Owner</span>
                     )}
                   </div>
                 </li>

--- a/packages/ui/src/admin/api.ts
+++ b/packages/ui/src/admin/api.ts
@@ -62,15 +62,6 @@ export const listLabMembers = async (labId: string): Promise<LabMemberRecord[]> 
   return (data as LabMemberRecord[]) ?? [];
 };
 
-export const updateLabMemberRole = async (labId: string, userId: string, role: "admin" | "member") => {
-  const { error } = await client().rpc("update_lab_member_role", {
-    p_lab_id: labId,
-    p_user_id: userId,
-    p_role: role,
-  });
-  if (error) throw error;
-};
-
 export const removeLabMember = async (labId: string, userId: string) => {
   const { error } = await client().rpc("remove_lab_member", {
     p_lab_id: labId,

--- a/packages/ui/src/admin/index.ts
+++ b/packages/ui/src/admin/index.ts
@@ -20,7 +20,6 @@ export {
   removeLabMember,
   requestLabJoin,
   revokeProjectLead,
-  updateLabMemberRole,
 } from "./api";
 export type {
   LabInvitationRecord,

--- a/supabase/migrations/20260427010000_drop_update_lab_member_role.sql
+++ b/supabase/migrations/20260427010000_drop_update_lab_member_role.sql
@@ -1,0 +1,9 @@
+-- Drop update_lab_member_role in favor of the owner-only promote/demote RPCs.
+--
+-- The older `update_lab_member_role` allowed any admin to change another
+-- member's admin/member role, which contradicts the invariant that only the
+-- sole lab owner may promote members to admin or demote admins back to
+-- member (see promote_member_to_admin / demote_admin_to_member in the
+-- 20260425000000 hardening migration).
+
+drop function if exists public.update_lab_member_role(uuid, uuid, text);


### PR DESCRIPTION
## Summary
While testing add/remove across roles the user hit three tied bugs in the membership/login flow:

- **LabMembersPanel** showed Promote/Demote buttons wired to `update_lab_member_role`, which the SQL allowed for any admin — bypassing the owner-only rule enforced elsewhere. Buttons removed; role changes stay in the owner-only Lab Settings card.
- **`update_lab_member_role` RPC dropped.** `promote_member_to_admin` / `demote_admin_to_member` (owner-only, from Stage 4 hardening) are the only supported path.
- **/ILM/account/join/<uuid> 404.** GitHub Pages serves `/<site>/404.html`, not per-folder 404s, so the prior `account/404.html` fallback was dead. Moved it to `.pages-dist/404.html`.

Migration `20260427010000_drop_update_lab_member_role.sql` already applied live via MCP.

## Test plan
- [ ] As an admin (non-owner), confirm there is no Promote/Demote UI on the Members panel.
- [ ] As owner, Promote/Demote still work from the Lab Settings card.
- [ ] Invited-but-not-yet-signed-up user opens `/ILM/account/join/<uuid>` → sees the auth/join screen instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)