### PR TITLE
Add GitHub repo link per project with lab-scoped PAT

### DIFF
--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -67,6 +67,21 @@ const toDateTimeLocalValue = (value: string | null) => {
 
 const fromDateTimeLocalValue = (value: string) => (value ? new Date(value).toISOString() : null);
 
+const formatRelativeTime = (value: string | null | undefined) => {
+  if (!value) return "never";
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return "unknown";
+  const diffSec = Math.round((then - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  if (abs < 60) return formatter.format(diffSec, "second");
+  if (abs < 3600) return formatter.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86_400) return formatter.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2_592_000) return formatter.format(Math.round(diffSec / 86_400), "day");
+  if (abs < 31_536_000) return formatter.format(Math.round(diffSec / 2_592_000), "month");
+  return formatter.format(Math.round(diffSec / 31_536_000), "year");
+};
+
 const resolveSiteRoot = (baseUrl: string) => {
   const normalized = (baseUrl.trim() || "/").replace(/\/?$/, "/");
   const currentBase = new URL(normalized.startsWith("/") ? normalized : `/${normalized}`, window.location.origin);
@@ -475,7 +490,12 @@ export const App = () => {
     protocols,
     leads,
     deletedProjects,
+    repoStatuses,
+    labGithubPatConfigured,
     refresh,
+    refreshRepoStatus,
+    setLabGithubPat,
+    clearLabGithubPat,
     createProjectDraft,
     withdrawProjectDraft,
     approveProject,
@@ -591,6 +611,28 @@ export const App = () => {
     });
     return map;
   }, [experiments]);
+
+  const repoStatusByProject = useMemo(() => {
+    const map = new Map<string, (typeof repoStatuses)[number]>();
+    repoStatuses.forEach((row) => map.set(row.project_id, row));
+    return map;
+  }, [repoStatuses]);
+
+  const [repoRefreshBusy, setRepoRefreshBusy] = useState<Record<string, boolean>>({});
+  const handleRefreshRepo = useCallback(async (projectId: string) => {
+    setRepoRefreshBusy((prev) => ({ ...prev, [projectId]: true }));
+    try {
+      await refreshRepoStatus(projectId);
+    } catch (err) {
+      setActionError(errorMessage(err));
+    } finally {
+      setRepoRefreshBusy((prev) => {
+        const next = { ...prev };
+        delete next[projectId];
+        return next;
+      });
+    }
+  }, [refreshRepoStatus]);
 
   const experimentsByMilestone = useMemo(() => {
     const map = new Map<string, ExperimentRecord[]>();
@@ -800,7 +842,7 @@ export const App = () => {
 
   // Info editor handlers
   const handleSaveMetadata = useCallback(
-    async (args: { name: string; description: string; status: ProjectStatus; approvalRequired: boolean }) => {
+    async (args: { name: string; description: string; status: ProjectStatus; approvalRequired: boolean; githubRepoUrl: string }) => {
       if (!activeProject) return;
       setProjectSaveBusy("saving");
       setProjectSaveError(null);
@@ -811,6 +853,7 @@ export const App = () => {
           description: args.description,
           status: args.status,
           approvalRequired: args.approvalRequired,
+          githubRepoUrl: args.githubRepoUrl,
         });
       } catch (err) {
         setProjectSaveError(errorMessage(err));
@@ -1087,6 +1130,8 @@ export const App = () => {
     const ex = experimentsByProject.get(project.id) ?? [];
     const isGeneral = project.name === "General";
     const isMine = project.created_by === user?.id;
+    const repoStatus = repoStatusByProject.get(project.id) ?? null;
+    const repoBusy = Boolean(repoRefreshBusy[project.id]);
     return (
       <article key={project.id} className="pm-library-card">
         <div className="pm-library-card-head">
@@ -1150,6 +1195,49 @@ export const App = () => {
             </button>
           ) : null}
         </div>
+        {project.github_repo_url ? (
+          labGithubPatConfigured ? (
+            <div className="pm-library-card-repo" title={repoStatus?.error ?? project.github_repo_url}>
+              <a
+                href={repoStatus?.html_url ?? project.github_repo_url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="pm-repo-link"
+              >
+                {repoStatus?.error
+                  ? "repo: error"
+                  : repoStatus?.pushed_at
+                    ? `last push ${formatRelativeTime(repoStatus.pushed_at)}`
+                    : "repo: no data yet"}
+              </a>
+              <button
+                type="button"
+                className="pm-text-button"
+                onClick={() => void handleRefreshRepo(project.id)}
+                disabled={repoBusy}
+                aria-label="Refresh repo status"
+              >
+                {repoBusy ? "..." : "↻"}
+              </button>
+            </div>
+          ) : (
+            <div
+              className="pm-library-card-repo pm-library-card-repo-muted"
+              title={isAdmin
+                ? "Add a lab GitHub PAT in Library → GitHub integration to enable monitoring."
+                : "Ask a lab admin to configure a GitHub PAT to enable monitoring."}
+            >
+              <a
+                href={project.github_repo_url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="pm-repo-link"
+              >
+                GitHub monitor unavailable — no lab PAT
+              </a>
+            </div>
+          )
+        ) : null}
       </article>
     );
   };
@@ -1220,6 +1308,14 @@ export const App = () => {
         </div>
       </header>
       {actionError ? <p className="pm-page-error">{actionError}</p> : null}
+
+      {isAdmin ? (
+        <LabGithubPatPanel
+          configured={labGithubPatConfigured}
+          onSet={setLabGithubPat}
+          onClear={clearLabGithubPat}
+        />
+      ) : null}
 
       <section className="pm-panel-section">
         <div className="pm-panel-section-head">
@@ -1783,12 +1879,13 @@ const InfoTab = ({
   project: ProjectRecord;
   busy: "idle" | "saving";
   error: string | null;
-  onSave: (args: { name: string; description: string; status: ProjectStatus; approvalRequired: boolean }) => Promise<void>;
+  onSave: (args: { name: string; description: string; status: ProjectStatus; approvalRequired: boolean; githubRepoUrl: string }) => Promise<void>;
 }) => {
   const [name, setName] = useState(project.name);
   const [description, setDescription] = useState(project.description ?? "");
   const [status, setStatus] = useState<ProjectStatus>((project.status as ProjectStatus | null) ?? "planning");
   const [approvalRequired, setApprovalRequired] = useState(project.approval_required);
+  const [githubRepoUrl, setGithubRepoUrl] = useState(project.github_repo_url ?? "");
   const isGeneral = project.name === "General";
 
   useEffect(() => {
@@ -1796,11 +1893,12 @@ const InfoTab = ({
     setDescription(project.description ?? "");
     setStatus((project.status as ProjectStatus | null) ?? "planning");
     setApprovalRequired(project.approval_required);
+    setGithubRepoUrl(project.github_repo_url ?? "");
   }, [project]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await onSave({ name, description, status, approvalRequired });
+    await onSave({ name, description, status, approvalRequired, githubRepoUrl });
   };
 
   return (
@@ -1819,6 +1917,15 @@ const InfoTab = ({
       <label className="pm-field">
         <span>Description</span>
         <textarea rows={5} value={description} onChange={(event) => setDescription(event.target.value)} />
+      </label>
+      <label className="pm-field">
+        <span>GitHub repository URL</span>
+        <input
+          type="url"
+          placeholder="https://github.com/owner/repo"
+          value={githubRepoUrl}
+          onChange={(event) => setGithubRepoUrl(event.target.value)}
+        />
       </label>
       <div className="pm-field-row">
         <label className="pm-field">
@@ -1860,5 +1967,98 @@ const InfoTab = ({
         </div>
       </div>
     </form>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// LabGithubPatPanel — admin-only control to set / clear the shared GitHub PAT.
+// ---------------------------------------------------------------------------
+
+const LabGithubPatPanel = ({
+  configured,
+  onSet,
+  onClear,
+}: {
+  configured: boolean;
+  onSet: (pat: string) => Promise<void>;
+  onClear: () => Promise<void>;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [pat, setPat] = useState("");
+  const [busy, setBusy] = useState<"idle" | "saving" | "clearing">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!pat.trim()) return;
+    setBusy("saving");
+    setError(null);
+    setNote(null);
+    try {
+      await onSet(pat.trim());
+      setPat("");
+      setNote("PAT saved. Project cards can now fetch GitHub activity.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save PAT");
+    } finally {
+      setBusy("idle");
+    }
+  };
+
+  const handleClear = async () => {
+    if (!window.confirm("Clear the lab's GitHub PAT? Project repo status will stop refreshing.")) return;
+    setBusy("clearing");
+    setError(null);
+    setNote(null);
+    try {
+      await onClear();
+      setNote("PAT cleared.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to clear PAT");
+    } finally {
+      setBusy("idle");
+    }
+  };
+
+  return (
+    <details className="pm-collapsible-section" open={open} onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}>
+      <summary>
+        <span>GitHub integration</span>
+        <span>{configured ? "PAT configured" : "Not configured"}</span>
+      </summary>
+      <div className="pm-panel-section-body" style={{ display: "grid", gap: "0.6rem", paddingTop: "0.6rem" }}>
+        <p className="pm-muted-note" style={{ fontSize: "0.8rem" }}>
+          Paste a fine-grained GitHub Personal Access Token with read-only access to the repos you link from projects.
+          The token is stored in the lab row and is only readable by the <code>fetch-github-activity</code> edge
+          function — it is never sent back to the browser. Any lab member can trigger a refresh from a project card;
+          the server uses this shared token on their behalf.
+        </p>
+        {error ? <p className="pm-inline-error">{error}</p> : null}
+        {note ? <p className="pm-inline-note">{note}</p> : null}
+        <form className="pm-inline-form" onSubmit={handleSave} style={{ gap: "0.5rem" }}>
+          <label className="pm-field">
+            <span>New PAT</span>
+            <input
+              type="password"
+              autoComplete="off"
+              placeholder="github_pat_..."
+              value={pat}
+              onChange={(event) => setPat(event.target.value)}
+            />
+          </label>
+          <div className="pm-inline-actions">
+            <button type="submit" className="pm-primary-button" disabled={busy !== "idle" || !pat.trim()}>
+              {busy === "saving" ? "Saving..." : configured ? "Replace PAT" : "Save PAT"}
+            </button>
+            {configured ? (
+              <button type="button" className="pm-text-button pm-text-button-danger" onClick={() => void handleClear()} disabled={busy !== "idle"}>
+                {busy === "clearing" ? "Clearing..." : "Clear PAT"}
+              </button>
+            ) : null}
+          </div>
+        </form>
+      </div>
+    </details>
   );
 };

--- a/apps/project-manager/src/lib/cloudAdapter.ts
+++ b/apps/project-manager/src/lib/cloudAdapter.ts
@@ -24,9 +24,21 @@ export interface ProjectRecord {
   review_requested_by: string | null;
   approval_required: boolean;
   submission_history: SubmissionHistoryEntryRecord[] | null;
+  github_repo_url: string | null;
   created_by: string | null;
   updated_by: string | null;
   created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectRepoStatusRecord {
+  project_id: string;
+  lab_id: string;
+  pushed_at: string | null;
+  default_branch: string | null;
+  html_url: string | null;
+  error: string | null;
+  fetched_at: string;
   updated_at: string;
 }
 
@@ -81,12 +93,16 @@ export interface ProjectWorkspaceSnapshot {
   experiments: ExperimentRecord[];
   protocols: ProtocolOptionRecord[];
   leads: ProjectLeadLinkRecord[];
+  repoStatuses: ProjectRepoStatusRecord[];
 }
 
 const client = () => getSupabaseClient();
 
 const PROJECT_FIELDS =
-  "id, lab_id, name, description, status, state, deleted_at, review_requested_at, review_requested_by, approval_required, submission_history, created_by, updated_by, created_at, updated_at";
+  "id, lab_id, name, description, status, state, deleted_at, review_requested_at, review_requested_by, approval_required, submission_history, github_repo_url, created_by, updated_by, created_at, updated_at";
+
+const REPO_STATUS_FIELDS =
+  "project_id, lab_id, pushed_at, default_branch, html_url, error, fetched_at, updated_at";
 
 const MILESTONE_FIELDS =
   "id, lab_id, project_id, sort_order, title, description, due_date, status, created_by, updated_by, created_at, updated_at";
@@ -95,12 +111,13 @@ const EXPERIMENT_FIELDS =
   "id, lab_id, project_id, milestone_id, sort_order, protocol_id, title, notes, status, started_at, completed_at, created_by, updated_by, created_at, updated_at";
 
 export async function listProjectWorkspace(labId: string): Promise<ProjectWorkspaceSnapshot> {
-  const [projectsResult, milestonesResult, experimentsResult, protocolsResult, leadsResult] = await Promise.all([
+  const [projectsResult, milestonesResult, experimentsResult, protocolsResult, leadsResult, repoStatusesResult] = await Promise.all([
     client().from("projects").select(PROJECT_FIELDS).eq("lab_id", labId).order("name", { ascending: true }),
     client().from("milestones").select(MILESTONE_FIELDS).eq("lab_id", labId).order("sort_order", { ascending: true }).order("created_at", { ascending: true }),
     client().from("experiments").select(EXPERIMENT_FIELDS).eq("lab_id", labId).order("sort_order", { ascending: true }).order("created_at", { ascending: true }),
     client().from("protocols").select("id, project_id, title, updated_at").eq("lab_id", labId).order("updated_at", { ascending: false }),
     client().from("project_leads").select("project_id, user_id, projects!inner(lab_id)").eq("projects.lab_id", labId),
+    client().from("project_repo_status").select(REPO_STATUS_FIELDS).eq("lab_id", labId),
   ]);
 
   if (projectsResult.error) throw projectsResult.error;
@@ -108,6 +125,8 @@ export async function listProjectWorkspace(labId: string): Promise<ProjectWorksp
   if (experimentsResult.error) throw experimentsResult.error;
   if (protocolsResult.error) throw protocolsResult.error;
   if (leadsResult.error) throw leadsResult.error;
+  // repo_status is optional infrastructure — tolerate missing table / RLS hiccups
+  // so the library still loads if the GitHub migration hasn't been applied yet.
 
   const leads = ((leadsResult.data ?? []) as Array<{ project_id: string; user_id: string }>).map((row) => ({
     project_id: row.project_id,
@@ -120,6 +139,7 @@ export async function listProjectWorkspace(labId: string): Promise<ProjectWorksp
     experiments: (experimentsResult.data as ExperimentRecord[]) ?? [],
     protocols: (protocolsResult.data as ProtocolOptionRecord[]) ?? [],
     leads,
+    repoStatuses: repoStatusesResult.error ? [] : ((repoStatusesResult.data as ProjectRepoStatusRecord[]) ?? []),
   };
 }
 
@@ -219,21 +239,57 @@ export async function updateProject(args: {
   description?: string;
   status?: string;
   approvalRequired: boolean;
+  githubRepoUrl?: string | null;
 }): Promise<ProjectRecord> {
+  const update: Record<string, unknown> = {
+    name: args.name,
+    description: args.description?.trim() || null,
+    status: args.status?.trim() || null,
+    approval_required: args.approvalRequired,
+    updated_by: args.userId,
+  };
+  if (args.githubRepoUrl !== undefined) {
+    const trimmed = args.githubRepoUrl?.trim();
+    update.github_repo_url = trimmed ? trimmed : null;
+  }
   const { data, error } = await client()
     .from("projects")
-    .update({
-      name: args.name,
-      description: args.description?.trim() || null,
-      status: args.status?.trim() || null,
-      approval_required: args.approvalRequired,
-      updated_by: args.userId,
-    })
+    .update(update)
     .eq("id", args.projectId)
     .select(PROJECT_FIELDS)
     .single();
   if (error) throw error;
   return data as ProjectRecord;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub integration — repo status + lab PAT management
+// ---------------------------------------------------------------------------
+
+export async function refreshProjectRepoStatus(projectId: string): Promise<ProjectRepoStatusRecord> {
+  const { data, error } = await client().functions.invoke<ProjectRepoStatusRecord>(
+    "fetch-github-activity",
+    { body: { project_id: projectId } }
+  );
+  if (error) throw error;
+  if (!data) throw new Error("Edge function returned no data");
+  return data;
+}
+
+export async function setLabGithubPat(labId: string, pat: string): Promise<void> {
+  const { error } = await client().rpc("set_lab_github_pat", { p_lab_id: labId, p_pat: pat });
+  if (error) throw error;
+}
+
+export async function clearLabGithubPat(labId: string): Promise<void> {
+  const { error } = await client().rpc("clear_lab_github_pat", { p_lab_id: labId });
+  if (error) throw error;
+}
+
+export async function labGithubPatConfigured(labId: string): Promise<boolean> {
+  const { data, error } = await client().rpc("lab_github_pat_configured", { p_lab_id: labId });
+  if (error) throw error;
+  return Boolean(data);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/project-manager/src/lib/useProjectWorkspace.ts
+++ b/apps/project-manager/src/lib/useProjectWorkspace.ts
@@ -1,19 +1,23 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   approveProject as rpcApproveProject,
+  clearLabGithubPat as rpcClearLabGithubPat,
   createExperiment as rpcCreateExperiment,
   createMilestone as rpcCreateMilestone,
   createProjectDraft as rpcCreateProjectDraft,
   deleteExperiment as rpcDeleteExperiment,
   deleteMilestone as rpcDeleteMilestone,
+  labGithubPatConfigured as rpcLabGithubPatConfigured,
   listDeletedProjects,
   listProjectWorkspace,
   permanentDeleteProject as rpcPermanentDeleteProject,
+  refreshProjectRepoStatus as rpcRefreshProjectRepoStatus,
   reorderExperiments as rpcReorderExperiments,
   reorderMilestones as rpcReorderMilestones,
   recycleProject as rpcRecycleProject,
   rejectProject as rpcRejectProject,
   restoreProject as rpcRestoreProject,
+  setLabGithubPat as rpcSetLabGithubPat,
   submitProjectForReview as rpcSubmitProjectForReview,
   updateExperiment as rpcUpdateExperiment,
   updateMilestone as rpcUpdateMilestone,
@@ -25,6 +29,7 @@ import {
   type MilestoneStatus,
   type ProjectLeadLinkRecord,
   type ProjectRecord,
+  type ProjectRepoStatusRecord,
   type ProjectStatus,
   type ProjectWorkspaceSnapshot,
   type ProtocolOptionRecord,
@@ -58,7 +63,14 @@ export interface UseProjectWorkspaceValue extends ProjectWorkspaceSnapshot {
     description?: string;
     status?: string;
     approvalRequired: boolean;
+    githubRepoUrl?: string | null;
   }) => Promise<ProjectRecord>;
+
+  refreshRepoStatus: (projectId: string) => Promise<ProjectRepoStatusRecord>;
+  setLabGithubPat: (pat: string) => Promise<void>;
+  clearLabGithubPat: () => Promise<void>;
+  refreshLabGithubPatConfigured: () => Promise<void>;
+  labGithubPatConfigured: boolean;
 
   createMilestone: (args: {
     projectId: string;
@@ -115,6 +127,8 @@ export function useProjectWorkspace(
   const [protocols, setProtocols] = useState<ProtocolOptionRecord[]>(EMPTY_ARRAY);
   const [leads, setLeads] = useState<ProjectLeadLinkRecord[]>(EMPTY_ARRAY);
   const [deletedProjects, setDeletedProjects] = useState<ProjectRecord[]>(EMPTY_ARRAY);
+  const [repoStatuses, setRepoStatuses] = useState<ProjectRepoStatusRecord[]>(EMPTY_ARRAY);
+  const [labGithubPatConfigured, setLabGithubPatConfiguredState] = useState<boolean>(false);
 
   const hydrate = useCallback(async () => {
     if (!labId) {
@@ -124,6 +138,8 @@ export function useProjectWorkspace(
       setProtocols(EMPTY_ARRAY);
       setLeads(EMPTY_ARRAY);
       setDeletedProjects(EMPTY_ARRAY);
+      setRepoStatuses(EMPTY_ARRAY);
+      setLabGithubPatConfiguredState(false);
       setStatus("idle");
       setError(null);
       return;
@@ -138,6 +154,13 @@ export function useProjectWorkspace(
       setExperiments(next.experiments);
       setProtocols(next.protocols);
       setLeads(next.leads);
+      setRepoStatuses(next.repoStatuses ?? EMPTY_ARRAY);
+      try {
+        setLabGithubPatConfiguredState(await rpcLabGithubPatConfigured(labId));
+      } catch {
+        // RPC missing or PAT read failed — treat as "not configured" and carry on.
+        setLabGithubPatConfiguredState(false);
+      }
       if (isAdmin) {
         try {
           const deleted = await listDeletedProjects(labId);
@@ -282,6 +305,40 @@ export function useProjectWorkspace(
     await hydrate();
   }, [hydrate, requireIdentity]);
 
+  const refreshRepoStatus = useCallback<UseProjectWorkspaceValue["refreshRepoStatus"]>(async (projectId) => {
+    requireIdentity();
+    const next = await rpcRefreshProjectRepoStatus(projectId);
+    setRepoStatuses((prev) => {
+      const without = prev.filter((row) => row.project_id !== projectId);
+      return [...without, next];
+    });
+    return next;
+  }, [requireIdentity]);
+
+  const setLabGithubPat = useCallback<UseProjectWorkspaceValue["setLabGithubPat"]>(async (pat) => {
+    const { labId: lab } = requireIdentity();
+    await rpcSetLabGithubPat(lab, pat);
+    setLabGithubPatConfiguredState(true);
+  }, [requireIdentity]);
+
+  const clearLabGithubPat = useCallback<UseProjectWorkspaceValue["clearLabGithubPat"]>(async () => {
+    const { labId: lab } = requireIdentity();
+    await rpcClearLabGithubPat(lab);
+    setLabGithubPatConfiguredState(false);
+  }, [requireIdentity]);
+
+  const refreshLabGithubPatConfigured = useCallback<UseProjectWorkspaceValue["refreshLabGithubPatConfigured"]>(async () => {
+    if (!labId) {
+      setLabGithubPatConfiguredState(false);
+      return;
+    }
+    try {
+      setLabGithubPatConfiguredState(await rpcLabGithubPatConfigured(labId));
+    } catch {
+      setLabGithubPatConfiguredState(false);
+    }
+  }, [labId]);
+
   return {
     status,
     error,
@@ -290,8 +347,14 @@ export function useProjectWorkspace(
     experiments,
     protocols,
     leads,
+    repoStatuses,
     deletedProjects,
+    labGithubPatConfigured,
     refresh: hydrate,
+    refreshRepoStatus,
+    setLabGithubPat,
+    clearLabGithubPat,
+    refreshLabGithubPatConfigured,
     createProjectDraft,
     withdrawProjectDraft,
     approveProject,

--- a/apps/project-manager/src/styles.css
+++ b/apps/project-manager/src/styles.css
@@ -408,6 +408,36 @@ a { color: inherit; }
   margin-top: 0.2rem;
 }
 
+.pm-library-card { position: relative; }
+.pm-library-card-repo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  position: absolute;
+  right: 0.8rem;
+  bottom: 0.6rem;
+  font-size: 0.72rem;
+  color: var(--pm-muted);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid var(--pm-line);
+}
+.pm-library-card-repo .pm-repo-link {
+  color: inherit;
+  text-decoration: none;
+}
+.pm-library-card-repo .pm-repo-link:hover { text-decoration: underline; }
+.pm-library-card-repo .pm-text-button {
+  padding: 0 0.25rem;
+  line-height: 1;
+  font-size: 0.8rem;
+}
+.pm-library-card-repo-muted {
+  opacity: 0.65;
+  font-style: italic;
+}
+
 /* =========================================================
    State + status tags
 ========================================================= */

--- a/docs/features.md
+++ b/docs/features.md
@@ -55,6 +55,7 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - Recycle bin for published projects; withdraw for drafts.
 - Experiments link to protocols; `completedAt >= startedAt` is validated client-side.
 - Personnel tab shows `ProjectLeadsPanel` and the roster. Lab-wide owner settings now live in the Account app.
+- **GitHub repo link per project**: optional `github_repo_url` on projects, editable from the Edit tab. Library cards show "last push {relative time}" in the bottom-right corner when a repo is linked, with a one-click refresh button. Status is cached in `project_repo_status` and fetched on demand by the `fetch-github-activity` edge function using a lab-scoped PAT (admin-managed, stored service-role-only on `labs.github_pat`, never sent to the browser).
 
 ## Audit & security
 

--- a/supabase/functions/fetch-github-activity/index.ts
+++ b/supabase/functions/fetch-github-activity/index.ts
@@ -1,0 +1,206 @@
+// Edge function: fetch-github-activity
+//
+// Input:  POST { project_id: string }
+// Output: { pushed_at, default_branch, html_url, fetched_at, error? }
+//
+// Flow:
+//   1. Verify the caller's JWT via the anon client; read the project row
+//      through RLS so non-members can't trigger fetches.
+//   2. Parse owner/repo from projects.github_repo_url.
+//   3. Read labs.github_pat via the service-role client (bypasses RLS and
+//      column grants).
+//   4. Call GitHub REST `GET /repos/{owner}/{repo}` with the PAT.
+//   5. Upsert into project_repo_status and return the row to the caller.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+type RepoIdent = { owner: string; repo: string };
+
+function parseRepoUrl(input: string | null | undefined): RepoIdent | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // https://github.com/OWNER/REPO(.git)(/...)
+  const httpsMatch = trimmed.match(/^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s#?]+?)(?:\.git)?(?:[/#?].*)?$/i);
+  if (httpsMatch) return { owner: httpsMatch[1], repo: httpsMatch[2] };
+
+  // git@github.com:OWNER/REPO(.git)
+  const sshMatch = trimmed.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i);
+  if (sshMatch) return { owner: sshMatch[1], repo: sshMatch[2] };
+
+  return null;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: CORS_HEADERS });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  const authHeader = req.headers.get("Authorization") ?? "";
+  if (!authHeader.toLowerCase().startsWith("bearer ")) {
+    return jsonResponse({ error: "Missing Authorization header" }, 401);
+  }
+
+  let body: { project_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
+  }
+  const projectId = body.project_id?.trim();
+  if (!projectId) {
+    return jsonResponse({ error: "project_id required" }, 400);
+  }
+
+  // 1. Caller-scoped read of the project (RLS enforces lab membership).
+  const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const projectResult = await userClient
+    .from("projects")
+    .select("id, lab_id, github_repo_url")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectResult.error) {
+    return jsonResponse({ error: projectResult.error.message }, 400);
+  }
+  if (!projectResult.data) {
+    return jsonResponse({ error: "Project not found or not accessible" }, 404);
+  }
+
+  const { lab_id: labId, github_repo_url: repoUrl } = projectResult.data as {
+    id: string;
+    lab_id: string;
+    github_repo_url: string | null;
+  };
+
+  const ident = parseRepoUrl(repoUrl);
+
+  // Service-role client for PAT read + status upsert.
+  const adminClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const upsertStatus = async (fields: {
+    pushed_at?: string | null;
+    default_branch?: string | null;
+    html_url?: string | null;
+    error?: string | null;
+  }) => {
+    const now = new Date().toISOString();
+    const { data, error } = await adminClient
+      .from("project_repo_status")
+      .upsert(
+        {
+          project_id: projectId,
+          lab_id: labId,
+          pushed_at: fields.pushed_at ?? null,
+          default_branch: fields.default_branch ?? null,
+          html_url: fields.html_url ?? null,
+          error: fields.error ?? null,
+          fetched_at: now,
+        },
+        { onConflict: "project_id" }
+      )
+      .select("project_id, lab_id, pushed_at, default_branch, html_url, error, fetched_at, updated_at")
+      .single();
+    if (error) throw error;
+    return data;
+  };
+
+  if (!ident) {
+    try {
+      const row = await upsertStatus({ error: "Invalid or missing GitHub repo URL" });
+      return jsonResponse(row);
+    } catch (err) {
+      return jsonResponse({ error: (err as Error).message }, 500);
+    }
+  }
+
+  // 3. Pull PAT via service role.
+  const labResult = await adminClient
+    .from("labs")
+    .select("github_pat")
+    .eq("id", labId)
+    .maybeSingle();
+
+  if (labResult.error) {
+    return jsonResponse({ error: labResult.error.message }, 500);
+  }
+  const pat = (labResult.data?.github_pat as string | null | undefined)?.trim();
+  if (!pat) {
+    try {
+      const row = await upsertStatus({ error: "Lab GitHub PAT not configured" });
+      return jsonResponse(row, 200);
+    } catch (err) {
+      return jsonResponse({ error: (err as Error).message }, 500);
+    }
+  }
+
+  // 4. GitHub REST call.
+  let pushedAt: string | null = null;
+  let defaultBranch: string | null = null;
+  let htmlUrl: string | null = null;
+  let ghError: string | null = null;
+
+  try {
+    const ghResp = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(ident.owner)}/${encodeURIComponent(ident.repo)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${pat}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "ilm-fetch-github-activity",
+        },
+      }
+    );
+    if (!ghResp.ok) {
+      const text = await ghResp.text();
+      ghError = `GitHub ${ghResp.status}: ${text.slice(0, 200)}`;
+    } else {
+      const payload = await ghResp.json();
+      pushedAt = typeof payload.pushed_at === "string" ? payload.pushed_at : null;
+      defaultBranch = typeof payload.default_branch === "string" ? payload.default_branch : null;
+      htmlUrl = typeof payload.html_url === "string" ? payload.html_url : null;
+    }
+  } catch (err) {
+    ghError = `Fetch failed: ${(err as Error).message}`;
+  }
+
+  try {
+    const row = await upsertStatus({
+      pushed_at: pushedAt,
+      default_branch: defaultBranch,
+      html_url: htmlUrl,
+      error: ghError,
+    });
+    return jsonResponse(row);
+  } catch (err) {
+    return jsonResponse({ error: (err as Error).message }, 500);
+  }
+});

--- a/supabase/migrations/20260429000000_project_github_integration.sql
+++ b/supabase/migrations/20260429000000_project_github_integration.sql
@@ -1,0 +1,136 @@
+-- Stage 4a.1 — GitHub repo link per project + lab-scoped PAT + cached repo status.
+--
+-- Projects gain an optional `github_repo_url`. Each lab can store a single
+-- GitHub Personal Access Token (fine-grained, read-only on the relevant repos)
+-- that the edge function `fetch-github-activity` uses to pull `pushed_at` from
+-- the GitHub API. The PAT is never exposed to the browser — the column is only
+-- readable by `service_role`. A per-project cache table (`project_repo_status`)
+-- holds the last fetched timestamp; lab members read it, only the edge function
+-- (via service role) writes it.
+
+-- ---------------------------------------------------------------------------
+-- Projects: github_repo_url
+-- ---------------------------------------------------------------------------
+
+alter table public.projects
+  add column if not exists github_repo_url text;
+
+-- ---------------------------------------------------------------------------
+-- Labs: github_pat (service-role only)
+-- ---------------------------------------------------------------------------
+
+alter table public.labs
+  add column if not exists github_pat text;
+
+comment on column public.labs.github_pat is
+  'Shared GitHub PAT used by the fetch-github-activity edge function. '
+  'Readable only by service_role; writable only via set_lab_github_pat RPC.';
+
+-- Revoke PAT visibility from authenticated users. Reads/writes on labs via
+-- existing RLS policies should never expose this column because those policies
+-- select explicit columns — but as defense-in-depth we add a column-level
+-- restriction: authenticated users cannot SELECT/UPDATE github_pat directly.
+revoke select (github_pat) on public.labs from authenticated, anon;
+revoke update (github_pat) on public.labs from authenticated, anon;
+
+-- ---------------------------------------------------------------------------
+-- RPC: admin-only PAT management
+-- ---------------------------------------------------------------------------
+
+create or replace function public.set_lab_github_pat(
+  p_lab_id uuid,
+  p_pat text
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_lab_admin(p_lab_id) then
+    raise exception 'Only lab admins can set the GitHub PAT.'
+      using errcode = '42501';
+  end if;
+  if p_pat is null or length(btrim(p_pat)) = 0 then
+    raise exception 'PAT cannot be empty. Use clear_lab_github_pat to remove it.'
+      using errcode = '22023';
+  end if;
+  update public.labs set github_pat = btrim(p_pat) where id = p_lab_id;
+end;
+$$;
+
+revoke all on function public.set_lab_github_pat(uuid, text) from public;
+grant execute on function public.set_lab_github_pat(uuid, text) to authenticated;
+
+create or replace function public.clear_lab_github_pat(p_lab_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_lab_admin(p_lab_id) then
+    raise exception 'Only lab admins can clear the GitHub PAT.'
+      using errcode = '42501';
+  end if;
+  update public.labs set github_pat = null where id = p_lab_id;
+end;
+$$;
+
+revoke all on function public.clear_lab_github_pat(uuid) from public;
+grant execute on function public.clear_lab_github_pat(uuid) to authenticated;
+
+create or replace function public.lab_github_pat_configured(p_lab_id uuid)
+returns boolean
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  has_pat boolean;
+begin
+  if not public.is_lab_member(p_lab_id) then
+    return false;
+  end if;
+  select github_pat is not null and length(btrim(github_pat)) > 0
+    into has_pat
+    from public.labs
+    where id = p_lab_id;
+  return coalesce(has_pat, false);
+end;
+$$;
+
+revoke all on function public.lab_github_pat_configured(uuid) from public;
+grant execute on function public.lab_github_pat_configured(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- project_repo_status — per-project cache of GitHub activity
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.project_repo_status (
+  project_id uuid primary key references public.projects(id) on delete cascade,
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  pushed_at timestamptz,
+  default_branch text,
+  html_url text,
+  error text,
+  fetched_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists project_repo_status_lab_id_idx
+  on public.project_repo_status (lab_id);
+
+drop trigger if exists project_repo_status_set_updated_at on public.project_repo_status;
+create trigger project_repo_status_set_updated_at
+before update on public.project_repo_status
+for each row execute function public.set_updated_at();
+
+alter table public.project_repo_status enable row level security;
+
+drop policy if exists project_repo_status_select_member on public.project_repo_status;
+create policy project_repo_status_select_member on public.project_repo_status
+  for select using (public.is_lab_member(lab_id));
+
+-- No INSERT/UPDATE/DELETE policies: writes go through the fetch-github-activity
+-- edge function using service_role, which bypasses RLS.


### PR DESCRIPTION
## Summary
- Projects carry an optional `github_repo_url`; library cards render a "last push {relative}" pill in the bottom-right with a refresh button.
- Lab admins configure a shared fine-grained PAT (stored service-role-only on `labs.github_pat`); a new `fetch-github-activity` edge function uses it to pull `pushed_at` from GitHub and cache it in `project_repo_status`.
- Without a PAT, cards show "GitHub monitor unavailable — no lab PAT" and the app otherwise runs normally.

## Test plan
- [ ] Apply migration `20260429000000_project_github_integration.sql` and deploy `fetch-github-activity` edge function.
- [ ] As a lab admin, open Project Manager → Library → GitHub integration → paste a fine-grained PAT.
- [ ] Edit a project, paste a private GitHub repo URL, save.
- [ ] Verify the card shows "last push Xd ago" after clicking ↻.
- [ ] Clear the PAT; confirm the pill shows the "unavailable" message and app still loads.
- [ ] Verify non-admins cannot see the GitHub integration section and cannot call `set_lab_github_pat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)