### PR TITLE
Draft shared UI kit plan, sequence before Supply Manager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Docs
 
-Two living documents:
+Living documents:
 
 - [`features.md`](features.md) — cumulative summary of what's shipped. Update after each PR that lands meaningful functionality.
 - [`next-stage.md`](next-stage.md) — the current planned next stage. Rewrite when priorities change.
+- [`ui-alignment.md`](ui-alignment.md) — shared design-system plan for `@ilm/ui` (tokens, primitives, app shell). Drives the UI kit work scheduled before Supply Manager.
 
 Historical stage plans and reviews are not kept here — the git log is the archive.

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,9 +4,27 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage: Supply Manager — stock + orders (Stage 4c)
+## Stage 4c-pre: Shared UI kit (before Supply Manager)
 
-**Why now.** Protocol Manager (Stage 3), Account (Stage 4a), and Project Manager (Stage 4b) are in production. Day-to-day bench work depends on knowing what reagents/consumables are on hand and what's on order; funding/accounting (Stage 4d) can wait. Supply is also a prerequisite for linking experiments to actual consumption. The `supply-manager` app is currently an auth shell with no schema.
+**Why now.** Protocol, Project, and Account each grew their own `styles.css` (2810 / 1060 / 454 lines). Tokens are already shared via `packages/ui/src/tokens.css`, but every app aliases them under a different prefix and reimplements the same button / card / tab / table / modal patterns. Building Supply Manager on this as-is would mean another 1000-line copy-paste or visual drift. Do the foundation first so Supply is built *on* the kit, not retrofitted later.
+
+**Scope.** Phases A + B + C from [`ui-alignment.md`](ui-alignment.md):
+
+- **Phase A — Token hygiene** (~0.5 day): delete per-app alias vars (`--ilm-*`, `--pm-*`, `--acct-*`), use `--rl-*` directly; codify radii / shadows / spacing / z-index into `tokens.css`; add `@ilm/ui/reset.css` for shared boilerplate.
+- **Phase B — Primitives** (~1–2 days): extract `Button`, `Input/Textarea/Select/FormField`, `Card/Panel/SectionHeader`, `Tabs`, `Modal/Drawer/ConfirmDialog`, `Table`, `Badge/Tag/StatusPill`, `EmptyState/ErrorBanner/InlineToast` from Protocol Manager into `@ilm/ui/primitives/`. Each exposes `className` pass-through + CSS-var variant slots for extension.
+- **Phase C — AppShell** (~0.5 day): single `<AppShell>` owning top bar (lab switcher + `AppSwitcher` + `AccountLinkCard`), page container, nav slot. Collapse the per-app variants.
+
+Phases D (migrate Account / Project / Protocol) and E (docs) are deferred until after Supply Manager ships — the kit gets battle-tested on Supply first, then the legacy apps migrate.
+
+**Exit criteria.** Supply Manager's screens can be built without re-implementing any primitive that's already in the kit (buttons, cards, modals, tabs, tables, badges, inputs). App-specific *compositions* are fine — e.g. the Storage tab's location tree view lives in `apps/supply-manager` on first use, following the "first use local, second use promote" rule from [`ui-alignment.md`](ui-alignment.md).
+
+See [`ui-alignment.md`](ui-alignment.md) for the full plan, extension contract, and re-skinning story.
+
+---
+
+## Stage 4c: Supply Manager — stock + orders
+
+**Why now.** Protocol Manager (Stage 3), Account (Stage 4a), and Project Manager (Stage 4b) are in production. Day-to-day bench work depends on knowing what reagents/consumables are on hand and what's on order; funding/accounting (Stage 4d) can wait. Supply is also a prerequisite for linking experiments to actual consumption. The `supply-manager` app is currently an auth shell with no schema. **Built on top of the shared UI kit from Stage 4c-pre** — no new one-off component CSS.
 
 **Scope for this stage.** Three capabilities:
 
@@ -52,7 +70,7 @@ Tabs in `apps/supply-manager`:
 ### Step 4 — Deployment + docs
 
 - Register `supply-manager` build in `.github/workflows/deploy-protocol-manager-pages.yml`.
-- Mount `AccountLinkCard` in the supply-manager shell (already present in the stub — just ensure it survives the rewrite).
+- Wrap the app in `<AppShell>` from `@ilm/ui` (introduced in Stage 4c-pre Phase C). `AppShell` already owns the top bar, `AppSwitcher`, and `AccountLinkCard` — don't mount them separately.
 - Update `docs/features.md` with a "Supply Manager (Stage 4c)" section on ship.
 
 ### Tradeoffs
@@ -65,6 +83,7 @@ Tabs in `apps/supply-manager`:
 
 ## After this stage
 
+- **UI kit Phases D + E.** Migrate Account / Project / Protocol onto the shared primitives; write `packages/ui/README.md` + `docs/design-system.md`. See [`ui-alignment.md`](ui-alignment.md).
 - **Stage 4d — Funding Manager.** `grants / budgets / allocations / expenses` with RLS + SECURITY DEFINER RPCs + audit. Takes over the experimental expense fields currently on `projects`. Deferred because accounting is not blocking day-to-day lab use.
 - **Stage 4e — Supply Manager v2.** Per-receipt lot/expiry tracking, supplier/catalog import, per-experiment consumption logging (links `experiments` to `stock_movements`).
 - **Rotatable share-link token.** Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in the share-link section would make leaked links revocable.

--- a/docs/ui-alignment.md
+++ b/docs/ui-alignment.md
@@ -1,0 +1,115 @@
+# UI alignment plan
+
+Shared design system for all ILM apps. Drafted 2026-04-23.
+
+## Why
+
+Protocol Manager, Project Manager, and Account each grew their own `styles.css` (2810 / 1060 / 454 lines). They already share `packages/ui/src/tokens.css` and the auth/admin shells, but every app reimplements the same button / card / tab / table / modal patterns and aliases shared tokens under a different prefix (`--ilm-*`, `--pm-*`, `--acct-*`). Building Supply Manager (Stage 4c) on this as-is guarantees either another 1000-line copy-paste or visual drift.
+
+## Goal
+
+Promote `@ilm/ui` into a real design system: tokens + reset + primitives + app shell. New apps compose from the shared kit instead of restyling. Future re-skins (e.g. importing a design from an AI tool) change `tokens.css` or swap a primitive, not every app.
+
+## Non-goals
+
+- Switching CSS strategy (Tailwind, CSS Modules, CSS-in-JS). Vanilla CSS + tokens works today; swapping is a separate decision.
+- Vendoring shadcn/Radix. Revisit only if a future design import demands it.
+- Exhaustive primitive coverage. Only extract patterns used in 2+ apps today or needed by Supply.
+
+## Starting point
+
+**Already shared (`packages/ui`):**
+- `tokens.css` — Rhine Lab palette, type scale, spacing (imported by every app).
+- `AuthProvider`, `AuthScreen`, `AuthGate`, `LabPicker` (+ `auth.css`).
+- `AccountLinkCard`, `AppSwitcher`, `SubmissionHistoryLink`.
+- Admin panels: `LabMembersPanel`, `LabJoinRequestsPanel`, `LabSettingsPanel`, `LabShareLinkPanel`, `ProjectLeadsPanel`.
+
+**Duplicated per app:**
+- Token alias layer (`--ilm-*`, `--pm-*`, `--acct-*` all point at the same `--rl-*`).
+- Reset boilerplate (box-sizing, body bg, focus ring, button reset).
+- Buttons, inputs, cards, tabs, tables, modals, badges, empty states.
+
+## Phases
+
+### Phase A — Token hygiene (~0.5 day)
+
+1. Delete per-app alias variables. Use `--rl-*` directly across all apps. Also reconcile the font-family drift (Protocol uses `var(--rl-font-sans)`, Project/Account hard-code `"Space Grotesk", Arial, sans-serif`) — all apps should read the token.
+2. Codify tokens that only exist inline today: radii, shadows, spacing scale, z-index layers, transition durations.
+3. Add `@ilm/ui/reset.css` for the shared boilerplate each app's `styles.css` opens with. Add `"./reset.css": "./src/reset.css"` to `packages/ui/package.json` exports (alongside the existing `./tokens.css` and `./auth.css`). Each app imports `tokens.css` + `reset.css`.
+
+**Payoff:** mechanical find-replace; makes Phase B primitives shareable without collisions.
+
+### Phase B — Extract primitives (~1–2 days)
+
+Source of truth: Protocol Manager (most mature, 2810 lines of CSS), cross-referenced against Project Manager where patterns differ — pick the better variant, don't pick Protocol by default. Add to `packages/ui/src/primitives/`, each with colocated CSS scoped under a single class prefix (`.rl-btn`, `.rl-card`):
+
+- `Button` — variants: primary / secondary / ghost / danger; sizes sm/md.
+- `Input`, `Textarea`, `Select`, `FormField` (label + error + helper).
+- `Card`, `Panel`, `SectionHeader`.
+- `Tabs`, `TabList`, `TabPanel`.
+- `Modal`, `Drawer`, `ConfirmDialog`.
+- `Table` (sticky header, empty state, loading row).
+- `Badge`, `Tag`, `StatusPill` (draft / submitted / published / rejected).
+- `EmptyState`, `ErrorBanner`, `InlineToast`.
+
+**Extension contract** — every primitive exposes:
+- `className` pass-through for ad-hoc overrides.
+- Variant slots backed by CSS custom properties (e.g. `--rl-btn-bg`, `--rl-btn-border`) so apps restyle without forking.
+
+### Phase C — Shared app shell (~0.5 day)
+
+Single `<AppShell>` in `@ilm/ui` owning:
+- Top bar: product name, lab switcher, `AppSwitcher`, `AccountLinkCard`.
+- Consistent page container (max-width, padding, breakpoints).
+- Slot for app-specific tabs/nav.
+
+Protocol, Project, Account each have their own variant today — collapse them.
+
+### Phase D — Migrate legacy apps
+
+Supply Manager is *not* part of this phase — it's built directly on A+B+C during Stage 4c and is the kit's first consumer. Phase D migrates the three pre-existing apps, ordered by risk:
+
+1. **Account** — 454 lines, smallest legacy surface.
+2. **Project Manager** — 1060 lines.
+3. **Protocol Manager** — 2810 lines, highest risk. Last.
+
+Each migration: replace app-local classes with primitives, delete dead CSS, visual parity check in browser.
+
+### Phase E — Document (~0.5 day)
+
+- `packages/ui/README.md` — primitive usage, props, do/don't.
+- `docs/design-system.md` — token reference, when to add a new primitive vs. extend one, the "first use local, second use promote" rule.
+- PR gate: no new one-off buttons/cards in app CSS.
+
+## Expandability
+
+Two questions come up whenever a new module is built or a new design is imported. Both are designed for.
+
+**Adding new elements (e.g. supply tables, quantity steppers).**
+- *Compose first.* A supply table = `<Table>` + `<StatusPill>` for stock + `<Button>` for row actions. No package change.
+- *Promote on second use.* Something genuinely new (e.g. `QuantityStepper`, `LocationTreeSelect`) stays local on first use; when a second app needs it, lift into `@ilm/ui/primitives/`. Keeps the shared package from becoming a junkyard.
+
+**Re-skinning to a different design (e.g. v0 / Figma Make / Claude Artifacts output).**
+- *Recolor/re-type whole system.* Edit `tokens.css`. Every primitive re-skins in one commit.
+- *Swap a primitive's shape/markup.* Replace the file under `@ilm/ui/primitives/`. Props stay stable, apps untouched.
+- *Full overhaul.* Fork tokens into a new theme file, flip an import. If the imported design assumes Tailwind / shadcn / Radix, decide at that point whether to port classes to CSS vars or vendor the dependency once in `@ilm/ui`.
+
+## Tradeoffs
+
+- **Do UI before Supply vs. ship Supply first.** Phases A+B+C land before Supply so it's built *on* the kit (including `<AppShell>`), not retrofitted. Cost: ~2–3 days of delay. Payoff: Supply's screens cost less and the kit is immediately battle-tested. Phases D+E defer until after Supply ships.
+- **Scope of Phase B.** Must be timeboxed — every pattern is extractable, but only patterns that have 2+ consumers today or are obviously needed by Supply belong in v1.
+- **CSS strategy.** Sticking with vanilla CSS + tokens is the path of least resistance. A Tailwind migration is possible later but shouldn't be coupled to this work.
+
+## Sizing
+
+| Phase | Effort |
+| --- | --- |
+| A — token hygiene | 0.5 day |
+| B — primitives | 1–2 days |
+| C — app shell | 0.5 day |
+| D — migrate Account | ~0.5 day |
+| D — migrate Project Manager | ~1 day |
+| D — migrate Protocol Manager | ~2 days |
+| E — docs | 0.5 day |
+
+Supply Manager (Stage 4c) is built on top of A+B+C, so it incurs no migration cost. Per-app estimates scale with `styles.css` line count and the depth of bespoke layout each app carries.


### PR DESCRIPTION
## Summary
- Adds `docs/ui-alignment.md` with the full phased plan for promoting `@ilm/ui` into a real design system (tokens + reset, primitives, `<AppShell>`, migrations).
- Inserts **Stage 4c-pre: Shared UI kit** in `docs/next-stage.md` so Phases A+B+C land before Supply Manager, making Supply the kit's first consumer rather than another copy-paste victim.
- Defers Phase D (migrate Account / Project / Protocol) and Phase E (docs) to "After this stage."
- Links the new plan from `docs/README.md`.

## Why
Protocol / Project / Account each carry their own `styles.css` (2810 / 1060 / 454 lines). Tokens are already shared via `packages/ui/src/tokens.css`, but every app re-aliases them under a per-app prefix (`--ilm-*`, `--pm-*`, `--acct-*`) and reimplements the same button / card / tab / table / modal patterns. Building Supply Manager on this as-is would mean another ~1000-line duplicate or visual drift.

## Design decisions a reviewer should know
- **Source for primitives.** Protocol Manager is the primary source (most mature, 2810 lines), cross-referenced against Project Manager where patterns differ — pick the better variant rather than defaulting to Protocol.
- **Extension contract.** Every primitive exposes a `className` pass-through and CSS-var variant slots (`--rl-btn-bg`, etc.) so apps can extend or re-skin without forking.
- **Expandability.** App-specific compositions (e.g. Supply's location tree view) stay local on first use; lift to `@ilm/ui` on second use.
- **Re-skinning.** Designed so future design imports (v0 / Figma Make / Claude Artifacts) can be applied by editing `tokens.css` or swapping a primitive file — apps untouched.

## Cross-doc consistency (from the re-examination pass)
- Supply Manager is *not* in Phase D's migration list — it's the kit's greenfield consumer, not a migration target.
- Sizing table per-app (Account 0.5d, Project 1d, Protocol 2d) matches the "Protocol is largest, highest risk" framing.
- Stage 4c-pre exit criteria allows app-local compositions under the first-use-local / second-use-promote rule.
- Supply's Step 4 now says "wrap in `<AppShell>`" (which owns `AccountLinkCard`) instead of mounting the card separately.
- Pre-Supply scope is A+B+C everywhere (Supply depends on `<AppShell>`).

## Test plan
- [ ] Reviewer confirms the phase sequencing reads correctly: A+B+C → Supply ships → D+E → Funding.
- [ ] Reviewer sanity-checks that the primitive list + extension contract is sufficient for Supply's screens without adding one-off button/card/modal CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)