### PR TITLE
Align stage numbering across docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,12 @@ singularity exec --bind /mnt/isilon/wang_lab/zac/projects/ILM:/work docker://nod
 singularity exec --bind /mnt/isilon/wang_lab/zac/projects/ILM:/work docker://node:24-slim sh -c "cd /work && npm run dev"
 ```
 
-## Supabase Migration Plan (in-flight, 2026-04)
+## Supabase Migration (Stage 4c — Supply Manager next)
 
-Migrating ILM from browser-only storage (localStorage) to Supabase Postgres +
-Supabase Auth, while keeping the frontend deployable to GitHub Pages (no custom
-backend). Auth model: each user has a personal account; users belong to one or
-more shared `labs` via `lab_memberships`; all data is scoped to a lab and
-protected by RLS.
+ILM has moved from browser-only storage to Supabase Postgres + Supabase Auth,
+while staying deployable to GitHub Pages (no custom backend). Auth model: each
+user has a personal account; users belong to one or more shared `labs` via
+`lab_memberships`; all data is scoped to a lab and protected by RLS.
 
 ### Data model
 
@@ -68,38 +67,33 @@ Relational tables (preferred for structured data):
 - `profiles` — one row per `auth.users` user (display_name, email)
 - `labs` — shared workspace (name, slug, created_by)
 - `lab_memberships` — (lab_id, user_id, role in {owner,admin,member})
-- `projects` — lab-scoped projects (name, description, status)
-- `protocols` — lab-scoped protocol records, structured columns +
-  `document_json jsonb` for the protocol body. `document_json` is the ONLY
-  jsonb payload; other domains (projects, supply, funding) should use
-  normalized columns.
+- `projects` — lab-scoped projects (name, description, status) + milestones, experiments, project_leads
+- `protocols` — lab-scoped, structured columns + `document_json jsonb` for
+  the protocol body. `document_json` is the ONLY jsonb payload; other domains
+  (projects, supply, funding) use normalized columns.
 - `protocol_revisions` — append-only snapshot of protocol `document_json`
 
 RLS on all tables; authorization driven by `lab_memberships`, never by
 user-editable metadata or frontend checks.
 
-### Staged implementation
+### Stage status
 
-**Stage 1 — Foundation (current)**
-- `supabase/migrations/` with schema, triggers (`updated_at`), RLS policies
-- `packages/utils` exposes a Supabase browser client reading
-  `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` (fail loudly if missing)
-- Root README / docs: how to create a Supabase project, env var setup,
-  GitHub Pages deployment notes, service-role key warning
-- No runtime wiring of the client into apps yet
+**Done**
+- **Stage 1 — Foundation**: migrations, RLS, Supabase client in `packages/utils`, env/deploy docs.
+- **Stage 2 — Auth shell**: sign in/up/out, `AuthProvider`, protected routes, lab picker + create-lab onboarding.
+- **Stage 3 — Protocol Manager**: visual editor, draft → submit → review → publish, append-only revisions, recycle bin.
+- **Stage 4a — Account app**: dedicated `/account/` app, tier hierarchy (owner > admin > member), invitations + join requests, share links, auto-claim.
+- **Stage 4b — Project Manager**: projects/milestones/experiments, project leads, review gate, recycle bin, GitHub repo activity per project.
 
-**Stage 2 — Auth shell**
-- `packages/ui`: auth screens (sign up, sign in, sign out, password reset),
-  `AuthProvider` + session state, protected-route wrapper
-- Lab selection + "create lab" onboarding (creator becomes `owner`)
-- Zero-lab / multi-lab / single-lab auto-open behavior
-- Invitations remain dashboard-admin only for now
+**Current**
+- **Stage 4c — Supply Manager**: stock + orders + storage locations. See `docs/next-stage.md`.
 
-**Living docs**
-- `docs/features.md` — cumulative summary of what's shipped (update after each
-  meaningful PR).
-- `docs/next-stage.md` — current planned next stage (rewrite when priorities
-  change). Read this before starting a new session.
+**Deferred**
+- **Stage 4d — Funding Manager**: grants / budgets / allocations / expenses.
+
+### Living docs
+- `docs/features.md` — cumulative summary of what's shipped. Update after each meaningful PR.
+- `docs/next-stage.md` — current planned next stage. Rewrite when priorities change. Read before starting a new session.
 
 ### Non-negotiables
 - Static frontend only; no custom backend server

--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@ Integrated Lab Manager is a modular monorepo for structured lab operations softw
 
 ## Current status
 
-Two apps are production-ready on Supabase with RLS-enforced, review-gated workflows:
+Three apps are production-ready on Supabase with RLS-enforced workflows:
 
-- **Protocol Manager** (Stage 3b) — visual protocol designer with typed steps, draft → submit → review → publish flow, append-only revisions, and a 30-day recycle bin.
-- **Project Manager** (Stage 4a) — project lifecycle with milestones, experiments, roadmap drag-reorder, project leads, and the same review-gated publish flow.
+- **Protocol Manager** (Stage 3) — visual protocol designer with typed steps, draft → submit → review → publish flow, append-only revisions, and a 30-day recycle bin.
+- **Account** (Stage 4a) — dedicated `/account/` app for profile, lab membership, invitations, join requests, and share links. Strict tier hierarchy (owner > admin > member).
+- **Project Manager** (Stage 4b) — project lifecycle with milestones, experiments, roadmap drag-reorder, project leads, review-gated publish flow, and per-project GitHub repo activity.
 
-**Funding Manager** and **Supply Manager** are scaffolded shells (auth + lab switcher + members panel) awaiting Stage 4b/4c schema design.
+**Supply Manager** (Stage 4c) is the current in-flight stage — see [`docs/next-stage.md`](docs/next-stage.md). **Funding Manager** (Stage 4d) is deferred. Both are scaffolded auth shells today.
 
 ## Monorepo layout
 
 ```text
 integrated-lab-manager/
 ├─ apps/
-│  ├─ protocol-manager/      # Stage 3b — production
-│  ├─ project-manager/       # Stage 4a — production
-│  ├─ supply-manager/        # Stage 4c — stub (auth shell only)
-│  └─ funding-manager/       # Stage 4b — stub (auth shell only)
+│  ├─ protocol-manager/      # Stage 3  — production
+│  ├─ account/               # Stage 4a — production
+│  ├─ project-manager/       # Stage 4b — production
+│  ├─ supply-manager/        # Stage 4c — in flight (auth shell only)
+│  └─ funding-manager/       # Stage 4d — deferred (auth shell only)
 ├─ packages/
 │  ├─ ai-import/             # AI import instructions + helpers
 │  ├─ types/                 # shared protocol TypeScript model

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,18 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - **Self-serve join flow**: `lab_join_requests` table + `request_lab_join` / `approve_lab_join` / `reject_lab_join` / `cancel_lab_join` / `lookup_lab_by_id` RPCs. Rejection requires a comment; one pending request per user per lab.
 - **LabPicker empty state**: create-new-lab or paste-invite-link.
 
-## Account app (`apps/account`) — complete
+## Protocol Manager (Stage 3 — production)
+
+- Visual protocol editor with typed steps (reagent, instrument, parameter, observation, wait, decision).
+- Draft → submit → review → publish flow. Drafts are per-user (`protocol_drafts`), submissions are frozen snapshots (`protocol_submissions`), published copies live in `protocols`, append-only `protocol_revisions` on approval.
+- Projects carry `approval_required`; the auto-created "General" project publishes immediately on submit.
+- Hard delete with 30-day recycle bin (`protocols.deleted_at`).
+- Per-draft `submission_history` log, opened from a script-size link left of the Summary tab (drafts only).
+- Reviewer rejection requires a non-empty comment; submitter comment on submit is optional.
+- localStorage → cloud migration banner for pre-Supabase data.
+- Save-draft button becomes an "Autosaved" caption while editing an existing draft; it stays as an explicit commit button when editing on top of a published protocol.
+
+## Account app (Stage 4a — production)
 
 - Dedicated app at `/account/`, reachable by clicking the login status box in any other app.
 - **Flat two-panel layout**: left sidebar with profile, active lab tier (owner / admin / member) + capability blurb, project counts, and a "Join or create another lab…" shortcut that reopens `LabPicker` without clearing the current active lab. Right main area with tabbed Lab Management (Members / Invitations & Requests).
@@ -35,18 +46,7 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - **Real-time badge updates**: role changes refresh both the members roster and the `AuthProvider` labs array so the sidebar tier badge updates without a reload.
 - Shared `AccountLinkCard` in `@ilm/ui` renders the login status box consistently across placeholder apps (`funding-manager`, `supply-manager`).
 
-## Protocol Manager (Stage 3b — production)
-
-- Visual protocol editor with typed steps (reagent, instrument, parameter, observation, wait, decision).
-- Draft → submit → review → publish flow. Drafts are per-user (`protocol_drafts`), submissions are frozen snapshots (`protocol_submissions`), published copies live in `protocols`, append-only `protocol_revisions` on approval.
-- Projects carry `approval_required`; the auto-created "General" project publishes immediately on submit.
-- Hard delete with 30-day recycle bin (`protocols.deleted_at`).
-- Per-draft `submission_history` log, opened from a script-size link left of the Summary tab (drafts only).
-- Reviewer rejection requires a non-empty comment; submitter comment on submit is optional.
-- localStorage → cloud migration banner for pre-Supabase data.
-- Save-draft button becomes an "Autosaved" caption while editing an existing draft; it stays as an explicit commit button when editing on top of a published protocol.
-
-## Project Manager (Stage 4a — production)
+## Project Manager (Stage 4b — production)
 
 - Projects, milestones, experiments; drag-reorder roadmap with 1024-gap `sort_order`.
 - Project leads (`project_leads`) independent of admin role.
@@ -64,5 +64,6 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 
 ## Known gaps (see `next-stage.md`)
 
-- `funding-manager` and `supply-manager` are auth-shell stubs with no schema or adapter.
+- `supply-manager` (Stage 4c) is the current in-flight stage — auth-shell stub today, schema + adapter + screens still to build.
+- `funding-manager` (Stage 4d) is deferred — auth-shell stub with no schema or adapter.
 - Share-link token is a raw lab UUID; a rotatable HMAC token is a deferred follow-up.

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,9 +4,9 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage: Supply Manager — stock + orders (Stage 4b)
+## Stage: Supply Manager — stock + orders (Stage 4c)
 
-**Why now.** Account app is done. Day-to-day bench work depends on knowing what reagents/consumables are on hand and what's on order; funding/accounting can wait. Supply is also a prerequisite for linking experiments to actual consumption. The `supply-manager` app is currently an auth shell with no schema.
+**Why now.** Protocol Manager (Stage 3), Account (Stage 4a), and Project Manager (Stage 4b) are in production. Day-to-day bench work depends on knowing what reagents/consumables are on hand and what's on order; funding/accounting (Stage 4d) can wait. Supply is also a prerequisite for linking experiments to actual consumption. The `supply-manager` app is currently an auth shell with no schema.
 
 **Scope for this stage.** Three capabilities:
 
@@ -53,7 +53,7 @@ Tabs in `apps/supply-manager`:
 
 - Register `supply-manager` build in `.github/workflows/deploy-protocol-manager-pages.yml`.
 - Mount `AccountLinkCard` in the supply-manager shell (already present in the stub — just ensure it survives the rewrite).
-- Update `docs/features.md` with a "Supply Manager (Stage 4b)" section on ship.
+- Update `docs/features.md` with a "Supply Manager (Stage 4c)" section on ship.
 
 ### Tradeoffs
 
@@ -65,7 +65,7 @@ Tabs in `apps/supply-manager`:
 
 ## After this stage
 
-- **Stage 4c — Supply Manager v2.** Per-receipt lot/expiry tracking, supplier/catalog import, per-experiment consumption logging (links `experiments` to `stock_movements`).
 - **Stage 4d — Funding Manager.** `grants / budgets / allocations / expenses` with RLS + SECURITY DEFINER RPCs + audit. Takes over the experimental expense fields currently on `projects`. Deferred because accounting is not blocking day-to-day lab use.
+- **Stage 4e — Supply Manager v2.** Per-receipt lot/expiry tracking, supplier/catalog import, per-experiment consumption logging (links `experiments` to `stock_movements`).
 - **Rotatable share-link token.** Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in the share-link section would make leaked links revocable.
 - **Deferred housekeeping.** Fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.


### PR DESCRIPTION
## Summary
- Reconcile stage labels across `CLAUDE.md`, `README.md`, `docs/features.md`, and `docs/next-stage.md` so they agree on what's shipped and what's next.
- Canonical map: **Stage 3** Protocol Manager · **4a** Account · **4b** Project Manager · **4c** Supply Manager (current) · **4d** Funding Manager (deferred).
- `CLAUDE.md` no longer describes Stage 1 Foundation as "current"; it now lists Stages 1–4b as done, 4c in flight, 4d deferred.
- `features.md` gains the missing Protocol Manager + Account stage labels and renumbers Project Manager 4a → 4b.
- `next-stage.md` retargets Supply Manager as Stage 4c, promotes Funding Manager to the immediate follow-up, pushes Supply v2 to 4e.

## Why
Previous docs disagreed on numbering (e.g. README called Funding 4b and Supply 4c, while next-stage.md used 4b for Supply and 4d for Funding). With Protocol + Project Manager migrations finished and Supply Manager about to start, a fresh session reading these files would get an inconsistent picture of progress.

## Test plan
- [x] Stage labels agree across all four files
- [ ] Reviewer sanity-checks that Protocol (3), Account (4a), Project (4b) match actual shipped state

🤖 Generated with [Claude Code](https://claude.com/claude-code)