### PR TITLE
Use npm: specifier for supabase-js in edge function

### DIFF
--- a/supabase/functions/fetch-github-activity/index.ts
+++ b/supabase/functions/fetch-github-activity/index.ts
@@ -12,7 +12,7 @@
 //   4. Call GitHub REST `GET /repos/{owner}/{repo}` with the PAT.
 //   5. Upsert into project_repo_status and return the row to the caller.
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2.45.0";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";


### PR DESCRIPTION
The esm.sh URL was failing to load in Supabase's edge runtime, causing the worker to crash on boot (500 on every request, including OPTIONS preflight). Switching to npm:@supabase/supabase-js@2 uses the runtime's built-in npm resolver and boots reliably.