### PR TITLE
Fix lab_memberships query returning every co-member's role

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -97,7 +97,7 @@ const TIER_DESCRIPTION: Record<MembershipTier, string> = {
 };
 
 const SidePanel = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
-  const { profile, user, activeLab, labs, selectLab, signOut } = useAuth();
+  const { profile, user, activeLab, signOut } = useAuth();
   const counts = useProjectCounts(activeLab?.id ?? null);
   const displayName = profile?.display_name ?? user?.email ?? "Signed in";
   const email = profile?.email ?? user?.email ?? "";
@@ -127,24 +127,6 @@ const SidePanel = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
         ) : (
           <h3>No lab selected</h3>
         )}
-        {labs.length > 1 ? (
-          <label className="acct-field" style={{ marginTop: "0.2rem" }}>
-            <span>Switch lab</span>
-            <select
-              value={activeLab?.id ?? ""}
-              onChange={(event) => {
-                const nextId = event.target.value;
-                if (nextId) selectLab(nextId);
-              }}
-            >
-              {labs.map((lab) => (
-                <option key={lab.id} value={lab.id}>
-                  {lab.name} ({TIER_LABEL[lab.role as MembershipTier]})
-                </option>
-              ))}
-            </select>
-          </label>
-        ) : null}
         <button
           type="button"
           className="acct-text-button"

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -88,23 +88,29 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     [supabase]
   );
 
-  const loadLabs = useCallback(async (): Promise<LabWithRole[]> => {
-    // lab_memberships RLS: only rows for labs the user belongs to
-    const { data, error: err } = await supabase
-      .from("lab_memberships")
-      .select("role, labs:lab_id(id, name, slug, created_by)")
-      .order("created_at", { ascending: true });
-    if (err) throw err;
+  const loadLabs = useCallback(
+    async (userId: string): Promise<LabWithRole[]> => {
+      // RLS lets any member read every membership row in labs they belong to,
+      // so we MUST filter by user_id here — otherwise the current user would
+      // see co-members' rows as if they were their own, conflating roles.
+      const { data, error: err } = await supabase
+        .from("lab_memberships")
+        .select("role, labs:lab_id(id, name, slug, created_by)")
+        .eq("user_id", userId)
+        .order("created_at", { ascending: true });
+      if (err) throw err;
 
-    type LabRow = Omit<LabWithRole, "role">;
-    type Row = { role: LabWithRole["role"]; labs: LabRow | LabRow[] | null };
-    return ((data as unknown as Row[]) ?? [])
-      .map((row) => {
-        const lab = Array.isArray(row.labs) ? row.labs[0] : row.labs;
-        return lab ? { ...lab, role: row.role } : null;
-      })
-      .filter((row): row is LabWithRole => row !== null);
-  }, [supabase]);
+      type LabRow = Omit<LabWithRole, "role">;
+      type Row = { role: LabWithRole["role"]; labs: LabRow | LabRow[] | null };
+      return ((data as unknown as Row[]) ?? [])
+        .map((row) => {
+          const lab = Array.isArray(row.labs) ? row.labs[0] : row.labs;
+          return lab ? { ...lab, role: row.role } : null;
+        })
+        .filter((row): row is LabWithRole => row !== null);
+    },
+    [supabase]
+  );
 
   const refreshAll = useCallback(
     async (nextSession: Session | null) => {
@@ -122,7 +128,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         } catch (claimErr) {
           console.warn("[ilm] claim_pending_invitations failed", claimErr);
         }
-        const nextLabs = await loadLabs();
+        const nextLabs = await loadLabs(nextSession.user.id);
         setProfile(nextProfile);
         setLabs(nextLabs);
         setStatus("signed-in");
@@ -234,9 +240,10 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
   );
 
   const refreshLabs = useCallback(async () => {
-    const next = await loadLabs();
+    if (!user) return;
+    const next = await loadLabs(user.id);
     setLabs(next);
-  }, [loadLabs]);
+  }, [loadLabs, user]);
 
   const createLab = useCallback(
     async (name: string, slug?: string): Promise<LabWithRole> => {


### PR DESCRIPTION
## Summary
- `loadLabs` in AuthProvider was selecting from `lab_memberships` with no user_id filter. RLS lets any member read every membership row in their lab, so a user in a lab with co-members got back multiple rows — LabPicker showed the same lab twice (one per role), and the dashboard collapsed onto whichever row came first (usually owner because it sorts earliest by created_at).
- Filter `.eq("user_id", userId)` so each lab appears once with the caller's actual tier.
- Drop the switch-lab dropdown from the account side panel per request; the existing "Join or create another lab…" button still reopens LabPicker.

## Test plan
- [ ] Sign in as a non-owner member of a lab that has an owner → LabPicker shows the lab once, dashboard badge reads "Member".
- [ ] Sign in as the owner of the same lab → dashboard badge reads "Owner".
- [ ] Multi-lab user still sees each lab exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)