### PR TITLE
Plan Supply Manager (stock + orders) as next stage; defer funding

### DIFF
--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,37 +4,60 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage: Funding Manager schema + adapter
+## Stage: Funding Manager (Stage 4b)
 
-**Why now.** Account app is feature-complete (flat two-panel layout, strict owner/admin/member tier hierarchy, invitations + join requests + share links, auto-claim on sign-in, real-time badge updates). The remaining auth-shell stubs (`funding-manager`, `supply-manager`) are the biggest gap. Funding first because it's a cleaner domain model (grants / budgets / allocations / expenses) and because project-manager already has experimental expense fields that funding should take over.
+**Why now.** Account app is complete. Of the remaining auth-shell stubs (`funding-manager`, `supply-manager`), funding has a cleaner domain model and project-manager already carries experimental expense fields that funding should take over — blocking cleanup there until funding lands.
 
-### Backend
+### Step 1 — Schema migration
 
-New migration `YYYYMMDDHHMMSS_funding_manager.sql`:
+Create `supabase/migrations/YYYYMMDDHHMMSS_funding_manager.sql`:
 
-- `grants` (lab_id, funder, title, amount, start_date, end_date, status, notes)
-- `budgets` (grant_id, fiscal_year, amount)
-- `allocations` (budget_id, project_id, amount, status: proposed/committed/declined)
-- `expenses` (allocation_id, amount, category, occurred_on, description, submitted_by)
-- RLS modeled on `projects`: lab-scoped, read for members, write for admins + project leads.
-- RPCs: `propose_allocation`, `commit_allocation`, `decline_allocation` (admin-only), `submit_expense`, `approve_expense`, `reject_expense`.
-- `audit_log` entries on commit / decline / approve / reject.
+- `grants` — `(id, lab_id, funder, title, amount_total numeric, currency, start_date, end_date, status: active/closed, notes, created_by, timestamps)`
+- `budgets` — `(id, grant_id, fiscal_year int, amount numeric, notes)`; unique `(grant_id, fiscal_year)`
+- `allocations` — `(id, budget_id, project_id, amount numeric, status: proposed/committed/declined, reviewed_by, reviewed_at, comment, created_by, timestamps)`
+- `expenses` — `(id, allocation_id, amount numeric, category, occurred_on date, description, submitted_by, status: submitted/approved/rejected, reviewed_by, reviewed_at, comment, timestamps)`
+- `updated_at` trigger on all four tables.
+- **RLS**: lab-scoped via the parent chain (`grants.lab_id` → `budgets.grant_id` → `allocations.budget_id` → `expenses.allocation_id`). Read for any lab member; write on grants/budgets restricted to `is_lab_admin`; allocations writable by admins + project leads of the target project; expenses submittable by project leads and approvable by admins.
+- **RPCs** (all SECURITY DEFINER, emit `_log_audit`):
+  - `propose_allocation(p_budget_id, p_project_id, p_amount)` — inserts with status=proposed
+  - `commit_allocation(p_allocation_id, p_comment?)` / `decline_allocation(p_allocation_id, p_comment)` — admin-only
+  - `submit_expense(p_allocation_id, p_amount, p_category, p_occurred_on, p_description)` — project-lead or admin
+  - `approve_expense(p_expense_id, p_comment?)` / `reject_expense(p_expense_id, p_comment)` — admin-only; reject requires comment
+- **Audit**: entries on `commit / decline / approve / reject` (mirror project review pattern); draft edits are not logged.
 
-### Frontend
+### Step 2 — Remove experimental fields from `projects`
 
-- `apps/funding-manager` adapter + hooks mirroring `useProjectWorkspace`.
-- Screens: Grants overview, Budget drill-down, Allocation queue (admin review), Expense ledger.
-- Reuse `SubmissionHistoryLink`, `LabMembersPanel` removed from the app (lives in Account shell now).
+Project-manager carries in-progress expense-ish columns that predate the funding model. Drop them in the same migration (or an immediately-following one) once funding owns the domain — list them during the migration write-up. Guard with a data-migration step if any rows are populated.
+
+### Step 3 — Shared types + adapter
+
+- `packages/types`: `Grant`, `Budget`, `Allocation`, `Expense`, status unions.
+- `packages/ui` (or `apps/funding-manager/src/adapters`): `useFundingWorkspace` hook mirroring `useProjectWorkspace` — one subscription per lab, local normalization, optimistic updates on the RPC verbs above.
+
+### Step 4 — Frontend screens
+
+- **Grants overview** — table of grants with fiscal-year budgets inlined; admins can create/edit/close.
+- **Budget drill-down** — per-grant view: budget vs. committed vs. expensed; per-project allocation rows; inline allocation proposals for project leads.
+- **Allocation queue** — admin review surface; approve/decline with optional comment; mirror the project review UX.
+- **Expense ledger** — per-allocation entry log; submit form for leads; approval queue for admins with required-comment rejection.
+- Reuse `SubmissionHistoryLink` pattern for per-allocation history.
+
+### Step 5 — Deployment + docs
+
+- Register the app in `.github/workflows/deploy-protocol-manager-pages.yml` (build step + artifact copy).
+- Add `AccountLinkCard` to the funding-manager shell.
+- Update `docs/features.md` under a new "Funding Manager (Stage 4b)" section once shipped.
 
 ### Tradeoffs
 
-- **Scope.** A first pass can ship grants + budgets + allocations and defer expenses. Recommend doing the full loop so expense approval surfaces the audit pattern before supply-manager copies it.
+- **Scope of first ship.** Could stop after allocations (grants → budgets → allocations) and defer expenses. Recommend shipping the full loop so expense approval surfaces the audit pattern before supply-manager copies it.
 - **Source of truth for committed dollars.** Allocations vs. expenses: commit-at-allocation keeps budgets tidy; commit-at-expense is more accurate but churns dashboards. Recommend commit-at-allocation with expense = actuals.
+- **Currency.** Single-currency per grant column keeps math simple. Multi-currency conversion is explicitly out of scope for this stage.
 
 ---
 
 ## After this stage
 
-- **Stage 4c (supply-manager)** — schema design + adapter + UI; reuse funding's audit pattern for order/receive transitions.
-- **Rotatable share-link token**. Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in `LabShareLinkPanel` would make leaked links revocable.
+- **Stage 4c — Supply Manager.** Schema design + adapter + UI; reuse funding's audit pattern for order/receive transitions.
+- **Rotatable share-link token.** Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in the share-link section would make leaked links revocable.
 - **Deferred housekeeping**: fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,60 +4,68 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage: Funding Manager (Stage 4b)
+## Stage: Supply Manager — stock + orders (Stage 4b)
 
-**Why now.** Account app is complete. Of the remaining auth-shell stubs (`funding-manager`, `supply-manager`), funding has a cleaner domain model and project-manager already carries experimental expense fields that funding should take over — blocking cleanup there until funding lands.
+**Why now.** Account app is done. Day-to-day bench work depends on knowing what reagents/consumables are on hand and what's on order; funding/accounting can wait. Supply is also a prerequisite for linking experiments to actual consumption. The `supply-manager` app is currently an auth shell with no schema.
+
+**Scope for this stage.** Three capabilities:
+
+1. **Items + stock** — a lab-scoped catalog of supply items (reagents, consumables, equipment) with current quantity on hand and storage location.
+2. **Orders** — purchase requests that flow pending → ordered → received (or cancelled), with receipt quantities feeding back into stock.
+3. **Storage locations** — a shallow hierarchy (room → shelf/freezer/fridge) so items can be filed and found.
+
+Out of scope for this stage: lot/expiry tracking per receipt, barcode scanning, per-experiment consumption logging, supplier/catalog integrations. Deferred to follow-ups.
 
 ### Step 1 — Schema migration
 
-Create `supabase/migrations/YYYYMMDDHHMMSS_funding_manager.sql`:
+Create `supabase/migrations/YYYYMMDDHHMMSS_supply_manager.sql`:
 
-- `grants` — `(id, lab_id, funder, title, amount_total numeric, currency, start_date, end_date, status: active/closed, notes, created_by, timestamps)`
-- `budgets` — `(id, grant_id, fiscal_year int, amount numeric, notes)`; unique `(grant_id, fiscal_year)`
-- `allocations` — `(id, budget_id, project_id, amount numeric, status: proposed/committed/declined, reviewed_by, reviewed_at, comment, created_by, timestamps)`
-- `expenses` — `(id, allocation_id, amount numeric, category, occurred_on date, description, submitted_by, status: submitted/approved/rejected, reviewed_by, reviewed_at, comment, timestamps)`
-- `updated_at` trigger on all four tables.
-- **RLS**: lab-scoped via the parent chain (`grants.lab_id` → `budgets.grant_id` → `allocations.budget_id` → `expenses.allocation_id`). Read for any lab member; write on grants/budgets restricted to `is_lab_admin`; allocations writable by admins + project leads of the target project; expenses submittable by project leads and approvable by admins.
-- **RPCs** (all SECURITY DEFINER, emit `_log_audit`):
-  - `propose_allocation(p_budget_id, p_project_id, p_amount)` — inserts with status=proposed
-  - `commit_allocation(p_allocation_id, p_comment?)` / `decline_allocation(p_allocation_id, p_comment)` — admin-only
-  - `submit_expense(p_allocation_id, p_amount, p_category, p_occurred_on, p_description)` — project-lead or admin
-  - `approve_expense(p_expense_id, p_comment?)` / `reject_expense(p_expense_id, p_comment)` — admin-only; reject requires comment
-- **Audit**: entries on `commit / decline / approve / reject` (mirror project review pattern); draft edits are not logged.
+- `storage_locations` — `(id, lab_id, parent_id nullable, name, kind: room/shelf/freezer/fridge/cabinet/other, notes, timestamps)`; RLS lab-scoped; admin write, member read.
+- `supply_items` — `(id, lab_id, name, category, unit (e.g. mL/box/tube), vendor, catalog_no, reorder_threshold numeric, location_id nullable, notes, created_by, timestamps)`; unique `(lab_id, catalog_no)` partial index when catalog_no is not null.
+- `stock_levels` — `(item_id primary key, on_hand numeric, updated_at, updated_by)`; kept in sync by the RPCs below (single row per item; simpler than a ledger for v1).
+- `supply_orders` — `(id, lab_id, item_id, quantity numeric, status: pending/ordered/received/cancelled, requested_by, ordered_by, ordered_at, received_by, received_at, received_quantity numeric nullable, comment, timestamps)`.
+- `updated_at` triggers on all four.
+- **RLS** — lab-scoped via `lab_id` (or item's lab for `stock_levels`). Read for any lab member; create/edit items + locations restricted to `is_lab_admin` OR the item's `created_by`; all members can create orders (requests); only admins can transition to `ordered` / `cancelled`; `received` can be recorded by any admin or the original requester.
+- **RPCs** (SECURITY DEFINER, audit-logged on state transitions):
+  - `upsert_supply_item(...)` / `delete_supply_item(p_item_id)` — admin-only for delete.
+  - `adjust_stock(p_item_id, p_delta numeric, p_reason text)` — manual correction; audit entry.
+  - `request_supply_order(p_item_id, p_quantity, p_comment?)` — any member; status=pending.
+  - `mark_order_ordered(p_order_id, p_comment?)` — admin; status=ordered, stamps `ordered_by/at`.
+  - `mark_order_received(p_order_id, p_received_quantity, p_comment?)` — admin or requester; status=received, increments `stock_levels.on_hand` by `received_quantity`, stamps `received_by/at`.
+  - `cancel_supply_order(p_order_id, p_comment)` — admin or requester; comment required.
+- **Audit** — `_log_audit` entries on order state transitions and manual stock adjustments. Item/location edits are not logged.
 
-### Step 2 — Remove experimental fields from `projects`
+### Step 2 — Shared types + adapter
 
-Project-manager carries in-progress expense-ish columns that predate the funding model. Drop them in the same migration (or an immediately-following one) once funding owns the domain — list them during the migration write-up. Guard with a data-migration step if any rows are populated.
+- `packages/types`: `StorageLocation`, `SupplyItem`, `StockLevel`, `SupplyOrder`, status unions.
+- `apps/supply-manager/src/adapters/useSupplyWorkspace.ts`: mirrors `useProjectWorkspace` — one subscription per lab, local normalization, optimistic updates on the RPC verbs.
 
-### Step 3 — Shared types + adapter
+### Step 3 — Frontend screens
 
-- `packages/types`: `Grant`, `Budget`, `Allocation`, `Expense`, status unions.
-- `packages/ui` (or `apps/funding-manager/src/adapters`): `useFundingWorkspace` hook mirroring `useProjectWorkspace` — one subscription per lab, local normalization, optimistic updates on the RPC verbs above.
+Tabs in `apps/supply-manager`:
 
-### Step 4 — Frontend screens
+- **Stock** — searchable/filterable item table: name, category, location, on-hand vs. reorder threshold (visual flag when below), last-updated. Inline "Adjust" action opens a quantity diff modal (calls `adjust_stock`). "Request order" button prefills the order form.
+- **Orders** — two sections: *Pending* (awaiting admin action with Order / Cancel buttons) and *In transit* (ordered, awaiting receipt, with Receive form). History log below. Admin-only actions gated on `activeLab.role`.
+- **Storage** — tree view of locations (room → shelf/freezer) with item counts per node. Admin CRUD on locations.
+- **Reorder alerts** — dashboard widget on the Stock tab: items below their `reorder_threshold` with a one-click "Request order" prefilled to the delta.
 
-- **Grants overview** — table of grants with fiscal-year budgets inlined; admins can create/edit/close.
-- **Budget drill-down** — per-grant view: budget vs. committed vs. expensed; per-project allocation rows; inline allocation proposals for project leads.
-- **Allocation queue** — admin review surface; approve/decline with optional comment; mirror the project review UX.
-- **Expense ledger** — per-allocation entry log; submit form for leads; approval queue for admins with required-comment rejection.
-- Reuse `SubmissionHistoryLink` pattern for per-allocation history.
+### Step 4 — Deployment + docs
 
-### Step 5 — Deployment + docs
-
-- Register the app in `.github/workflows/deploy-protocol-manager-pages.yml` (build step + artifact copy).
-- Add `AccountLinkCard` to the funding-manager shell.
-- Update `docs/features.md` under a new "Funding Manager (Stage 4b)" section once shipped.
+- Register `supply-manager` build in `.github/workflows/deploy-protocol-manager-pages.yml`.
+- Mount `AccountLinkCard` in the supply-manager shell (already present in the stub — just ensure it survives the rewrite).
+- Update `docs/features.md` with a "Supply Manager (Stage 4b)" section on ship.
 
 ### Tradeoffs
 
-- **Scope of first ship.** Could stop after allocations (grants → budgets → allocations) and defer expenses. Recommend shipping the full loop so expense approval surfaces the audit pattern before supply-manager copies it.
-- **Source of truth for committed dollars.** Allocations vs. expenses: commit-at-allocation keeps budgets tidy; commit-at-expense is more accurate but churns dashboards. Recommend commit-at-allocation with expense = actuals.
-- **Currency.** Single-currency per grant column keeps math simple. Multi-currency conversion is explicitly out of scope for this stage.
+- **Single stock row vs. ledger.** v1 keeps one `on_hand` number per item, mutated by RPCs. A full append-only `stock_movements` ledger is more auditable but adds a table + join. We get 80% of the value from the audit log on the RPCs that touch stock; upgrade to a ledger when lot/expiry tracking lands.
+- **Location hierarchy depth.** Two-level (room → container) is enough for most labs. Modeled as a self-referential `parent_id` so deeper nesting is possible without a schema change, but the UI only renders two levels for v1.
+- **Order approval.** Skipping a pending→approved admin gate before ordering keeps the flow short; admins are the ones who actually place orders anyway, so the "place order" click is the de-facto approval. Revisit if labs want multi-admin sign-off.
 
 ---
 
 ## After this stage
 
-- **Stage 4c — Supply Manager.** Schema design + adapter + UI; reuse funding's audit pattern for order/receive transitions.
+- **Stage 4c — Supply Manager v2.** Per-receipt lot/expiry tracking, supplier/catalog import, per-experiment consumption logging (links `experiments` to `stock_movements`).
+- **Stage 4d — Funding Manager.** `grants / budgets / allocations / expenses` with RLS + SECURITY DEFINER RPCs + audit. Takes over the experimental expense fields currently on `projects`. Deferred because accounting is not blocking day-to-day lab use.
 - **Rotatable share-link token.** Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in the share-link section would make leaked links revocable.
-- **Deferred housekeeping**: fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.
+- **Deferred housekeeping.** Fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.


### PR DESCRIPTION
## Summary
Swap the stage-4b plan from Funding Manager to Supply Manager. Bench work needs stock and orders more than accounting needs grants; funding moves to stage 4d.

Four-step plan in `docs/next-stage.md`:
1. **Schema** — `storage_locations`, `supply_items`, `stock_levels`, `supply_orders` + RLS + SECURITY DEFINER RPCs + audit on state transitions.
2. **Types + adapter** — `useSupplyWorkspace` hook mirroring `useProjectWorkspace`.
3. **Screens** — Stock (searchable table with reorder-threshold flags + adjust), Orders (pending / in-transit / history with admin gates), Storage (room→container tree), Reorder alerts widget.
4. **Deployment** — register in the Pages workflow, keep AccountLinkCard.

Deferred to v2 / later stages: per-receipt lot/expiry, supplier/catalog import, per-experiment consumption logging, rotatable share links, funding module.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)