### PR TITLE
Redesign Account app with flat two-panel layout

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -1,62 +1,677 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   AppSwitcher,
   AuthScreen,
-  LabJoinRequestsPanel,
-  LabMembersPanel,
   LabPicker,
-  LabSettingsPanel,
-  LabShareLinkPanel,
+  approveLabJoin,
+  buildLabShareUrl,
   cancelLabJoin,
+  demoteAdminToMember,
+  inviteMemberToLab,
+  listLabInvitations,
+  listLabJoinRequests,
+  listLabMembers,
   lookupLabById,
+  promoteMemberToAdmin,
+  rejectLabJoin,
+  removeLabMember,
   requestLabJoin,
   useAuth,
+  type LabInvitationRecord,
+  type LabJoinRequestRecord,
   type LabLookupResult,
+  type LabMemberRecord,
 } from "@ilm/ui";
+import { getSupabaseClient } from "@ilm/utils";
 
 const APP_BASE_URL = import.meta.env.BASE_URL || "/";
 
 const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
 
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(new Date(value));
+
 const parseJoinLabId = (pathname: string, base: string): string | null => {
   const normalizedBase = base.endsWith("/") ? base : `${base}/`;
   const pathBase = pathname.startsWith(normalizedBase) ? pathname.slice(normalizedBase.length) : pathname;
   const segments = pathBase.split("/").filter(Boolean);
-  if (segments[0] === "join" && segments[1]) {
-    return segments[1];
-  }
+  if (segments[0] === "join" && segments[1]) return segments[1];
   return null;
 };
 
 const isUuid = (value: string): boolean =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 
-const AccountDashboard = () => {
-  const { profile, user, signOut } = useAuth();
-  const signedInLabel = profile?.display_name ?? user?.email ?? "Signed in";
+// ---------------------------------------------------------------------------
+// Left panel
+// ---------------------------------------------------------------------------
+
+type ProjectCounts = { total: number; drafts: number; pendingReview: number };
+
+const useProjectCounts = (labId: string | null): ProjectCounts | null => {
+  const [counts, setCounts] = useState<ProjectCounts | null>(null);
+  useEffect(() => {
+    if (!labId) {
+      setCounts(null);
+      return;
+    }
+    let cancelled = false;
+    const supabase = getSupabaseClient();
+    supabase
+      .from("projects")
+      .select("id, state, review_requested_at")
+      .eq("lab_id", labId)
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error || !data) {
+          setCounts({ total: 0, drafts: 0, pendingReview: 0 });
+          return;
+        }
+        type Row = { state: string; review_requested_at: string | null };
+        const rows = data as Row[];
+        setCounts({
+          total: rows.filter((r) => r.state === "published").length,
+          drafts: rows.filter((r) => r.state === "draft").length,
+          pendingReview: rows.filter((r) => r.state === "draft" && r.review_requested_at !== null).length,
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [labId]);
+  return counts;
+};
+
+const SidePanel = () => {
+  const { profile, user, activeLab, labs, selectLab, signOut } = useAuth();
+  const counts = useProjectCounts(activeLab?.id ?? null);
+  const displayName = profile?.display_name ?? user?.email ?? "Signed in";
+  const email = profile?.email ?? user?.email ?? "";
+  const role = activeLab?.role ?? "member";
+
   return (
-    <div className="acct-shell">
-      <header className="acct-topbar">
-        <div>
-          <p style={{ margin: 0, color: "#60606b", fontSize: "0.85rem" }}>{signedInLabel}</p>
-          <h1>Account & Lab Settings</h1>
+    <aside className="acct-side" aria-label="Account summary">
+      <div className="acct-side-header">
+        <strong>Account</strong>
+        <small>Integrated Lab Manager</small>
+      </div>
+
+      <section className="acct-side-section acct-side-profile">
+        <h2>Profile</h2>
+        <strong>{displayName}</strong>
+        <span>{email}</span>
+      </section>
+
+      <section className="acct-side-section acct-lab-switcher">
+        <h2>Active Lab</h2>
+        {activeLab ? (
+          <>
+            <h3>{activeLab.name}</h3>
+            <span className={`acct-lab-role ${role}`}>{role}</span>
+          </>
+        ) : (
+          <h3>No lab selected</h3>
+        )}
+        {labs.length > 1 ? (
+          <label className="acct-field" style={{ marginTop: "0.2rem" }}>
+            <span>Switch lab</span>
+            <select
+              value={activeLab?.id ?? ""}
+              onChange={(event) => {
+                const nextId = event.target.value;
+                if (nextId) selectLab(nextId);
+              }}
+            >
+              {labs.map((lab) => (
+                <option key={lab.id} value={lab.id}>
+                  {lab.name} ({lab.role})
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+      </section>
+
+      <section className="acct-side-section">
+        <h2>Projects in this lab</h2>
+        <div className="acct-stat-row">
+          <div className="acct-stat">
+            <span className="acct-stat-value">{counts?.total ?? "–"}</span>
+            <span className="acct-stat-label">Published</span>
+          </div>
+          <div className="acct-stat">
+            <span className="acct-stat-value">{counts?.pendingReview ?? "–"}</span>
+            <span className="acct-stat-label">In review</span>
+          </div>
+          <div className="acct-stat">
+            <span className="acct-stat-value">{counts?.drafts ?? "–"}</span>
+            <span className="acct-stat-label">Drafts</span>
+          </div>
         </div>
-        <div className="acct-topbar-actions">
-          <AppSwitcher currentApp="home" baseUrl={APP_BASE_URL} />
-          <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
-            Sign out
+      </section>
+
+      <section className="acct-side-section">
+        <h2>Working status</h2>
+        <span style={{ fontSize: "0.85rem", color: "var(--acct-muted)" }}>
+          {activeLab
+            ? `Signed in as ${role} of ${activeLab.name}. Use the top-right switcher to open another app.`
+            : "Pick a lab to get started."}
+        </span>
+      </section>
+
+      <div className="acct-side-footer">
+        <button type="button" className="acct-text-button" onClick={() => void signOut()}>
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Members tab
+// ---------------------------------------------------------------------------
+
+const MembersTab = () => {
+  const { activeLab, user } = useAuth();
+  const labId = activeLab?.id ?? null;
+  const role = activeLab?.role ?? "member";
+  const isOwner = role === "owner";
+  const isAdmin = role === "admin" || role === "owner";
+  const [members, setMembers] = useState<LabMemberRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!labId) {
+      setMembers([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setMembers(await listLabMembers(labId));
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const doPromote = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await promoteMemberToAdmin(labId, member.user_id);
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const doDemote = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await demoteAdminToMember(labId, member.user_id);
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const doRemove = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    const label = member.display_name || member.email || "this member";
+    if (!window.confirm(`Remove ${label} from ${activeLab?.name ?? "the lab"}?`)) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await removeLabMember(labId, member.user_id);
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  if (!activeLab) {
+    return <p className="acct-empty">Pick a lab from the left panel to see its members.</p>;
+  }
+
+  return (
+    <section className="acct-card">
+      <div className="acct-card-header">
+        <div>
+          <h2>Lab members</h2>
+          <p>
+            {isAdmin
+              ? "Admins and the owner can promote members to admin and remove members. Only the owner can demote or remove an admin."
+              : "Only admins and the owner can edit membership."}
+          </p>
+        </div>
+        <span className="acct-card-pill">{members.length} total</span>
+      </div>
+
+      {error ? <p className="acct-error">{error}</p> : null}
+      {loading ? <p className="acct-empty">Loading roster…</p> : null}
+
+      {!loading && members.length > 0 ? (
+        <ul className="acct-member-list">
+          {members.map((member) => {
+            const label = member.display_name || member.email || member.user_id;
+            const isSelf = member.user_id === user?.id;
+            const busy = busyUserId === member.user_id;
+            const canPromote = isAdmin && member.role === "member" && !isSelf;
+            const canDemote = isOwner && member.role === "admin";
+            const canRemove = member.role !== "owner" && !isSelf && (isOwner || (isAdmin && member.role === "member"));
+
+            return (
+              <li className="acct-member" key={member.user_id}>
+                <div className="acct-member-copy">
+                  <strong>
+                    {label}
+                    {isSelf ? " (you)" : ""}
+                  </strong>
+                  <span>{member.email || "No email available"}</span>
+                  <small>Joined {formatDate(member.joined_at)}</small>
+                </div>
+                <div className="acct-member-actions">
+                  <span className={`acct-badge ${member.role}`}>{member.role}</span>
+                  {canPromote ? (
+                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doPromote(member)}>
+                      Promote to admin
+                    </button>
+                  ) : null}
+                  {canDemote ? (
+                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doDemote(member)}>
+                      Demote to member
+                    </button>
+                  ) : null}
+                  {canRemove ? (
+                    <button type="button" className="acct-danger-button" disabled={busy} onClick={() => void doRemove(member)}>
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {!loading && members.length === 0 ? <p className="acct-empty">No members yet.</p> : null}
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Invitations tab
+// ---------------------------------------------------------------------------
+
+const InvitationsTab = () => {
+  const { activeLab } = useAuth();
+  const labId = activeLab?.id ?? null;
+  const isAdmin = activeLab?.role === "owner" || activeLab?.role === "admin";
+
+  const [invitations, setInvitations] = useState<LabInvitationRecord[]>([]);
+  const [requests, setRequests] = useState<LabJoinRequestRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
+  const [submittingInvite, setSubmittingInvite] = useState(false);
+
+  const [busyRequestId, setBusyRequestId] = useState<string | null>(null);
+  const [rejectOpen, setRejectOpen] = useState<string | null>(null);
+  const [rejectComment, setRejectComment] = useState("");
+
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!labId || !isAdmin) {
+      setInvitations([]);
+      setRequests([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextInvitations, nextRequests] = await Promise.all([
+        listLabInvitations(labId),
+        listLabJoinRequests(labId, "pending"),
+      ]);
+      setInvitations(nextInvitations);
+      setRequests(nextRequests);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId, isAdmin]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pendingInvitations = useMemo(
+    () => invitations.filter((invitation) => invitation.status === "pending"),
+    [invitations]
+  );
+
+  const shareUrl = useMemo(() => (activeLab ? buildLabShareUrl(activeLab.id, APP_BASE_URL) : ""), [activeLab]);
+
+  const handleInvite = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!labId || !inviteEmail.trim()) return;
+    setSubmittingInvite(true);
+    setError(null);
+    try {
+      await inviteMemberToLab(labId, inviteEmail.trim(), inviteRole);
+      setInviteEmail("");
+      setInviteRole("member");
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmittingInvite(false);
+    }
+  };
+
+  const handleApprove = async (request: LabJoinRequestRecord) => {
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await approveLabJoin(request.id);
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  const handleReject = async (request: LabJoinRequestRecord) => {
+    const comment = rejectComment.trim();
+    if (!comment) {
+      setError("A comment is required to reject a request.");
+      return;
+    }
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await rejectLabJoin(request.id, comment);
+      setRejectOpen(null);
+      setRejectComment("");
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl || typeof navigator === "undefined" || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  if (!activeLab) {
+    return <p className="acct-empty">Pick a lab from the left panel first.</p>;
+  }
+  if (!isAdmin) {
+    return <p className="acct-empty">Only admins and the owner can send invitations or review join requests.</p>;
+  }
+
+  return (
+    <>
+      {error ? <p className="acct-error">{error}</p> : null}
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Invite by email</h2>
+            <p>Invited users are added automatically when they sign in with this email.</p>
+          </div>
+        </div>
+        <form className="acct-form" onSubmit={handleInvite}>
+          <div className="acct-field-row">
+            <label className="acct-field">
+              <span>Email</span>
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => setInviteEmail(event.target.value)}
+                placeholder="scientist@lab.org"
+                required
+              />
+            </label>
+            <label className="acct-field">
+              <span>Role</span>
+              <select value={inviteRole} onChange={(event) => setInviteRole(event.target.value as "admin" | "member")}>
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+          </div>
+          <div>
+            <button type="submit" className="acct-primary-button" disabled={submittingInvite}>
+              {submittingInvite ? "Saving…" : "Save invitation"}
+            </button>
+          </div>
+        </form>
+
+        {pendingInvitations.length > 0 ? (
+          <div className="acct-invitations">
+            <div style={{ fontSize: "0.72rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--acct-muted)" }}>
+              {pendingInvitations.length} pending
+            </div>
+            {pendingInvitations.map((invitation) => (
+              <div className="acct-invitation" key={invitation.id}>
+                <div>
+                  <strong>{invitation.email}</strong>
+                  <div><small>Saved {formatDate(invitation.created_at)}</small></div>
+                </div>
+                <span className="acct-badge">{invitation.role}</span>
+                <span className="acct-badge">{invitation.status}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Share link</h2>
+            <p>Anyone who opens this link can sign in and request to join {activeLab.name}.</p>
+          </div>
+        </div>
+        <div className="acct-share-row">
+          <input type="text" readOnly value={shareUrl} onFocus={(event) => event.currentTarget.select()} />
+          <button type="button" className="acct-text-button" onClick={() => void handleCopy()}>
+            {copied ? "Copied!" : "Copy link"}
           </button>
         </div>
-      </header>
-      <div className="acct-sections">
-        <LabSettingsPanel />
-        <LabMembersPanel />
-        <LabJoinRequestsPanel />
-        <LabShareLinkPanel baseUrl={APP_BASE_URL} />
-      </div>
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Join requests</h2>
+            <p>Approve or reject people who asked to join via the share link.</p>
+          </div>
+          <span className="acct-card-pill">{requests.length} pending</span>
+        </div>
+        {loading ? <p className="acct-empty">Loading…</p> : null}
+        {!loading && requests.length === 0 ? <p className="acct-empty">No pending join requests.</p> : null}
+        {requests.length > 0 ? (
+          <div>
+            {requests.map((request) => {
+              const busy = busyRequestId === request.id;
+              const label = request.display_name || request.email || request.user_id;
+              const rejecting = rejectOpen === request.id;
+              return (
+                <div className="acct-request-item" key={request.id}>
+                  <div>
+                    <strong>{label}</strong>
+                    <div><small>{request.email || "No email available"} · requested {formatDate(request.created_at)}</small></div>
+                    {request.message ? <p className="acct-request-message">"{request.message}"</p> : null}
+                  </div>
+                  {rejecting ? (
+                    <div className="acct-reject-form">
+                      <textarea
+                        value={rejectComment}
+                        onChange={(event) => setRejectComment(event.target.value)}
+                        placeholder="Reason (required)"
+                        rows={2}
+                      />
+                      <div className="acct-row-actions">
+                        <button
+                          type="button"
+                          className="acct-danger-button"
+                          disabled={busy}
+                          onClick={() => void handleReject(request)}
+                        >
+                          Confirm reject
+                        </button>
+                        <button
+                          type="button"
+                          className="acct-text-button"
+                          disabled={busy}
+                          onClick={() => {
+                            setRejectOpen(null);
+                            setRejectComment("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="acct-row-actions">
+                      <button
+                        type="button"
+                        className="acct-primary-button"
+                        disabled={busy}
+                        onClick={() => void handleApprove(request)}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        className="acct-text-button"
+                        disabled={busy}
+                        onClick={() => {
+                          setRejectOpen(request.id);
+                          setRejectComment("");
+                        }}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </section>
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Dashboard + join routes + root
+// ---------------------------------------------------------------------------
+
+type ManagementTab = "members" | "invitations";
+
+const AccountDashboard = () => {
+  const { activeLab } = useAuth();
+  const [tab, setTab] = useState<ManagementTab>("members");
+  const [pendingCount, setPendingCount] = useState<number>(0);
+  const labId = activeLab?.id ?? null;
+  const isAdmin = activeLab?.role === "owner" || activeLab?.role === "admin";
+
+  useEffect(() => {
+    if (!labId || !isAdmin) {
+      setPendingCount(0);
+      return;
+    }
+    let cancelled = false;
+    listLabJoinRequests(labId, "pending")
+      .then((rows) => {
+        if (!cancelled) setPendingCount(rows.length);
+      })
+      .catch(() => {
+        if (!cancelled) setPendingCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [labId, isAdmin, tab]);
+
+  return (
+    <div className="acct-shell">
+      <SidePanel />
+      <main className="acct-main">
+        <header className="acct-topbar">
+          <div className="acct-topbar-copy">
+            <p className="acct-kicker">Account</p>
+            <h1>Lab Management</h1>
+          </div>
+          <div className="acct-topbar-actions">
+            <AppSwitcher currentApp="home" baseUrl={APP_BASE_URL} />
+          </div>
+        </header>
+        <nav className="acct-tabs" aria-label="Lab management tabs">
+          <button
+            type="button"
+            className={`acct-tab${tab === "members" ? " active" : ""}`}
+            onClick={() => setTab("members")}
+          >
+            Members
+          </button>
+          <button
+            type="button"
+            className={`acct-tab${tab === "invitations" ? " active" : ""}`}
+            onClick={() => setTab("invitations")}
+          >
+            Invitations & Requests
+            {pendingCount > 0 ? <span className="acct-tab-badge">{pendingCount}</span> : null}
+          </button>
+        </nav>
+        <div className="acct-main-body">
+          {tab === "members" ? <MembersTab /> : <InvitationsTab />}
+        </div>
+      </main>
     </div>
   );
 };
+
+// ---------------------------------------------------------------------------
+// Join-by-link route
+// ---------------------------------------------------------------------------
 
 const JoinScreen = ({ labId }: { labId: string }) => {
   const { status, labs, selectLab, signOut, profile, user } = useAuth();
@@ -104,10 +719,7 @@ const JoinScreen = ({ labId }: { labId: string }) => {
       </div>
     );
   }
-
-  if (status === "signed-out") {
-    return <AuthScreen />;
-  }
+  if (status === "signed-out") return <AuthScreen />;
 
   const alreadyMember = lookup?.already_member ?? labs.some((l) => l.id === labId);
   const hasPending = (lookup?.has_pending_request ?? false) || pendingRequestId !== null;
@@ -171,9 +783,7 @@ const JoinScreen = ({ labId }: { labId: string }) => {
           <p className="ilm-auth-error" role="alert">{error}</p>
         ) : alreadyMember ? (
           <>
-            <p className="ilm-auth-note">
-              You're already a member of <strong>{labName}</strong>.
-            </p>
+            <p className="ilm-auth-note">You're already a member of <strong>{labName}</strong>.</p>
             <button type="button" className="ilm-auth-submit" onClick={handleOpenLab}>
               Open {labName}
             </button>
@@ -223,11 +833,13 @@ const JoinScreen = ({ labId }: { labId: string }) => {
   );
 };
 
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
 const SignedInShell = () => {
   const { activeLab } = useAuth();
-  if (!activeLab) {
-    return <LabPicker />;
-  }
+  if (!activeLab) return <LabPicker />;
   return <AccountDashboard />;
 };
 
@@ -238,10 +850,7 @@ export const App = () => {
     return parseJoinLabId(window.location.pathname, APP_BASE_URL);
   }, []);
 
-  if (joinLabId) {
-    return <JoinScreen labId={joinLabId} />;
-  }
-
+  if (joinLabId) return <JoinScreen labId={joinLabId} />;
   if (status === "loading") {
     return (
       <div className="ilm-auth-screen">
@@ -251,10 +860,6 @@ export const App = () => {
       </div>
     );
   }
-
-  if (status === "signed-out") {
-    return <AuthScreen />;
-  }
-
+  if (status === "signed-out") return <AuthScreen />;
   return <SignedInShell />;
 };

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -1,59 +1,454 @@
+@import "../../../packages/ui/src/tokens.css";
+
 :root {
-  color-scheme: light;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--rl-ink-2);
+  background: var(--rl-paper);
+  font-family: "Space Grotesk", Arial, sans-serif;
+  line-height: 1.55;
+
+  --acct-ink: var(--rl-ink);
+  --acct-muted: var(--rl-muted);
+  --acct-line: var(--rl-line);
+  --acct-hairline: var(--rl-hairline);
+  --acct-panel: var(--rl-surface);
+  --acct-soft: var(--rl-soft);
+  --acct-green: var(--rl-green);
+  --acct-green-2: var(--rl-green-2);
+  --acct-green-soft: var(--rl-green-soft);
 }
+
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
-  background: #f5f6f8;
-  color: #1a1a1f;
+  background: #f9f8f4;
+  color: var(--acct-ink);
+  font-family: "Space Grotesk", Arial, sans-serif;
 }
 
+button, input, textarea, select { font: inherit; }
+button { cursor: pointer; }
+a { color: inherit; }
+
+/* Shell */
 .acct-shell {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+}
+
+/* Left panel */
+.acct-side {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  overflow-y: auto;
+  background: var(--acct-soft);
+  border-right: 1px solid var(--acct-line);
+  padding: 1.1rem 1rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
+}
+
+.acct-side-header {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.1rem 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--acct-hairline);
+}
+.acct-side-header strong {
+  font-family: "Noto Serif", Georgia, serif;
+  font-size: 1.05rem;
+  color: var(--acct-ink);
+}
+.acct-side-header small {
+  color: var(--acct-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.acct-side-section {
+  background: var(--acct-panel);
+  border: 1px solid var(--acct-line);
+  border-radius: 12px;
+  padding: 0.8rem 0.9rem;
+  display: grid;
+  gap: 0.5rem;
+}
+.acct-side-section h2 {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--acct-muted);
+}
+.acct-side-section h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--acct-ink);
+}
+
+.acct-side-profile strong {
+  font-size: 0.95rem;
+  color: var(--acct-ink);
+}
+.acct-side-profile span {
+  font-size: 0.8rem;
+  color: var(--acct-muted);
+}
+
+.acct-lab-switcher {
+  display: grid;
+  gap: 0.4rem;
+}
+.acct-lab-switcher select {
+  padding: 0.45rem 0.55rem;
+  border: 1px solid var(--acct-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--acct-ink);
+}
+.acct-lab-role {
+  display: inline-block;
+  align-self: start;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: var(--acct-green-soft);
+  color: var(--acct-green);
+}
+.acct-lab-role.admin { background: #e8eddc; color: #4a5a33; }
+.acct-lab-role.member { background: var(--rl-surface-2); color: var(--acct-muted); }
+
+.acct-stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+.acct-stat {
+  background: var(--acct-soft);
+  border: 1px solid var(--acct-hairline);
+  border-radius: 10px;
+  padding: 0.55rem 0.6rem;
+  display: grid;
+  gap: 0.1rem;
+  text-align: center;
+}
+.acct-stat-value {
+  font-family: "Noto Serif", Georgia, serif;
+  font-size: 1.25rem;
+  color: var(--acct-ink);
+  line-height: 1;
+}
+.acct-stat-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--acct-muted);
+}
+
+.acct-side-footer {
+  margin-top: auto;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.acct-text-button {
+  appearance: none;
+  border: 1px solid var(--acct-line);
+  background: #fff;
+  color: var(--acct-ink);
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+}
+.acct-text-button:hover:not(:disabled) { background: var(--acct-soft); }
+.acct-text-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.acct-primary-button {
+  appearance: none;
+  border: 1px solid var(--acct-green);
+  background: var(--acct-green);
+  color: #fff;
+  padding: 0.55rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+.acct-primary-button:hover:not(:disabled) { background: var(--acct-green-2); border-color: var(--acct-green-2); }
+.acct-primary-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.acct-danger-button {
+  appearance: none;
+  border: 1px solid #d89593;
+  background: #fff;
+  color: var(--rl-danger-text);
+  padding: 0.4rem 0.65rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+}
+.acct-danger-button:hover:not(:disabled) { background: var(--rl-error-c); }
+.acct-danger-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Main */
+.acct-main {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .acct-topbar {
   display: flex;
+  align-items: flex-end;
   justify-content: space-between;
+  gap: 1.25rem;
+  padding: 1.1rem 1.8rem 0.9rem;
+  border-bottom: 1px solid var(--acct-hairline);
+  background: rgba(249, 248, 244, 0.92);
+  backdrop-filter: blur(6px);
+}
+.acct-topbar-copy .acct-kicker {
+  margin: 0 0 0.3rem;
+  color: var(--acct-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.acct-topbar-copy h1 {
+  margin: 0;
+  font-family: "Noto Serif", Georgia, serif;
+  font-size: 1.6rem;
+  color: var(--acct-ink);
+}
+.acct-topbar-actions { display: flex; gap: 0.6rem; align-items: center; }
+
+.acct-tabs {
+  display: flex;
+  gap: 0.3rem;
+  border-bottom: 1px solid var(--acct-hairline);
+  padding: 0 1.8rem;
+  background: rgba(249, 248, 244, 0.92);
+}
+.acct-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--acct-muted);
+  padding: 0.75rem 1rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  position: relative;
+}
+.acct-tab:hover { color: var(--acct-ink); }
+.acct-tab.active {
+  color: var(--acct-green);
+  border-bottom-color: var(--acct-green);
+  font-weight: 600;
+}
+.acct-tab-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  background: var(--acct-green);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+}
+
+.acct-main-body {
+  padding: 1.4rem 1.8rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.acct-error {
+  background: var(--rl-error-c);
+  border: 1px solid #f2b3af;
+  color: var(--rl-danger-text);
+  padding: 0.55rem 0.8rem;
+  border-radius: 8px;
+  margin: 0;
+  font-size: 0.88rem;
+}
+.acct-empty {
+  color: var(--acct-muted);
+  font-size: 0.92rem;
+  margin: 0.4rem 0;
+}
+
+/* Cards/Tables */
+.acct-card {
+  background: var(--acct-panel);
+  border: 1px solid var(--acct-line);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+.acct-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+.acct-card-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--acct-ink);
+}
+.acct-card-header p {
+  margin: 0.15rem 0 0;
+  color: var(--acct-muted);
+  font-size: 0.85rem;
+}
+.acct-card-pill {
+  background: var(--acct-soft);
+  border: 1px solid var(--acct-hairline);
+  color: var(--acct-muted);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+.acct-member-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.acct-member {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--acct-hairline);
+  align-items: center;
+}
+.acct-member:first-child { border-top: none; }
+.acct-member-copy { display: grid; gap: 0.15rem; min-width: 0; }
+.acct-member-copy strong { font-size: 0.95rem; color: var(--acct-ink); }
+.acct-member-copy span { font-size: 0.82rem; color: var(--acct-muted); }
+.acct-member-copy small { font-size: 0.72rem; color: var(--acct-muted); }
+.acct-member-actions {
+  display: flex;
+  gap: 0.4rem;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  justify-content: flex-end;
 }
 
-.acct-topbar h1 {
-  margin: 0;
-  font-size: 1.5rem;
+.acct-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: var(--rl-surface-2);
+  color: var(--acct-muted);
+}
+.acct-badge.owner { background: var(--acct-green-soft); color: var(--acct-green); }
+.acct-badge.admin { background: #e8eddc; color: #4a5a33; }
+
+.acct-form {
+  display: grid;
+  gap: 0.6rem;
+}
+.acct-field {
+  display: grid;
+  gap: 0.25rem;
+}
+.acct-field span {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--acct-muted);
+}
+.acct-field input,
+.acct-field select,
+.acct-field textarea {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--acct-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--acct-ink);
+}
+.acct-field-row {
+  display: grid;
+  grid-template-columns: 1fr 10rem;
+  gap: 0.6rem;
+}
+@media (max-width: 680px) {
+  .acct-field-row { grid-template-columns: 1fr; }
 }
 
-.acct-topbar p {
-  margin: 0;
-  color: #60606b;
-}
-
-.acct-topbar-actions {
-  display: flex;
+.acct-share-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.5rem;
   align-items: center;
 }
-
-.acct-sections {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+.acct-share-row input {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--acct-line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--acct-ink);
 }
 
-.acct-back-link {
-  font-size: 0.9rem;
-  color: #3b3be0;
-  text-decoration: none;
+.acct-request-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--acct-hairline);
+  align-items: flex-start;
 }
+.acct-request-item:first-child { border-top: none; }
+.acct-request-message {
+  margin-top: 0.35rem;
+  color: var(--acct-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+.acct-reject-form {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 16rem;
+}
+.acct-reject-form textarea { min-height: 3rem; }
 
-.acct-back-link:hover {
-  text-decoration: underline;
+.acct-invitations {
+  display: grid;
+  gap: 0.4rem;
 }
+.acct-invitation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.75rem;
+  padding: 0.55rem 0;
+  border-top: 1px solid var(--acct-hairline);
+  align-items: center;
+}
+.acct-invitation:first-child { border-top: none; }
+.acct-invitation strong { font-size: 0.9rem; color: var(--acct-ink); }
+.acct-invitation small { font-size: 0.72rem; color: var(--acct-muted); }
+
+.acct-row-actions { display: flex; gap: 0.35rem; }

--- a/supabase/migrations/20260428000000_role_management_hierarchy.sql
+++ b/supabase/migrations/20260428000000_role_management_hierarchy.sql
@@ -1,0 +1,89 @@
+-- Role management hierarchy:
+--   * One owner per lab (immutable via these RPCs).
+--   * Admins and the owner can promote members -> admins and remove *members*.
+--   * Only the owner can demote admin -> member or remove an admin.
+--
+-- Loosens `promote_member_to_admin` to admin-or-owner. Tightens
+-- `remove_lab_member` to reject admin removals unless the caller is the
+-- owner. `demote_admin_to_member` stays owner-only (Stage 4 hardening).
+
+create or replace function public.promote_member_to_admin(
+  p_lab_id  uuid,
+  p_user_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_current text;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if not public.is_lab_admin(p_lab_id) then
+    raise exception 'only lab admins or the owner may promote members' using errcode = '42501';
+  end if;
+  select role into v_current from public.lab_memberships
+    where lab_id = p_lab_id and user_id = p_user_id;
+  if v_current is null then
+    raise exception 'user is not a member of this lab' using errcode = '22023';
+  end if;
+  if v_current = 'owner' then
+    raise exception 'cannot change the owner role via this RPC' using errcode = '22023';
+  end if;
+  if v_current = 'admin' then
+    return;
+  end if;
+  update public.lab_memberships
+     set role = 'admin'
+   where lab_id = p_lab_id and user_id = p_user_id;
+  perform public._log_audit(p_lab_id, 'membership', p_user_id, 'promote_admin', '{}'::jsonb);
+end;
+$$;
+
+create or replace function public.remove_lab_member(
+  p_lab_id uuid,
+  p_user_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_caller_role text;
+  v_target_role text;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  v_caller_role := public.lab_role(p_lab_id);
+  if v_caller_role not in ('owner', 'admin') then
+    raise exception 'only lab admins or the owner can remove members' using errcode = '42501';
+  end if;
+
+  select role into v_target_role
+  from public.lab_memberships
+  where lab_id = p_lab_id and user_id = p_user_id;
+
+  if v_target_role is null then
+    raise exception 'member not found' using errcode = '42501';
+  end if;
+  if v_target_role = 'owner' then
+    raise exception 'the owner cannot be removed' using errcode = '22023';
+  end if;
+  if v_target_role = 'admin' and v_caller_role <> 'owner' then
+    raise exception 'only the owner can remove an admin' using errcode = '42501';
+  end if;
+
+  delete from public.lab_memberships
+  where lab_id = p_lab_id and user_id = p_user_id;
+
+  perform public._log_audit(p_lab_id, 'membership', p_user_id, 'remove', '{}'::jsonb);
+end;
+$$;


### PR DESCRIPTION
Replaces the card-stack with a left profile/lab sidebar and a right Lab Management panel (Members / Invitations tabs). Admins and the owner can promote members and remove members; only the owner can demote or remove admins (enforced in new role-hierarchy migration).