### PR TITLE
Optimistically patch member roster on role change

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -212,9 +212,17 @@ const MembersTab = () => {
     void load();
   }, [load]);
 
-  // After any role change, refresh both the member list (affects other rows'
-  // badges) and the AuthProvider labs array (affects the sidebar badge when
-  // the caller changed their own role).
+  // Optimistic local patch: apply immediately so the badge flips without
+  // waiting for the server reload (which can race with the RPC's commit
+  // visibility in some Postgrest setups). The background reload still runs
+  // as ground truth.
+  const applyLocalRole = (userId: string, nextRole: MembershipTier) => {
+    setMembers((prev) => prev.map((m) => (m.user_id === userId ? { ...m, role: nextRole } : m)));
+  };
+  const applyLocalRemove = (userId: string) => {
+    setMembers((prev) => prev.filter((m) => m.user_id !== userId));
+  };
+
   const refreshAfterAction = useCallback(async () => {
     await Promise.all([load(), refreshLabs()]);
   }, [load, refreshLabs]);
@@ -225,6 +233,7 @@ const MembersTab = () => {
     setError(null);
     try {
       await promoteMemberToAdmin(labId, member.user_id);
+      applyLocalRole(member.user_id, "admin");
       await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));
@@ -239,6 +248,7 @@ const MembersTab = () => {
     setError(null);
     try {
       await demoteAdminToMember(labId, member.user_id);
+      applyLocalRole(member.user_id, "member");
       await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));
@@ -255,6 +265,7 @@ const MembersTab = () => {
     setError(null);
     try {
       await removeLabMember(labId, member.user_id);
+      applyLocalRemove(member.user_id);
       await refreshAfterAction();
     } catch (err) {
       setError(errorMessage(err));


### PR DESCRIPTION
## Summary
Even after refreshing from the server, the acct-badge in the members list was lagging behind the sidebar. Apply the new role (or removal) optimistically to local state the moment the RPC resolves, so the row re-renders immediately. The server reload still runs afterwards as ground truth.

## Test plan
- [ ] Promote a member → their row badge flips from "Member" to "Admin" without a perceptible delay.
- [ ] Demote an admin → badge flips back to "Member".
- [ ] Remove a member → row disappears immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)