### PR TITLE
Live-refresh tier badge + mark Account app complete

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -178,7 +178,7 @@ const SidePanel = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
 // ---------------------------------------------------------------------------
 
 const MembersTab = () => {
-  const { activeLab, user } = useAuth();
+  const { activeLab, user, refreshLabs } = useAuth();
   const labId = activeLab?.id ?? null;
   const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
   // Strict stratification: owner > admin > member. Each user has exactly one
@@ -212,13 +212,20 @@ const MembersTab = () => {
     void load();
   }, [load]);
 
+  // After any role change, refresh both the member list (affects other rows'
+  // badges) and the AuthProvider labs array (affects the sidebar badge when
+  // the caller changed their own role).
+  const refreshAfterAction = useCallback(async () => {
+    await Promise.all([load(), refreshLabs()]);
+  }, [load, refreshLabs]);
+
   const doPromote = async (member: LabMemberRecord) => {
     if (!labId) return;
     setBusyUserId(member.user_id);
     setError(null);
     try {
       await promoteMemberToAdmin(labId, member.user_id);
-      await load();
+      await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));
     } finally {
@@ -232,7 +239,7 @@ const MembersTab = () => {
     setError(null);
     try {
       await demoteAdminToMember(labId, member.user_id);
-      await load();
+      await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));
     } finally {
@@ -248,7 +255,7 @@ const MembersTab = () => {
     setError(null);
     try {
       await removeLabMember(labId, member.user_id);
-      await load();
+      await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));
     } finally {

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,11 +20,19 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - **Self-serve join flow**: `lab_join_requests` table + `request_lab_join` / `approve_lab_join` / `reject_lab_join` / `cancel_lab_join` / `lookup_lab_by_id` RPCs. Rejection requires a comment; one pending request per user per lab.
 - **LabPicker empty state**: create-new-lab or paste-invite-link.
 
-## Account shell (`apps/account`)
+## Account app (`apps/account`) — complete
 
 - Dedicated app at `/account/`, reachable by clicking the login status box in any other app.
-- Dashboard mounts `LabSettingsPanel` (owner promote/demote), `LabMembersPanel` (invite + remove), `LabJoinRequestsPanel` (approve/reject pending requests with required comment), and `LabShareLinkPanel` (copyable `/account/join/<uuid>` URL).
-- Join-by-link route at `/account/join/<lab-uuid>`: signed-out users see auth shell; signed-in members get "Open this lab"; non-members see lab name preview + "Request to join" form with optional message and self-cancel.
+- **Flat two-panel layout**: left sidebar with profile, active lab tier (owner / admin / member) + capability blurb, project counts, and a "Join or create another lab…" shortcut that reopens `LabPicker` without clearing the current active lab. Right main area with tabbed Lab Management (Members / Invitations & Requests).
+- **Strict tier hierarchy** (owner > admin > member; one tier per user per lab, enforced by PK on `lab_memberships`):
+  - Admins + owner can promote members to admin and remove members.
+  - Only the owner can demote admins to member or remove admins.
+  - Owner is immutable via RPCs (`promote_member_to_admin`, `demote_admin_to_member`, `remove_lab_member`).
+- **Invitations & requests** in one tab: invite-by-email with role choice, pending-invitation list, copyable `/account/join/<uuid>` share link, and join-request queue with approve / reject-with-required-comment.
+- **Auto-claim on sign-in**: `claim_pending_invitations` RPC converts matching-email pending invitations to memberships when the user signs in.
+- **Join-by-link route** at `/account/join/<lab-uuid>`: signed-out users hit the auth shell; existing members get "Open this lab"; non-members see a lab-name preview + "Request to join" form with optional message + self-cancel.
+- **GitHub Pages SPA fallback** routed to the Account shell so deep links like `/account/join/<uuid>` resolve.
+- **Real-time badge updates**: role changes refresh both the members roster and the `AuthProvider` labs array so the sidebar tier badge updates without a reload.
 - Shared `AccountLinkCard` in `@ilm/ui` renders the login status box consistently across placeholder apps (`funding-manager`, `supply-manager`).
 
 ## Protocol Manager (Stage 3b — production)

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -6,7 +6,7 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ## Stage: Funding Manager schema + adapter
 
-**Why now.** With membership surfaces shipped in the Account app, the remaining auth-shell stubs (`funding-manager`, `supply-manager`) are the biggest gap. Funding first because it's a cleaner domain model (grants / budgets / allocations / expenses) and because project-manager already has experimental expense fields that funding should take over.
+**Why now.** Account app is feature-complete (flat two-panel layout, strict owner/admin/member tier hierarchy, invitations + join requests + share links, auto-claim on sign-in, real-time badge updates). The remaining auth-shell stubs (`funding-manager`, `supply-manager`) are the biggest gap. Funding first because it's a cleaner domain model (grants / budgets / allocations / expenses) and because project-manager already has experimental expense fields that funding should take over.
 
 ### Backend
 


### PR DESCRIPTION
## Summary
- After promote/demote/remove in MembersTab, also call `refreshLabs()` so the AuthProvider-owned labs array updates. The sidebar tier badge (bound to `activeLab.role`) now changes in sync with the members-list badges instead of sticking on the stale cached role.
- Mark the Account app as complete in `docs/features.md` and update `docs/next-stage.md` to reflect that Funding Manager is the next stage.

## Test plan
- [ ] As owner, demote an admin → sidebar of the demoted user (if logged in) and the members row both update.
- [ ] Promote a member → badge flips from Member to Admin without reloading.
- [ ] Remove a member → row disappears; no stale sidebar state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)