### PR TITLE
UI kit Phase A: token hygiene + shared reset

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -144,7 +144,7 @@ const SidePanel = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
           <>
             <h3>{activeLab.name}</h3>
             <span className={`acct-lab-role ${tier}`}>{TIER_LABEL[tier]}</span>
-            <small style={{ color: "var(--acct-muted)" }}>{TIER_DESCRIPTION[tier]}</small>
+            <small style={{ color: "var(--rl-muted)" }}>{TIER_DESCRIPTION[tier]}</small>
           </>
         ) : (
           <h3>No lab selected</h3>
@@ -179,7 +179,7 @@ const SidePanel = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
 
       <section className="acct-side-section">
         <h2>Working status</h2>
-        <span style={{ fontSize: "0.85rem", color: "var(--acct-muted)" }}>
+        <span style={{ fontSize: "0.85rem", color: "var(--rl-muted)" }}>
           {activeLab && tier
             ? `Signed in as ${TIER_LABEL[tier]} of ${activeLab.name}. Use the top-right switcher to open another app.`
             : "Pick a lab to get started."}
@@ -530,7 +530,7 @@ const InvitationsTab = () => {
 
         {pendingInvitations.length > 0 ? (
           <div className="acct-invitations">
-            <div style={{ fontSize: "0.72rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--acct-muted)" }}>
+            <div style={{ fontSize: "0.72rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--rl-muted)" }}>
               {pendingInvitations.length} pending
             </div>
             {pendingInvitations.map((invitation) => (

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -1,34 +1,5 @@
 @import "../../../packages/ui/src/tokens.css";
-
-:root {
-  color: var(--rl-ink-2);
-  background: var(--rl-paper);
-  font-family: "Space Grotesk", Arial, sans-serif;
-  line-height: 1.55;
-
-  --acct-ink: var(--rl-ink);
-  --acct-muted: var(--rl-muted);
-  --acct-line: var(--rl-line);
-  --acct-hairline: var(--rl-hairline);
-  --acct-panel: var(--rl-surface);
-  --acct-soft: var(--rl-soft);
-  --acct-green: var(--rl-green);
-  --acct-green-2: var(--rl-green-2);
-  --acct-green-soft: var(--rl-green-soft);
-}
-
-* { box-sizing: border-box; }
-
-body {
-  margin: 0;
-  background: #f9f8f4;
-  color: var(--acct-ink);
-  font-family: "Space Grotesk", Arial, sans-serif;
-}
-
-button, input, textarea, select { font: inherit; }
-button { cursor: pointer; }
-a { color: inherit; }
+@import "../../../packages/ui/src/reset.css";
 
 /* Shell */
 .acct-shell {
@@ -44,8 +15,8 @@ a { color: inherit; }
   align-self: start;
   height: 100vh;
   overflow-y: auto;
-  background: var(--acct-soft);
-  border-right: 1px solid var(--acct-line);
+  background: var(--rl-soft);
+  border-right: 1px solid var(--rl-line);
   padding: 1.1rem 1rem;
   display: flex;
   flex-direction: column;
@@ -56,23 +27,23 @@ a { color: inherit; }
   display: grid;
   gap: 0.2rem;
   padding: 0.1rem 0.4rem 0.6rem;
-  border-bottom: 1px solid var(--acct-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
 }
 .acct-side-header strong {
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.05rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-side-header small {
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .acct-side-section {
-  background: var(--acct-panel);
-  border: 1px solid var(--acct-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 12px;
   padding: 0.8rem 0.9rem;
   display: grid;
@@ -83,21 +54,21 @@ a { color: inherit; }
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
 }
 .acct-side-section h3 {
   margin: 0;
   font-size: 0.95rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 
 .acct-side-profile strong {
   font-size: 0.95rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-side-profile span {
   font-size: 0.8rem;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
 }
 
 .acct-lab-switcher {
@@ -106,10 +77,10 @@ a { color: inherit; }
 }
 .acct-lab-switcher select {
   padding: 0.45rem 0.55rem;
-  border: 1px solid var(--acct-line);
+  border: 1px solid var(--rl-line);
   border-radius: 8px;
   background: #fff;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-lab-role {
   display: inline-block;
@@ -119,11 +90,11 @@ a { color: inherit; }
   font-size: 0.7rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  background: var(--acct-green-soft);
-  color: var(--acct-green);
+  background: var(--rl-green-soft);
+  color: var(--rl-green);
 }
 .acct-lab-role.admin { background: #e8eddc; color: #4a5a33; }
-.acct-lab-role.member { background: var(--rl-surface-2); color: var(--acct-muted); }
+.acct-lab-role.member { background: var(--rl-surface-2); color: var(--rl-muted); }
 
 .acct-stat-row {
   display: grid;
@@ -131,8 +102,8 @@ a { color: inherit; }
   gap: 0.5rem;
 }
 .acct-stat {
-  background: var(--acct-soft);
-  border: 1px solid var(--acct-hairline);
+  background: var(--rl-soft);
+  border: 1px solid var(--rl-hairline);
   border-radius: 10px;
   padding: 0.55rem 0.6rem;
   display: grid;
@@ -142,14 +113,14 @@ a { color: inherit; }
 .acct-stat-value {
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.25rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
   line-height: 1;
 }
 .acct-stat-label {
   font-size: 0.62rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
 }
 
 .acct-side-footer {
@@ -160,20 +131,20 @@ a { color: inherit; }
 
 .acct-text-button {
   appearance: none;
-  border: 1px solid var(--acct-line);
+  border: 1px solid var(--rl-line);
   background: #fff;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
   padding: 0.5rem 0.75rem;
   border-radius: 8px;
   font-size: 0.82rem;
 }
-.acct-text-button:hover:not(:disabled) { background: var(--acct-soft); }
+.acct-text-button:hover:not(:disabled) { background: var(--rl-soft); }
 .acct-text-button:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .acct-primary-button {
   appearance: none;
-  border: 1px solid var(--acct-green);
-  background: var(--acct-green);
+  border: 1px solid var(--rl-green);
+  background: var(--rl-green);
   color: #fff;
   padding: 0.55rem 0.9rem;
   border-radius: 8px;
@@ -181,7 +152,7 @@ a { color: inherit; }
   letter-spacing: 0.08em;
   font-weight: 600;
 }
-.acct-primary-button:hover:not(:disabled) { background: var(--acct-green-2); border-color: var(--acct-green-2); }
+.acct-primary-button:hover:not(:disabled) { background: var(--rl-green-2); border-color: var(--rl-green-2); }
 .acct-primary-button:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .acct-danger-button {
@@ -209,13 +180,13 @@ a { color: inherit; }
   justify-content: space-between;
   gap: 1.25rem;
   padding: 1.1rem 1.8rem 0.9rem;
-  border-bottom: 1px solid var(--acct-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
   background: rgba(249, 248, 244, 0.92);
   backdrop-filter: blur(6px);
 }
 .acct-topbar-copy .acct-kicker {
   margin: 0 0 0.3rem;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   font-size: 0.72rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -224,14 +195,14 @@ a { color: inherit; }
   margin: 0;
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.6rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-topbar-actions { display: flex; gap: 0.6rem; align-items: center; }
 
 .acct-tabs {
   display: flex;
   gap: 0.3rem;
-  border-bottom: 1px solid var(--acct-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
   padding: 0 1.8rem;
   background: rgba(249, 248, 244, 0.92);
 }
@@ -239,7 +210,7 @@ a { color: inherit; }
   appearance: none;
   background: transparent;
   border: none;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   padding: 0.75rem 1rem;
   font-size: 0.78rem;
   letter-spacing: 0.12em;
@@ -248,16 +219,16 @@ a { color: inherit; }
   margin-bottom: -1px;
   position: relative;
 }
-.acct-tab:hover { color: var(--acct-ink); }
+.acct-tab:hover { color: var(--rl-ink); }
 .acct-tab.active {
-  color: var(--acct-green);
-  border-bottom-color: var(--acct-green);
+  color: var(--rl-green);
+  border-bottom-color: var(--rl-green);
   font-weight: 600;
 }
 .acct-tab-badge {
   display: inline-block;
   margin-left: 0.4rem;
-  background: var(--acct-green);
+  background: var(--rl-green);
   color: #fff;
   border-radius: 999px;
   padding: 0.05rem 0.4rem;
@@ -284,15 +255,15 @@ a { color: inherit; }
   font-size: 0.88rem;
 }
 .acct-empty {
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   font-size: 0.92rem;
   margin: 0.4rem 0;
 }
 
 /* Cards/Tables */
 .acct-card {
-  background: var(--acct-panel);
-  border: 1px solid var(--acct-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 12px;
   padding: 1rem 1.1rem;
   display: flex;
@@ -309,17 +280,17 @@ a { color: inherit; }
 .acct-card-header h2 {
   margin: 0;
   font-size: 1.05rem;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-card-header p {
   margin: 0.15rem 0 0;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   font-size: 0.85rem;
 }
 .acct-card-pill {
-  background: var(--acct-soft);
-  border: 1px solid var(--acct-hairline);
-  color: var(--acct-muted);
+  background: var(--rl-soft);
+  border: 1px solid var(--rl-hairline);
+  color: var(--rl-muted);
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
   font-size: 0.72rem;
@@ -338,14 +309,14 @@ a { color: inherit; }
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
   padding: 0.7rem 0;
-  border-top: 1px solid var(--acct-hairline);
+  border-top: 1px solid var(--rl-hairline);
   align-items: center;
 }
 .acct-member:first-child { border-top: none; }
 .acct-member-copy { display: grid; gap: 0.15rem; min-width: 0; }
-.acct-member-copy strong { font-size: 0.95rem; color: var(--acct-ink); }
-.acct-member-copy span { font-size: 0.82rem; color: var(--acct-muted); }
-.acct-member-copy small { font-size: 0.72rem; color: var(--acct-muted); }
+.acct-member-copy strong { font-size: 0.95rem; color: var(--rl-ink); }
+.acct-member-copy span { font-size: 0.82rem; color: var(--rl-muted); }
+.acct-member-copy small { font-size: 0.72rem; color: var(--rl-muted); }
 .acct-member-actions {
   display: flex;
   gap: 0.4rem;
@@ -362,9 +333,9 @@ a { color: inherit; }
   letter-spacing: 0.1em;
   text-transform: uppercase;
   background: var(--rl-surface-2);
-  color: var(--acct-muted);
+  color: var(--rl-muted);
 }
-.acct-badge.owner { background: var(--acct-green-soft); color: var(--acct-green); }
+.acct-badge.owner { background: var(--rl-green-soft); color: var(--rl-green); }
 .acct-badge.admin { background: #e8eddc; color: #4a5a33; }
 
 .acct-form {
@@ -379,16 +350,16 @@ a { color: inherit; }
   font-size: 0.72rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
 }
 .acct-field input,
 .acct-field select,
 .acct-field textarea {
   padding: 0.5rem 0.6rem;
-  border: 1px solid var(--acct-line);
+  border: 1px solid var(--rl-line);
   border-radius: 8px;
   background: #fff;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 .acct-field-row {
   display: grid;
@@ -407,10 +378,10 @@ a { color: inherit; }
 }
 .acct-share-row input {
   padding: 0.5rem 0.6rem;
-  border: 1px solid var(--acct-line);
+  border: 1px solid var(--rl-line);
   border-radius: 8px;
   background: #fff;
-  color: var(--acct-ink);
+  color: var(--rl-ink);
 }
 
 .acct-request-item {
@@ -418,13 +389,13 @@ a { color: inherit; }
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
   padding: 0.7rem 0;
-  border-top: 1px solid var(--acct-hairline);
+  border-top: 1px solid var(--rl-hairline);
   align-items: flex-start;
 }
 .acct-request-item:first-child { border-top: none; }
 .acct-request-message {
   margin-top: 0.35rem;
-  color: var(--acct-muted);
+  color: var(--rl-muted);
   font-size: 0.85rem;
   font-style: italic;
 }
@@ -444,11 +415,11 @@ a { color: inherit; }
   grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 0.75rem;
   padding: 0.55rem 0;
-  border-top: 1px solid var(--acct-hairline);
+  border-top: 1px solid var(--rl-hairline);
   align-items: center;
 }
 .acct-invitation:first-child { border-top: none; }
-.acct-invitation strong { font-size: 0.9rem; color: var(--acct-ink); }
-.acct-invitation small { font-size: 0.72rem; color: var(--acct-muted); }
+.acct-invitation strong { font-size: 0.9rem; color: var(--rl-ink); }
+.acct-invitation small { font-size: 0.72rem; color: var(--rl-muted); }
 
 .acct-row-actions { display: flex; gap: 0.35rem; }

--- a/apps/project-manager/src/styles.css
+++ b/apps/project-manager/src/styles.css
@@ -1,35 +1,5 @@
 @import "../../../packages/ui/src/tokens.css";
-
-:root {
-  color: var(--rl-ink-2);
-  background: var(--rl-paper);
-  font-family: "Space Grotesk", Arial, sans-serif;
-  line-height: 1.55;
-
-  --pm-ink: var(--rl-ink);
-  --pm-muted: var(--rl-muted);
-  --pm-line: var(--rl-line);
-  --pm-hairline: var(--rl-hairline);
-  --pm-panel: var(--rl-surface);
-  --pm-soft: var(--rl-soft);
-  --pm-soft-2: var(--rl-soft-2);
-  --pm-green: var(--rl-green);
-  --pm-green-2: var(--rl-green-2);
-  --pm-green-soft: var(--rl-green-soft);
-}
-
-* { box-sizing: border-box; }
-
-body {
-  margin: 0;
-  background: #f9f8f4;
-  color: var(--pm-ink);
-  font-family: "Space Grotesk", Arial, sans-serif;
-}
-
-button, input, textarea, select { font: inherit; }
-button { cursor: pointer; }
-a { color: inherit; }
+@import "../../../packages/ui/src/reset.css";
 
 /* =========================================================
    Shell
@@ -45,8 +15,8 @@ a { color: inherit; }
   top: 0;
   align-self: start;
   height: 100vh;
-  background: var(--pm-soft);
-  border-right: 1px solid var(--pm-line);
+  background: var(--rl-soft);
+  border-right: 1px solid var(--rl-line);
   padding: 1.1rem 0.9rem;
   display: flex;
   flex-direction: column;
@@ -57,15 +27,15 @@ a { color: inherit; }
   display: grid;
   gap: 0.2rem;
   padding: 0.1rem 0.6rem 0.6rem;
-  border-bottom: 1px solid var(--pm-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
 }
 .pm-side-rail-header strong {
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.05rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-side-rail-header small {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -86,7 +56,7 @@ a { color: inherit; }
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   border-radius: 10px;
   display: flex;
   align-items: center;
@@ -96,11 +66,11 @@ a { color: inherit; }
 }
 .pm-rail-item:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.6);
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-rail-item.active {
-  background: var(--pm-green-soft);
-  color: var(--pm-green);
+  background: var(--rl-green-soft);
+  color: var(--rl-green);
   border-color: rgba(55, 86, 59, 0.18);
   font-weight: 600;
 }
@@ -108,7 +78,7 @@ a { color: inherit; }
 
 .pm-rail-badge {
   margin-left: auto;
-  background: var(--pm-green);
+  background: var(--rl-green);
   color: #fff;
   border-radius: 999px;
   padding: 0.1rem 0.45rem;
@@ -123,8 +93,8 @@ a { color: inherit; }
 }
 
 .pm-rail-item-strong {
-  background: var(--pm-green);
-  border-color: var(--pm-green);
+  background: var(--rl-green);
+  border-color: var(--rl-green);
   color: #ffffff;
   justify-content: center;
   padding: 0.7rem 0.75rem;
@@ -132,14 +102,14 @@ a { color: inherit; }
   font-weight: 600;
 }
 .pm-rail-item-strong:hover:not(:disabled) {
-  background: var(--pm-green-2);
-  border-color: var(--pm-green-2);
+  background: var(--rl-green-2);
+  border-color: var(--rl-green-2);
   color: #ffffff;
 }
 
 .pm-side-account {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 0.8rem 0.9rem;
   display: grid;
@@ -155,24 +125,24 @@ a { color: inherit; }
   outline: none;
 }
 .pm-side-account-head { display: grid; gap: 0.1rem; }
-.pm-side-account-head strong { font-size: 0.88rem; color: var(--pm-ink); }
-.pm-side-account-head span { font-size: 0.75rem; color: var(--pm-muted); }
+.pm-side-account-head strong { font-size: 0.88rem; color: var(--rl-ink); }
+.pm-side-account-head span { font-size: 0.75rem; color: var(--rl-muted); }
 .pm-side-account-meta {
   display: flex;
   justify-content: space-between;
   font-size: 0.7rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
 .pm-side-account-action {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: rgba(255, 255, 255, 0.92);
   padding: 0.45rem 0.6rem;
   border-radius: 10px;
   font-size: 0.78rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-side-account-action:hover { background: #ffffff; }
 
@@ -187,13 +157,13 @@ a { color: inherit; }
   justify-content: space-between;
   gap: 1.25rem;
   padding: 1.1rem 1.8rem 0.9rem;
-  border-bottom: 1px solid var(--pm-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
   background: rgba(249, 248, 244, 0.92);
   backdrop-filter: blur(6px);
 }
 .pm-topbar-copy .pm-kicker {
   margin: 0 0 0.3rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.72rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -202,7 +172,7 @@ a { color: inherit; }
   margin: 0;
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.7rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-topbar-actions { display: flex; gap: 0.6rem; align-items: center; }
 
@@ -225,7 +195,7 @@ a { color: inherit; }
 }
 
 .pm-empty {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.92rem;
   margin: 0.4rem 0;
 }
@@ -262,11 +232,11 @@ a { color: inherit; }
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.35rem;
 }
-.pm-panel-header p { margin: 0.15rem 0 0; color: var(--pm-muted); }
+.pm-panel-header p { margin: 0.15rem 0 0; color: var(--rl-muted); }
 
 .pm-panel-section {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 1rem 1.2rem 1.2rem;
   display: flex;
@@ -285,14 +255,14 @@ a { color: inherit; }
 }
 .pm-panel-section-head span {
   font-size: 0.75rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
 
 .pm-collapsible-section {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 0.85rem 1rem 1rem;
 }
@@ -302,7 +272,7 @@ a { color: inherit; }
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1rem;
 }
@@ -320,15 +290,15 @@ a { color: inherit; }
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 .pm-summary-card {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 0.95rem 1.1rem;
   display: grid;
   gap: 0.25rem;
 }
 .pm-summary-kicker {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   text-transform: uppercase;
   font-size: 0.7rem;
   letter-spacing: 0.12em;
@@ -336,9 +306,9 @@ a { color: inherit; }
 .pm-summary-card strong {
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.35rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
-.pm-summary-card small { color: var(--pm-muted); font-size: 0.8rem; }
+.pm-summary-card small { color: var(--rl-muted); font-size: 0.8rem; }
 
 .pm-card-grid {
   display: grid;
@@ -347,8 +317,8 @@ a { color: inherit; }
 }
 
 .pm-library-card {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 1rem 1.2rem;
   display: flex;
@@ -365,12 +335,12 @@ a { color: inherit; }
   display: block;
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.05rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-library-card-head span {
   display: block;
   font-size: 0.85rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   margin-top: 0.15rem;
 }
 .pm-library-card-tags {
@@ -389,7 +359,7 @@ a { color: inherit; }
 }
 .pm-library-card-meta div { display: grid; gap: 0.15rem; }
 .pm-library-card-meta dt {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.68rem;
@@ -397,7 +367,7 @@ a { color: inherit; }
 }
 .pm-library-card-meta dd {
   margin: 0;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
   font-weight: 500;
 }
 
@@ -417,11 +387,11 @@ a { color: inherit; }
   right: 0.8rem;
   bottom: 0.6rem;
   font-size: 0.72rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   background: rgba(255, 255, 255, 0.6);
   padding: 0.1rem 0.45rem;
   border-radius: 999px;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
 }
 .pm-library-card-repo .pm-repo-link {
   color: inherit;
@@ -452,8 +422,8 @@ a { color: inherit; }
   font-weight: 600;
 }
 .pm-state-tag-draft { background: #fbf2e4; color: #8a4900; border: 1px solid #d7bca1; }
-.pm-state-tag-published { background: var(--pm-green-soft); color: var(--pm-green); border: 1px solid rgba(55, 86, 59, 0.2); }
-.pm-state-tag-deleted { background: #f0f0f0; color: #6d736a; border: 1px solid var(--pm-line); }
+.pm-state-tag-published { background: var(--rl-green-soft); color: var(--rl-green); border: 1px solid rgba(55, 86, 59, 0.2); }
+.pm-state-tag-deleted { background: #f0f0f0; color: #6d736a; border: 1px solid var(--rl-line); }
 
 .pm-status-tag {
   display: inline-flex;
@@ -464,19 +434,19 @@ a { color: inherit; }
   letter-spacing: 0.05em;
   text-transform: uppercase;
   background: #f0f0f0;
-  color: var(--pm-muted);
-  border: 1px solid var(--pm-line);
+  color: var(--rl-muted);
+  border: 1px solid var(--rl-line);
 }
 .pm-status-tag-planning { background: #eaf1f6; color: #2c4f71; border-color: #bed0e0; }
-.pm-status-tag-active { background: var(--pm-green-soft); color: var(--pm-green); border-color: rgba(55, 86, 59, 0.2); }
+.pm-status-tag-active { background: var(--rl-green-soft); color: var(--rl-green); border-color: rgba(55, 86, 59, 0.2); }
 .pm-status-tag-blocked { background: #ffdad6; color: #93000a; border-color: #f2b3af; }
 .pm-status-tag-completed { background: #dbe9d6; color: #304632; border-color: #b4cdb2; }
-.pm-status-tag-archived { background: #e8e8e8; color: #6d736a; border-color: var(--pm-line); }
+.pm-status-tag-archived { background: #e8e8e8; color: #6d736a; border-color: var(--rl-line); }
 
 .pm-status-tag-planned { background: #eaf1f6; color: #2c4f71; border-color: #bed0e0; }
 .pm-status-tag-in_progress { background: #fff1cb; color: #7a5f00; border-color: #ead8a4; }
-.pm-status-tag-done { background: var(--pm-green-soft); color: var(--pm-green); border-color: rgba(55, 86, 59, 0.2); }
-.pm-status-tag-cancelled { background: #f0f0f0; color: var(--pm-muted); border-color: var(--pm-line); }
+.pm-status-tag-done { background: var(--rl-green-soft); color: var(--rl-green); border-color: rgba(55, 86, 59, 0.2); }
+.pm-status-tag-cancelled { background: #f0f0f0; color: var(--rl-muted); border-color: var(--rl-line); }
 
 .pm-status-tag-running { background: #fff1cb; color: #7a5f00; border-color: #ead8a4; }
 .pm-status-tag-failed { background: #ffdad6; color: #93000a; border-color: #f2b3af; }
@@ -491,7 +461,7 @@ a { color: inherit; }
 }
 .pm-status-dot-planning, .pm-status-dot-planned { background: #6994b9; }
 .pm-status-dot-active, .pm-status-dot-running, .pm-status-dot-in_progress { background: #d6a93b; }
-.pm-status-dot-completed, .pm-status-dot-done { background: var(--pm-green); }
+.pm-status-dot-completed, .pm-status-dot-done { background: var(--rl-green); }
 .pm-status-dot-blocked, .pm-status-dot-failed { background: #c44b43; }
 .pm-status-dot-archived, .pm-status-dot-cancelled { background: #9aa097; }
 
@@ -503,11 +473,11 @@ a { color: inherit; }
   letter-spacing: 0.08em;
   text-transform: uppercase;
   background: #f0f0f0;
-  color: var(--pm-muted);
-  border: 1px solid var(--pm-line);
+  color: var(--rl-muted);
+  border: 1px solid var(--rl-line);
 }
 .pm-role-tag-owner { background: #f3e7fe; color: #5b278b; border-color: #ddbce6; }
-.pm-role-tag-admin { background: var(--pm-green-soft); color: var(--pm-green); border-color: rgba(55, 86, 59, 0.2); }
+.pm-role-tag-admin { background: var(--rl-green-soft); color: var(--rl-green); border-color: rgba(55, 86, 59, 0.2); }
 .pm-role-tag-member { background: #eaf1f6; color: #2c4f71; border-color: #bed0e0; }
 
 /* =========================================================
@@ -521,8 +491,8 @@ a { color: inherit; }
 }
 
 .pm-outline-pane {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 1rem 1.1rem 1.1rem;
   min-height: 60vh;
@@ -540,16 +510,16 @@ a { color: inherit; }
   gap: 0.8rem;
   align-items: flex-start;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--pm-hairline);
+  border-bottom: 1px solid var(--rl-hairline);
 }
 .pm-outline-root strong {
   display: block;
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.05rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-outline-selection-copy {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.74rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -561,19 +531,19 @@ a { color: inherit; }
 }
 .pm-outline-tool {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   border-radius: 10px;
   padding: 0.5rem 0.7rem;
   font-size: 0.76rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
   text-align: center;
 }
-.pm-outline-tool:hover:not(:disabled) { background: var(--pm-soft); }
+.pm-outline-tool:hover:not(:disabled) { background: var(--rl-soft); }
 .pm-outline-tool:disabled { opacity: 0.5; cursor: not-allowed; }
 .pm-outline-help {
   margin: 0;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.82rem;
 }
 .pm-outline-groups {
@@ -582,7 +552,7 @@ a { color: inherit; }
   gap: 0.6rem;
 }
 .pm-outline-card {
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(246, 245, 239, 0.96));
   padding: 0.7rem 0.8rem 0.8rem;
@@ -592,7 +562,7 @@ a { color: inherit; }
 }
 .pm-outline-card.selected {
   border-color: rgba(55, 86, 59, 0.3);
-  background: var(--pm-green-soft);
+  background: var(--rl-green-soft);
 }
 .pm-outline-card.dragging,
 .pm-outline-step.dragging {
@@ -613,11 +583,11 @@ a { color: inherit; }
 }
 .pm-drag-handle {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   border-radius: 9px;
   padding: 0.4rem 0.45rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.7rem;
   line-height: 1;
   flex: 0 0 auto;
@@ -625,11 +595,11 @@ a { color: inherit; }
 .pm-drag-handle-step { padding-inline: 0.35rem; }
 .pm-collapse-toggle {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   border-radius: 9px;
   padding: 0.35rem 0.5rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   line-height: 1;
   flex: 0 0 auto;
 }
@@ -648,11 +618,11 @@ a { color: inherit; }
 .pm-outline-row-button strong,
 .pm-outline-step-copy strong {
   font-size: 0.92rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-outline-row-button small,
 .pm-outline-step-copy small {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.76rem;
 }
 .pm-outline-card-meta {
@@ -664,11 +634,11 @@ a { color: inherit; }
 }
 .pm-outline-inline-button {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   border-radius: 999px;
   padding: 0.2rem 0.55rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
   font-size: 0.72rem;
 }
 .pm-outline-dropzone {
@@ -682,14 +652,14 @@ a { color: inherit; }
   padding: 0.35rem 0.45rem 0.45rem;
 }
 .pm-outline-subhead {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   padding-top: 0.15rem;
 }
 .pm-outline-drop-copy {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.76rem;
 }
 .pm-outline-step-list {
@@ -701,17 +671,17 @@ a { color: inherit; }
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  border: 1px solid var(--pm-line);
-  background: var(--pm-panel);
+  border: 1px solid var(--rl-line);
+  background: var(--rl-surface);
   border-radius: 12px;
   padding: 0.45rem 0.55rem;
 }
 .pm-outline-step.selected {
-  border-color: var(--pm-green);
-  background: var(--pm-green-soft);
+  border-color: var(--rl-green);
+  background: var(--rl-green-soft);
 }
 .pm-outline-step-index {
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.78rem;
   min-width: 1.2rem;
 }
@@ -723,8 +693,8 @@ a { color: inherit; }
 
 /* Detail pane */
 .pm-detail-pane {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   display: flex;
   flex-direction: column;
@@ -735,8 +705,8 @@ a { color: inherit; }
   align-items: center;
   gap: 1rem;
   padding: 0.55rem 1.1rem;
-  border-bottom: 1px solid var(--pm-hairline);
-  background: var(--pm-soft);
+  border-bottom: 1px solid var(--rl-hairline);
+  background: var(--rl-soft);
 }
 .pm-tab-link {
   appearance: none;
@@ -744,13 +714,13 @@ a { color: inherit; }
   border: none;
   padding: 0.35rem 0;
   font-size: 0.82rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   letter-spacing: 0.04em;
   position: relative;
 }
-.pm-tab-link:hover { color: var(--pm-ink); }
+.pm-tab-link:hover { color: var(--rl-ink); }
 .pm-tab-link.active {
-  color: var(--pm-ink);
+  color: var(--rl-ink);
   font-weight: 600;
 }
 .pm-tab-link.active::after {
@@ -760,7 +730,7 @@ a { color: inherit; }
   right: 0;
   bottom: -0.58rem;
   height: 2px;
-  background: var(--pm-green);
+  background: var(--rl-green);
 }
 .pm-tab-nav-right { margin-left: auto; }
 
@@ -809,21 +779,21 @@ a { color: inherit; }
   justify-content: space-between;
   gap: 0.6rem;
   padding: 0.5rem 0.7rem;
-  background: var(--pm-soft);
-  border: 1px solid var(--pm-hairline);
+  background: var(--rl-soft);
+  border: 1px solid var(--rl-hairline);
   border-radius: 10px;
 }
 .pm-roster-row strong { display: block; font-size: 0.92rem; }
-.pm-roster-row span { color: var(--pm-muted); font-size: 0.8rem; }
+.pm-roster-row span { color: var(--rl-muted); font-size: 0.8rem; }
 
 .pm-item-list { display: flex; flex-direction: column; gap: 0.9rem; }
 .pm-item-wrap {
-  background: var(--pm-soft);
-  border: 1px solid var(--pm-hairline);
+  background: var(--rl-soft);
+  border: 1px solid var(--rl-hairline);
   border-radius: 12px;
   padding: 0.9rem 1rem;
 }
-.pm-item-wrap.highlight { border-color: var(--pm-green); background: var(--pm-green-soft); }
+.pm-item-wrap.highlight { border-color: var(--rl-green); background: var(--rl-green-soft); }
 
 .pm-roadmap-preview {
   display: flex;
@@ -831,9 +801,9 @@ a { color: inherit; }
   gap: 1rem;
 }
 .pm-roadmap-section {
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
-  background: var(--pm-panel);
+  background: var(--rl-surface);
   padding: 1rem 1.1rem 1.1rem;
   display: flex;
   flex-direction: column;
@@ -852,14 +822,14 @@ a { color: inherit; }
 }
 .pm-roadmap-section-head p {
   margin: 0;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
 }
 .pm-roadmap-section-meta {
   display: grid;
   gap: 0.35rem;
   justify-items: end;
   font-size: 0.8rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
 }
 .pm-roadmap-card-grid {
   display: grid;
@@ -867,9 +837,9 @@ a { color: inherit; }
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 .pm-roadmap-card {
-  border: 1px solid var(--pm-hairline);
+  border: 1px solid var(--rl-hairline);
   border-radius: 12px;
-  background: var(--pm-soft);
+  background: var(--rl-soft);
   padding: 0.85rem 0.9rem;
   display: flex;
   flex-direction: column;
@@ -888,7 +858,7 @@ a { color: inherit; }
 }
 .pm-roadmap-card p {
   margin: 0;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
   font-size: 0.86rem;
 }
 .pm-roadmap-card-meta {
@@ -897,7 +867,7 @@ a { color: inherit; }
   gap: 0.75rem;
   flex-wrap: wrap;
   font-size: 0.76rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
 }
 
 /* =========================================================
@@ -915,7 +885,7 @@ a { color: inherit; }
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.02rem;
 }
-.pm-form-head small { color: var(--pm-muted); font-size: 0.78rem; }
+.pm-form-head small { color: var(--rl-muted); font-size: 0.78rem; }
 
 .pm-form-footer {
   display: flex;
@@ -923,23 +893,23 @@ a { color: inherit; }
   justify-content: space-between;
   gap: 0.8rem;
   padding-top: 0.4rem;
-  border-top: 1px dashed var(--pm-hairline);
+  border-top: 1px dashed var(--rl-hairline);
   margin-top: 0.2rem;
 }
-.pm-form-footer small { color: var(--pm-muted); font-size: 0.78rem; }
+.pm-form-footer small { color: var(--rl-muted); font-size: 0.78rem; }
 
 .pm-field { display: grid; gap: 0.3rem; font-size: 0.88rem; color: #343434; }
 .pm-field span { font-weight: 500; }
 .pm-field input, .pm-field textarea, .pm-field select {
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   border-radius: 10px;
   padding: 0.55rem 0.75rem;
   background: #fff;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
 .pm-field input:focus, .pm-field textarea:focus, .pm-field select:focus {
   outline: none;
-  border-color: var(--pm-green-2);
+  border-color: var(--rl-green-2);
   box-shadow: 0 0 0 3px rgba(79, 111, 82, 0.18);
 }
 .pm-field-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.8rem; }
@@ -959,8 +929,8 @@ a { color: inherit; }
 /* Buttons */
 .pm-primary-button {
   appearance: none;
-  border: 1px solid var(--pm-green);
-  background: var(--pm-green);
+  border: 1px solid var(--rl-green);
+  background: var(--rl-green);
   color: #ffffff;
   padding: 0.55rem 1rem;
   border-radius: 10px;
@@ -968,19 +938,19 @@ a { color: inherit; }
   font-weight: 600;
   letter-spacing: 0.04em;
 }
-.pm-primary-button:hover:not(:disabled) { background: var(--pm-green-2); border-color: var(--pm-green-2); }
+.pm-primary-button:hover:not(:disabled) { background: var(--rl-green-2); border-color: var(--rl-green-2); }
 .pm-primary-button:disabled { opacity: 0.6; cursor: not-allowed; }
 
 .pm-text-button {
   appearance: none;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   padding: 0.45rem 0.85rem;
   border-radius: 10px;
   font-size: 0.8rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
-.pm-text-button:hover:not(:disabled) { background: var(--pm-soft); }
+.pm-text-button:hover:not(:disabled) { background: var(--rl-soft); }
 .pm-text-button-danger { color: var(--rl-danger-text); border-color: #f2b3af; }
 .pm-text-button-danger:hover:not(:disabled) { background: #fbefed; }
 
@@ -990,12 +960,12 @@ a { color: inherit; }
   text-decoration: none;
   padding: 0.45rem 0.85rem;
   border-radius: 10px;
-  border: 1px solid var(--pm-line);
+  border: 1px solid var(--rl-line);
   background: #ffffff;
   font-size: 0.8rem;
-  color: var(--pm-ink);
+  color: var(--rl-ink);
 }
-.pm-link-button:hover { background: var(--pm-soft); }
+.pm-link-button:hover { background: var(--rl-soft); }
 
 /* Modal */
 .pm-modal-backdrop {
@@ -1009,8 +979,8 @@ a { color: inherit; }
   z-index: 50;
 }
 .pm-modal {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 16px;
   padding: 1.3rem 1.4rem 1.4rem;
   width: min(560px, 100%);
@@ -1032,7 +1002,7 @@ a { color: inherit; }
 .pm-modal-note {
   margin: 0;
   font-size: 0.85rem;
-  color: var(--pm-muted);
+  color: var(--rl-muted);
 }
 
 /* =========================================================
@@ -1040,8 +1010,8 @@ a { color: inherit; }
    visually consistent when embedded here
 ========================================================= */
 .pm-personnel-body .ilm-admin-card {
-  background: var(--pm-panel);
-  border: 1px solid var(--pm-line);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   padding: 1rem 1.2rem;
 }
@@ -1053,7 +1023,7 @@ a { color: inherit; }
     position: relative;
     height: auto;
     border-right: none;
-    border-bottom: 1px solid var(--pm-line);
+    border-bottom: 1px solid var(--rl-line);
   }
   .pm-view-grid { grid-template-columns: 1fr; }
   .pm-library-card-meta { grid-template-columns: repeat(2, 1fr); }

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -1,56 +1,12 @@
 @import "../../../packages/ui/src/tokens.css";
-
-:root {
-  color: var(--rl-ink-2);
-  background: var(--rl-paper);
-  font-family: var(--rl-font-sans);
-  line-height: 1.55;
-  --ilm-ink: var(--rl-ink);
-  --ilm-muted: var(--rl-muted);
-  --ilm-line: var(--rl-line);
-  --ilm-panel: var(--rl-surface);
-  --ilm-soft: var(--rl-soft);
-  --ilm-soft-2: var(--rl-soft-2);
-  --ilm-green: var(--rl-green);
-  --ilm-green-2: var(--rl-green-2);
-  --ilm-green-soft: var(--rl-green-soft);
-  --ilm-warn: var(--rl-warn);
-  --ilm-warn-bg: var(--rl-warn-bg);
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  background: #f9f8f4;
-  color: var(--ilm-ink);
-  font-family: "Space Grotesk", Arial, sans-serif;
-}
-
-a {
-  color: inherit;
-}
-
-button,
-input,
-textarea,
-select {
-  font: inherit;
-}
+@import "../../../packages/ui/src/reset.css";
 
 button {
-  border: 1px solid var(--ilm-line);
+  border: 1px solid var(--rl-line);
   background: rgba(255, 255, 255, 0.94);
   border-radius: 0;
   padding: 0.6rem 1rem;
-  color: var(--ilm-ink);
-  cursor: pointer;
+  color: var(--rl-ink);
   transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
 }
 
@@ -415,7 +371,7 @@ label {
 .outline-node-icon {
   display: inline-flex;
   align-items: center;
-  color: var(--ilm-green);
+  color: var(--rl-green);
   flex: 0 0 auto;
 }
 
@@ -826,7 +782,7 @@ label {
   gap: 2rem;
   align-items: center;
   padding-bottom: 1.6rem;
-  border-bottom: 2px solid var(--ilm-ink);
+  border-bottom: 2px solid var(--rl-ink);
 }
 
 .dashboard-brand {
@@ -840,7 +796,7 @@ label {
   place-items: center;
   width: 3rem;
   height: 3rem;
-  border: 1px solid var(--ilm-line);
+  border: 1px solid var(--rl-line);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.9rem;
   letter-spacing: 0.2em;
@@ -888,7 +844,7 @@ label {
 
 .dashboard-brand-subtitle {
   margin: 0.2rem 0 0;
-  color: var(--ilm-muted);
+  color: var(--rl-muted);
   font-size: 0.76rem;
 }
 
@@ -906,8 +862,8 @@ label {
 }
 
 .dashboard-nav a.active {
-  color: var(--ilm-ink);
-  border-bottom: 2px solid var(--ilm-ink);
+  color: var(--rl-ink);
+  border-bottom: 2px solid var(--rl-ink);
 }
 
 .dashboard-actions {
@@ -928,7 +884,7 @@ label {
 .dashboard-connection-badge span {
   display: inline-flex;
   align-items: center;
-  background: var(--ilm-ink);
+  background: var(--rl-ink);
   color: white;
   padding: 0.55rem 0.8rem;
 }
@@ -1005,7 +961,7 @@ label {
 .dashboard-metric-card,
 .dashboard-schematic {
   position: relative;
-  background: var(--ilm-panel);
+  background: var(--rl-surface);
   border: 1px solid #dde1da;
 }
 
@@ -1021,7 +977,7 @@ label {
   position: absolute;
   width: 14px;
   height: 14px;
-  border-color: var(--ilm-ink);
+  border-color: var(--rl-ink);
   border-style: solid;
 }
 
@@ -1088,7 +1044,7 @@ label {
 .dashboard-meter span {
   display: block;
   height: 100%;
-  background: var(--ilm-ink);
+  background: var(--rl-ink);
 }
 
 .dashboard-meter.muted span {
@@ -1151,18 +1107,18 @@ label {
 .dashboard-core-mark {
   font-size: 3.8rem;
   line-height: 1;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .dashboard-core-node p {
   font-size: 1.1rem;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .dashboard-core-node strong {
   font-family: "JetBrains Mono", monospace;
   font-size: 0.8rem;
-  color: var(--ilm-green);
+  color: var(--rl-green);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
@@ -1170,7 +1126,7 @@ label {
 .dashboard-node {
   padding: 0.9rem 1.25rem;
   font-size: 0.86rem;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .dashboard-node-top {
@@ -1356,8 +1312,8 @@ label {
 }
 
 .protocol-tab-link.active {
-  color: var(--ilm-ink);
-  border-bottom: 1px solid var(--ilm-green);
+  color: var(--rl-ink);
+  border-bottom: 1px solid var(--rl-green);
 }
 
 .protocol-danger-action {
@@ -1398,7 +1354,7 @@ label {
   position: absolute;
   width: 10px;
   height: 10px;
-  border-color: var(--ilm-green);
+  border-color: var(--rl-green);
   border-style: solid;
 }
 
@@ -1462,13 +1418,13 @@ label {
 }
 
 .protocol-rail-item.active {
-  color: var(--ilm-green);
+  color: var(--rl-green);
   background: #e9ece5;
-  border-left: 2px solid var(--ilm-green);
+  border-left: 2px solid var(--rl-green);
 }
 
 .protocol-rail-item-strong {
-  background: var(--ilm-green);
+  background: var(--rl-green);
   color: white;
 }
 
@@ -1518,7 +1474,7 @@ label {
 .protocol-side-account-header strong,
 .home-highlights strong,
 .home-module-footer span {
-  color: var(--ilm-ink);
+  color: var(--rl-ink);
 }
 
 .protocol-side-account-header strong,
@@ -1546,7 +1502,7 @@ label {
 }
 
 .protocol-side-account-meta span:first-child {
-  color: var(--ilm-ink);
+  color: var(--rl-ink);
   font-size: 0.72rem;
 }
 
@@ -1666,7 +1622,7 @@ label {
 }
 
 .protocol-resize-handle:hover::before {
-  background: var(--ilm-green);
+  background: var(--rl-green);
 }
 
 .protocol-main-panel {
@@ -1740,7 +1696,7 @@ label {
 .protocol-outline-header h2 {
   font-size: 1.25rem;
   font-weight: 700;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-outline-header button {
@@ -1928,8 +1884,8 @@ label {
 }
 
 .protocol-view-toggle.active {
-  background: var(--ilm-green);
-  border-color: var(--ilm-green);
+  background: var(--rl-green);
+  border-color: var(--rl-green);
   color: #ffffff;
 }
 
@@ -1984,7 +1940,7 @@ label {
 }
 
 .protocol-content-card-accent {
-  border-top: 4px solid var(--ilm-green);
+  border-top: 4px solid var(--rl-green);
 }
 
 .protocol-content-card-hero {
@@ -2010,7 +1966,7 @@ label {
 .protocol-card-heading h3,
 .protocol-panel-header h3 {
   font-size: 1.15rem;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-card-heading span,
@@ -2049,7 +2005,7 @@ label {
 .protocol-data-table td:last-child,
 .protocol-summary-grid strong,
 .protocol-timeline-stage strong {
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-form-grid {
@@ -2087,7 +2043,7 @@ label {
 }
 
 .protocol-switch-row strong {
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-switch-row span {
@@ -2130,7 +2086,7 @@ label {
 }
 
 .protocol-switch-control input:checked + .protocol-switch-slider {
-  background: var(--ilm-green);
+  background: var(--rl-green);
 }
 
 .protocol-switch-control input:checked + .protocol-switch-slider::after {
@@ -2187,13 +2143,13 @@ label {
 }
 
 .protocol-callout-warning {
-  background: var(--ilm-warn-bg);
+  background: var(--rl-warn-bg);
   border-color: #d7bca1;
 }
 
 .protocol-callout-warning .protocol-card-heading h3,
 .protocol-callout-warning p {
-  color: var(--ilm-warn);
+  color: var(--rl-warn);
 }
 
 .protocol-observation-copy {
@@ -2228,7 +2184,7 @@ label {
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  color: var(--ilm-green);
+  color: var(--rl-green);
   font-family: "Space Grotesk", sans-serif;
   font-size: 0.95rem;
   letter-spacing: 0.08em;
@@ -2252,7 +2208,7 @@ label {
 
 .protocol-library-link strong,
 .protocol-library-card strong {
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-library-card-main > div:first-child {
@@ -2382,7 +2338,7 @@ label {
 }
 
 .protocol-compact-row strong {
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-compact-row span,
@@ -2434,7 +2390,7 @@ label {
 .protocol-new-choice strong {
   font-family: "Noto Serif", Georgia, serif;
   font-size: 1.1rem;
-  color: var(--ilm-green);
+  color: var(--rl-green);
 }
 
 .protocol-new-choice span {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.tsx",
     "./tokens.css": "./src/tokens.css",
+    "./reset.css": "./src/reset.css",
     "./auth.css": "./src/auth/auth.css"
   },
   "dependencies": {

--- a/packages/ui/src/reset.css
+++ b/packages/ui/src/reset.css
@@ -1,0 +1,39 @@
+/* ============================================================
+   Rhine Lab ILM — Shared reset / base
+   Imported by every app after tokens.css. Owns the boilerplate
+   each app's styles.css used to repeat: box-sizing, body bg,
+   form element font inheritance, button cursor, link color.
+   Assumes tokens.css is already loaded.
+   ============================================================ */
+
+html {
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--rl-paper);
+  color: var(--rl-ink);
+  font-family: var(--rl-font-sans);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+}

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -75,11 +75,16 @@
   --rl-space-7: 48px;
   --rl-space-8: 64px;
 
-  /* ---------- Radii (mostly zero — chrome is sharp) ---------- */
-  --rl-radius-sharp: 0;
-  --rl-radius-soft:  14px;   /* Protocol Manager composer cards */
+  /* ---------- Radii ---------- */
+  --rl-radius-sharp:   0;
+  --rl-radius-xs:      6px;
+  --rl-radius-sm:      8px;
+  --rl-radius-md:      12px;
+  --rl-radius-soft:    14px;   /* Protocol Manager composer cards */
+  --rl-radius-lg:      18px;
   --rl-radius-soft-lg: 22px;
-  --rl-radius-pill:  999px;
+  --rl-radius-xl:      24px;
+  --rl-radius-pill:    999px;
 
   /* ---------- Borders ---------- */
   --rl-border-hairline: 0.5px solid var(--rl-outline-variant);
@@ -92,6 +97,20 @@
   --rl-shadow-float:        0 22px 48px rgba(83, 73, 56, 0.18);
   --rl-shadow-soft:         0 12px 30px rgba(83, 73, 56, 0.08);
   --rl-shadow-step:         0 0 15px rgba(79, 111, 82, 0.05);
+
+  /* ---------- Z-index layers ---------- */
+  --rl-z-base:      1;
+  --rl-z-raised:    10;
+  --rl-z-sticky:    20;
+  --rl-z-dropdown:  40;
+  --rl-z-overlay:   50;
+  --rl-z-modal:     100;
+
+  /* ---------- Motion ---------- */
+  --rl-dur-fast: 120ms;
+  --rl-dur-base: 140ms;
+  --rl-dur-slow: 200ms;
+  --rl-ease:     ease;
 }
 
 /* ============================================================


### PR DESCRIPTION
Drops per-app CSS var alias layers (--acct-*, --pm-*, --ilm-*) in favor of direct --rl-* references, codifies inline tokens (radii, z-index, motion) in tokens.css, and factors shared reset boilerplate into a new @ilm/ui/reset.css imported by every app. Eliminates font-family and body-background drift that each app was hardcoding.

Net -83 lines of app CSS; no visual change intended.