### PR TITLE
UI kit Phase B: extract primitives into @ilm/ui

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -57,6 +57,11 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 - Personnel tab shows `ProjectLeadsPanel` and the roster. Lab-wide owner settings now live in the Account app.
 - **GitHub repo link per project**: optional `github_repo_url` on projects, editable from the Edit tab. Library cards show "last push {relative time}" in the bottom-right corner when a repo is linked, with a one-click refresh button. Status is cached in `project_repo_status` and fetched on demand by the `fetch-github-activity` edge function using a lab-scoped PAT (admin-managed, stored service-role-only on `labs.github_pat`, never sent to the browser).
 
+## Shared UI kit (Stage 4c-pre)
+
+- **Phase A — tokens + reset.** `@ilm/ui/tokens.css` owns the full `--rl-*` design-token set (colors, type scale, spacing, radii, z-index, motion); `@ilm/ui/reset.css` factors out the boilerplate each app's `styles.css` used to repeat. Per-app `--acct-*` / `--pm-*` / `--ilm-*` alias layers are gone.
+- **Phase B — primitives.** `@ilm/ui` now exports `Button`, `FormField` + `Input` / `Textarea` / `Select` / `CheckboxField` + `FormRow`, `Panel` + `SectionHeader` + `CardGrid`, `Tabs` + `TabButton` + `TabPanel`, `Modal` + `ConfirmDialog`, `Table` + `TableEmpty` + `TableLoading`, `Badge` + `StatusPill`, `EmptyState` + `ErrorBanner` + `InlineError` + `InlineNote`. Styles ship in `@ilm/ui/primitives.css`; every primitive exposes CSS custom properties (`--rl-btn-bg`, `--rl-panel-bg`, `--rl-badge-fg`, ...) so apps can restyle a single usage without forking the primitive. Existing apps keep their local CSS until Phase D — Supply Manager (Stage 4c) is the first consumer.
+
 ## Audit & security
 
 - `audit_log` table captures state transitions only (submit / approve / reject / recycle / restore / purge). Draft edits and roadmap reorders are not logged.

--- a/docs/ui-alignment.md
+++ b/docs/ui-alignment.md
@@ -39,22 +39,25 @@ Promote `@ilm/ui` into a real design system: tokens + reset + primitives + app s
 
 **Payoff:** mechanical find-replace; makes Phase B primitives shareable without collisions.
 
-### Phase B — Extract primitives (~1–2 days)
+### Phase B — Extract primitives ✅ shipped
 
-Source of truth: Protocol Manager (most mature, 2810 lines of CSS), cross-referenced against Project Manager where patterns differ — pick the better variant, don't pick Protocol by default. Add to `packages/ui/src/primitives/`, each with colocated CSS scoped under a single class prefix (`.rl-btn`, `.rl-card`):
+Primitives live in `packages/ui/src/primitives/`, styles in `packages/ui/src/primitives/primitives.css` (exported as `@ilm/ui/primitives.css`), all scoped under `.rl-*`. Sourced from Project Manager (forms, panels, tabs, modal, feedback) and Protocol Manager (buttons, status badges).
 
-- `Button` — variants: primary / secondary / ghost / danger; sizes sm/md.
-- `Input`, `Textarea`, `Select`, `FormField` (label + error + helper).
-- `Card`, `Panel`, `SectionHeader`.
-- `Tabs`, `TabList`, `TabPanel`.
-- `Modal`, `Drawer`, `ConfirmDialog`.
-- `Table` (sticky header, empty state, loading row).
-- `Badge`, `Tag`, `StatusPill` (draft / submitted / published / rejected).
-- `EmptyState`, `ErrorBanner`, `InlineToast`.
+Shipped:
+- `Button` — variants: primary / secondary / ghost / danger / ink; sizes sm/md; `block` modifier.
+- `FormField` + `Input`, `Textarea`, `Select`, `CheckboxField`, `FormRow` — label + hint + error contract; `invalid` prop swaps to error styling.
+- `Panel`, `SectionHeader`, `CardGrid` — bordered container + titled section header + responsive card grid.
+- `Tabs`, `TabButton`, `TabPanel` — controlled tabs with `aria-selected`.
+- `Modal`, `ConfirmDialog` — backdrop + dialog with narrow/default/wide widths; Esc/backdrop dismiss; `ConfirmDialog` wraps Modal with primary/danger tone.
+- `Table`, `TableEmpty`, `TableLoading` — sticky header, hover row, empty + loading rows.
+- `Badge` (tones: neutral/info/success/warning/danger) + `StatusPill` (workflow statuses: draft/submitted/reviewing/reviewed/published/validated/active/archived/rejected/failed/blocked/proposed/cancelled/deleted/neutral).
+- `EmptyState`, `ErrorBanner`, `InlineError`, `InlineNote`.
+
+Deferred to first real demand under the "first use local, second use promote" rule: `Drawer`, `InlineToast`, table column-sort affordances, `Tag` as a distinct primitive from `Badge`.
 
 **Extension contract** — every primitive exposes:
 - `className` pass-through for ad-hoc overrides.
-- Variant slots backed by CSS custom properties (e.g. `--rl-btn-bg`, `--rl-btn-border`) so apps restyle without forking.
+- Variant slots backed by CSS custom properties (`--rl-btn-bg`, `--rl-panel-bg`, `--rl-badge-fg`, `--rl-modal-width`, ...) so apps restyle a single usage without forking the primitive.
 
 ### Phase C — Shared app shell (~0.5 day)
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.tsx",
     "./tokens.css": "./src/tokens.css",
     "./reset.css": "./src/reset.css",
+    "./primitives.css": "./src/primitives/primitives.css",
     "./auth.css": "./src/auth/auth.css"
   },
   "dependencies": {

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,23 +1,7 @@
-import type { PropsWithChildren } from "react";
-
 export * from "./auth";
 export * from "./admin";
+export * from "./primitives";
 export { AppSwitcher, appUrl, type AppId } from "./AppSwitcher";
 export { AccountLinkCard } from "./AccountLinkCard";
 export { SubmissionHistoryLink, type SubmissionHistoryEntry } from "./SubmissionHistoryLink";
 export { LabSettingsPanel } from "./admin/LabSettingsPanel";
-
-export const Panel = ({ title, children }: PropsWithChildren<{ title: string }>) => (
-  <section className="ilm-panel">
-    <h2 className="ilm-panel-title">{title}</h2>
-    {children}
-  </section>
-);
-
-export const Tag = ({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "info" | "warning" | "success" }) => {
-  return (
-    <span className={`ilm-tag ilm-tag-${tone}`}>
-      {label}
-    </span>
-  );
-};

--- a/packages/ui/src/primitives/Badge.tsx
+++ b/packages/ui/src/primitives/Badge.tsx
@@ -1,0 +1,58 @@
+import type { HTMLAttributes, PropsWithChildren } from "react";
+
+export type BadgeTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone;
+}
+
+export const Badge = ({
+  tone = "neutral",
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<BadgeProps>) => (
+  <span
+    className={["rl-badge", `rl-badge--${tone}`, className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children}
+  </span>
+);
+
+export type StatusTone =
+  | "draft"
+  | "submitted"
+  | "reviewing"
+  | "reviewed"
+  | "published"
+  | "validated"
+  | "active"
+  | "archived"
+  | "rejected"
+  | "failed"
+  | "blocked"
+  | "proposed"
+  | "cancelled"
+  | "deleted"
+  | "neutral";
+
+export interface StatusPillProps extends HTMLAttributes<HTMLSpanElement> {
+  status: StatusTone;
+  label?: string;
+}
+
+export const StatusPill = ({
+  status,
+  label,
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<StatusPillProps>) => (
+  <span
+    className={["rl-status", `rl-status--${status}`, className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children ?? label ?? status}
+  </span>
+);

--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "ink";
+export type ButtonSize = "sm" | "md";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  block?: boolean;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "secondary", size = "md", block, className, type = "button", ...rest },
+  ref,
+) {
+  const classes = [
+    "rl-btn",
+    `rl-btn--${variant}`,
+    size === "sm" ? "rl-btn--sm" : null,
+    block ? "rl-btn--block" : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <button ref={ref} type={type} className={classes} {...rest} />;
+});

--- a/packages/ui/src/primitives/Feedback.tsx
+++ b/packages/ui/src/primitives/Feedback.tsx
@@ -1,0 +1,73 @@
+import type { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
+
+export interface EmptyStateProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  boxed?: boolean;
+}
+
+export const EmptyState = ({
+  title,
+  description,
+  action,
+  boxed,
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<EmptyStateProps>) => (
+  <div
+    className={["rl-empty", boxed ? "rl-empty--boxed" : null, className]
+      .filter(Boolean)
+      .join(" ")}
+    {...rest}
+  >
+    {title ? <h4 className="rl-empty-title">{title}</h4> : null}
+    {description ? <p className="rl-empty-description">{description}</p> : null}
+    {children}
+    {action}
+  </div>
+);
+
+export interface ErrorBannerProps extends HTMLAttributes<HTMLParagraphElement> {}
+
+export const ErrorBanner = ({
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<ErrorBannerProps>) => (
+  <p
+    role="alert"
+    className={["rl-error-banner", className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children}
+  </p>
+);
+
+export const InlineError = ({
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>) => (
+  <p
+    role="alert"
+    className={["rl-inline-error", className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children}
+  </p>
+);
+
+export const InlineNote = ({
+  className,
+  children,
+  ...rest
+}: PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>) => (
+  <p
+    className={["rl-inline-note", className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children}
+  </p>
+);

--- a/packages/ui/src/primitives/FormField.tsx
+++ b/packages/ui/src/primitives/FormField.tsx
@@ -1,0 +1,109 @@
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type PropsWithChildren,
+  type ReactNode,
+  type SelectHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from "react";
+
+export interface FormFieldProps {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  htmlFor?: string;
+  className?: string;
+  labelClassName?: string;
+}
+
+export const FormField = ({
+  label,
+  hint,
+  error,
+  htmlFor,
+  className,
+  labelClassName,
+  children,
+}: PropsWithChildren<FormFieldProps>) => {
+  const classes = ["rl-field", className].filter(Boolean).join(" ");
+  const labelClasses = ["rl-field-label", labelClassName].filter(Boolean).join(" ");
+  return (
+    <label className={classes} htmlFor={htmlFor}>
+      {label ? <span className={labelClasses}>{label}</span> : null}
+      {children}
+      {hint && !error ? <span className="rl-field-hint">{hint}</span> : null}
+      {error ? <span className="rl-field-error">{error}</span> : null}
+    </label>
+  );
+};
+
+export const FormRow = ({ children, className }: PropsWithChildren<{ className?: string }>) => (
+  <div className={["rl-field-row", className].filter(Boolean).join(" ")}>{children}</div>
+);
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { invalid, className, ...rest },
+  ref,
+) {
+  const classes = ["rl-input", invalid ? "rl-input--error" : null, className]
+    .filter(Boolean)
+    .join(" ");
+  return <input ref={ref} className={classes} {...rest} />;
+});
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  invalid?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { invalid, className, ...rest },
+  ref,
+) {
+  const classes = ["rl-textarea", invalid ? "rl-textarea--error" : null, className]
+    .filter(Boolean)
+    .join(" ");
+  return <textarea ref={ref} className={classes} {...rest} />;
+});
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  invalid?: boolean;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { invalid, className, children, ...rest },
+  ref,
+) {
+  const classes = ["rl-select", invalid ? "rl-select--error" : null, className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <select ref={ref} className={classes} {...rest}>
+      {children}
+    </select>
+  );
+});
+
+export interface CheckboxFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: ReactNode;
+  hint?: ReactNode;
+  wrapperClassName?: string;
+}
+
+export const CheckboxField = forwardRef<HTMLInputElement, CheckboxFieldProps>(function CheckboxField(
+  { label, hint, wrapperClassName, className, type = "checkbox", ...rest },
+  ref,
+) {
+  return (
+    <label className={["rl-checkbox-field", wrapperClassName].filter(Boolean).join(" ")}>
+      <input ref={ref} type={type} className={className} {...rest} />
+      <span>
+        {label}
+        {hint ? <span className="rl-field-hint"> — {hint}</span> : null}
+      </span>
+    </label>
+  );
+});

--- a/packages/ui/src/primitives/Modal.tsx
+++ b/packages/ui/src/primitives/Modal.tsx
@@ -1,0 +1,120 @@
+import { useEffect, type MouseEvent, type PropsWithChildren, type ReactNode } from "react";
+import { Button } from "./Button";
+
+export type ModalWidth = "narrow" | "default" | "wide";
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  note?: ReactNode;
+  actions?: ReactNode;
+  width?: ModalWidth;
+  closeOnBackdrop?: boolean;
+  closeOnEscape?: boolean;
+  className?: string;
+  labelledBy?: string;
+}
+
+export const Modal = ({
+  open,
+  onClose,
+  title,
+  note,
+  actions,
+  width = "default",
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  className,
+  labelledBy,
+  children,
+}: PropsWithChildren<ModalProps>) => {
+  useEffect(() => {
+    if (!open || !closeOnEscape) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, closeOnEscape, onClose]);
+
+  if (!open) return null;
+
+  const handleBackdrop = (event: MouseEvent<HTMLDivElement>) => {
+    if (!closeOnBackdrop) return;
+    if (event.target === event.currentTarget) onClose();
+  };
+
+  const widthClass =
+    width === "wide" ? "rl-modal--wide" : width === "narrow" ? "rl-modal--narrow" : null;
+
+  return (
+    <div className="rl-modal-backdrop" onMouseDown={handleBackdrop}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelledBy}
+        className={["rl-modal", widthClass, className].filter(Boolean).join(" ")}
+      >
+        {title ? (
+          <header className="rl-modal-head">
+            <h2 id={labelledBy}>{title}</h2>
+            <button type="button" className="rl-modal-close" aria-label="Close" onClick={onClose}>
+              ×
+            </button>
+          </header>
+        ) : null}
+        {note ? <p className="rl-modal-note">{note}</p> : null}
+        {children}
+        {actions ? <div className="rl-modal-actions">{actions}</div> : null}
+      </div>
+    </div>
+  );
+};
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  title: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: ReactNode;
+  cancelLabel?: ReactNode;
+  tone?: "primary" | "danger";
+  busy?: boolean;
+}
+
+export const ConfirmDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  tone = "primary",
+  busy,
+}: ConfirmDialogProps) => (
+  <Modal
+    open={open}
+    onClose={onClose}
+    title={title}
+    width="narrow"
+    actions={
+      <>
+        <Button variant="secondary" onClick={onClose} disabled={busy}>
+          {cancelLabel}
+        </Button>
+        <Button
+          variant={tone === "danger" ? "danger" : "primary"}
+          onClick={() => void onConfirm()}
+          disabled={busy}
+        >
+          {confirmLabel}
+        </Button>
+      </>
+    }
+  >
+    {description ? <p className="rl-modal-note">{description}</p> : null}
+  </Modal>
+);

--- a/packages/ui/src/primitives/Panel.tsx
+++ b/packages/ui/src/primitives/Panel.tsx
@@ -1,0 +1,48 @@
+import type { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
+
+export interface PanelProps extends HTMLAttributes<HTMLElement> {
+  flush?: boolean;
+  as?: "section" | "div" | "article";
+}
+
+export const Panel = ({ flush, as = "section", className, children, ...rest }: PanelProps) => {
+  const Element = as;
+  const classes = ["rl-panel", flush ? "rl-panel--flush" : null, className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <Element className={classes} {...rest}>
+      {children}
+    </Element>
+  );
+};
+
+export interface SectionHeaderProps {
+  title: ReactNode;
+  meta?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+  titleClassName?: string;
+}
+
+export const SectionHeader = ({
+  title,
+  meta,
+  actions,
+  className,
+  titleClassName,
+}: SectionHeaderProps) => {
+  const classes = ["rl-section-header", className].filter(Boolean).join(" ");
+  const titleClasses = ["rl-section-header__title", titleClassName].filter(Boolean).join(" ");
+  return (
+    <header className={classes}>
+      <h3 className={titleClasses}>{title}</h3>
+      {meta ? <span className="rl-section-header__meta">{meta}</span> : null}
+      {actions ? <div className="rl-section-header__actions">{actions}</div> : null}
+    </header>
+  );
+};
+
+export const CardGrid = ({ className, children }: PropsWithChildren<{ className?: string }>) => (
+  <div className={["rl-card-grid", className].filter(Boolean).join(" ")}>{children}</div>
+);

--- a/packages/ui/src/primitives/Table.tsx
+++ b/packages/ui/src/primitives/Table.tsx
@@ -1,0 +1,34 @@
+import type { PropsWithChildren, TableHTMLAttributes } from "react";
+
+export interface TableProps extends TableHTMLAttributes<HTMLTableElement> {}
+
+export const Table = ({ className, children, ...rest }: TableProps) => (
+  <table className={["rl-table", className].filter(Boolean).join(" ")} {...rest}>
+    {children}
+  </table>
+);
+
+export const TableEmpty = ({
+  children,
+  colSpan,
+}: PropsWithChildren<{ colSpan: number }>) => (
+  <tr>
+    <td colSpan={colSpan} className="rl-table-empty">
+      {children}
+    </td>
+  </tr>
+);
+
+export const TableLoading = ({
+  colSpan,
+  label = "Loading…",
+}: {
+  colSpan: number;
+  label?: string;
+}) => (
+  <tr>
+    <td colSpan={colSpan} className="rl-table-loading">
+      {label}
+    </td>
+  </tr>
+);

--- a/packages/ui/src/primitives/Tabs.tsx
+++ b/packages/ui/src/primitives/Tabs.tsx
@@ -1,0 +1,75 @@
+import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from "react";
+
+export interface TabItem<T extends string = string> {
+  id: T;
+  label: ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps<T extends string = string> {
+  items: readonly TabItem<T>[];
+  activeId: T;
+  onChange: (id: T) => void;
+  plain?: boolean;
+  className?: string;
+  right?: ReactNode;
+}
+
+export const Tabs = <T extends string = string>({
+  items,
+  activeId,
+  onChange,
+  plain,
+  className,
+  right,
+}: TabsProps<T>) => {
+  const classes = ["rl-tabs", plain ? "rl-tabs--plain" : null, className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div role="tablist" className={classes}>
+      {items.map((item) => (
+        <button
+          key={item.id}
+          role="tab"
+          type="button"
+          disabled={item.disabled}
+          aria-selected={item.id === activeId}
+          className="rl-tab"
+          onClick={() => onChange(item.id)}
+        >
+          {item.label}
+        </button>
+      ))}
+      {right ? <div className="rl-tabs-right">{right}</div> : null}
+    </div>
+  );
+};
+
+export interface TabButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean;
+}
+
+export const TabButton = ({ active, className, type = "button", ...rest }: TabButtonProps) => (
+  <button
+    type={type}
+    className={["rl-tab", active ? "is-active" : null, className].filter(Boolean).join(" ")}
+    aria-selected={active}
+    role="tab"
+    {...rest}
+  />
+);
+
+export const TabPanel = ({
+  children,
+  className,
+  ...rest
+}: PropsWithChildren<{ className?: string } & React.HTMLAttributes<HTMLDivElement>>) => (
+  <div
+    role="tabpanel"
+    className={["rl-tab-panel", className].filter(Boolean).join(" ")}
+    {...rest}
+  >
+    {children}
+  </div>
+);

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,0 +1,40 @@
+export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
+export {
+  FormField,
+  FormRow,
+  Input,
+  Textarea,
+  Select,
+  CheckboxField,
+  type FormFieldProps,
+  type InputProps,
+  type TextareaProps,
+  type SelectProps,
+  type CheckboxFieldProps,
+} from "./FormField";
+export { Panel, SectionHeader, CardGrid, type PanelProps, type SectionHeaderProps } from "./Panel";
+export { Tabs, TabButton, TabPanel, type TabItem, type TabsProps, type TabButtonProps } from "./Tabs";
+export {
+  Modal,
+  ConfirmDialog,
+  type ModalProps,
+  type ModalWidth,
+  type ConfirmDialogProps,
+} from "./Modal";
+export { Table, TableEmpty, TableLoading, type TableProps } from "./Table";
+export {
+  Badge,
+  StatusPill,
+  type BadgeProps,
+  type BadgeTone,
+  type StatusPillProps,
+  type StatusTone,
+} from "./Badge";
+export {
+  EmptyState,
+  ErrorBanner,
+  InlineError,
+  InlineNote,
+  type EmptyStateProps,
+  type ErrorBannerProps,
+} from "./Feedback";

--- a/packages/ui/src/primitives/primitives.css
+++ b/packages/ui/src/primitives/primitives.css
@@ -1,0 +1,496 @@
+/* ============================================================
+   @ilm/ui — Primitives
+   Imported by apps after tokens.css + reset.css.
+   All classes are scoped under the .rl-* prefix. Every primitive
+   exposes CSS custom properties (--rl-btn-bg, --rl-card-bg, ...) so
+   apps can restyle a single usage without forking the primitive.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   Button (.rl-btn)
+   Variants: primary / secondary / ghost / danger / ink
+   Sizes:    sm / md
+   ------------------------------------------------------------ */
+.rl-btn {
+  --rl-btn-bg: #ffffff;
+  --rl-btn-fg: var(--rl-ink);
+  --rl-btn-border: var(--rl-line);
+  --rl-btn-bg-hover: var(--rl-soft);
+  --rl-btn-border-hover: var(--rl-line);
+  --rl-btn-shadow-hover: none;
+  --rl-btn-pad-y: 0.55rem;
+  --rl-btn-pad-x: 1rem;
+  --rl-btn-font-size: 0.82rem;
+  --rl-btn-radius: var(--rl-radius-sm);
+
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--rl-btn-border);
+  background: var(--rl-btn-bg);
+  color: var(--rl-btn-fg);
+  border-radius: var(--rl-btn-radius);
+  padding: var(--rl-btn-pad-y) var(--rl-btn-pad-x);
+  font-family: var(--rl-font-sans);
+  font-size: var(--rl-btn-font-size);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background var(--rl-dur-base) var(--rl-ease),
+    border-color var(--rl-dur-base) var(--rl-ease),
+    box-shadow var(--rl-dur-base) var(--rl-ease),
+    color var(--rl-dur-base) var(--rl-ease),
+    transform var(--rl-dur-base) var(--rl-ease);
+}
+.rl-btn:hover:not(:disabled) {
+  background: var(--rl-btn-bg-hover);
+  border-color: var(--rl-btn-border-hover);
+  box-shadow: var(--rl-btn-shadow-hover);
+}
+.rl-btn:active:not(:disabled) { transform: scale(0.98); }
+.rl-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(79, 111, 82, 0.3);
+}
+.rl-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.rl-btn--primary {
+  --rl-btn-bg: var(--rl-green);
+  --rl-btn-fg: #ffffff;
+  --rl-btn-border: var(--rl-green);
+  --rl-btn-bg-hover: var(--rl-green-2);
+  --rl-btn-border-hover: var(--rl-green-2);
+  --rl-btn-shadow-hover: var(--rl-shadow-glow-primary);
+}
+
+.rl-btn--secondary {
+  --rl-btn-bg: transparent;
+  --rl-btn-fg: var(--rl-ink);
+  --rl-btn-border: var(--rl-outline);
+  --rl-btn-bg-hover: var(--rl-lab-gray);
+  --rl-btn-border-hover: var(--rl-outline);
+}
+
+.rl-btn--ghost {
+  --rl-btn-bg: transparent;
+  --rl-btn-fg: var(--rl-ink);
+  --rl-btn-border: transparent;
+  --rl-btn-bg-hover: var(--rl-soft);
+  --rl-btn-border-hover: transparent;
+}
+
+.rl-btn--danger {
+  --rl-btn-bg: #ffffff;
+  --rl-btn-fg: var(--rl-danger-text);
+  --rl-btn-border: #f2b3af;
+  --rl-btn-bg-hover: #fbefed;
+  --rl-btn-border-hover: #e89a95;
+}
+
+.rl-btn--ink {
+  --rl-btn-bg: var(--rl-ink);
+  --rl-btn-fg: #ffffff;
+  --rl-btn-border: var(--rl-ink);
+  --rl-btn-bg-hover: var(--rl-ink-2);
+  --rl-btn-border-hover: var(--rl-ink-2);
+}
+
+.rl-btn--sm {
+  --rl-btn-pad-y: 0.35rem;
+  --rl-btn-pad-x: 0.7rem;
+  --rl-btn-font-size: 0.76rem;
+}
+
+.rl-btn--block { width: 100%; }
+
+/* ------------------------------------------------------------
+   FormField / Input / Textarea / Select
+   ------------------------------------------------------------ */
+.rl-field {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.88rem;
+  color: var(--rl-fg-2);
+}
+.rl-field-label {
+  font-weight: 500;
+  color: var(--rl-fg-2);
+}
+.rl-field-hint {
+  font-size: 0.78rem;
+  color: var(--rl-muted);
+}
+.rl-field-error {
+  font-size: 0.8rem;
+  color: var(--rl-danger-text);
+}
+.rl-field-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8rem;
+}
+
+.rl-input,
+.rl-textarea,
+.rl-select {
+  width: 100%;
+  border: 1px solid var(--rl-line);
+  border-radius: var(--rl-radius-sm);
+  padding: 0.55rem 0.75rem;
+  background: var(--rl-surface);
+  color: var(--rl-ink);
+  font-family: var(--rl-font-sans);
+  font-size: 0.9rem;
+  transition: border-color var(--rl-dur-base) var(--rl-ease), box-shadow var(--rl-dur-base) var(--rl-ease);
+}
+.rl-input:focus,
+.rl-textarea:focus,
+.rl-select:focus {
+  outline: none;
+  border-color: var(--rl-green-2);
+  box-shadow: 0 0 0 3px rgba(79, 111, 82, 0.18);
+}
+.rl-input:disabled,
+.rl-textarea:disabled,
+.rl-select:disabled {
+  background: var(--rl-surface-2);
+  color: var(--rl-muted);
+  cursor: not-allowed;
+}
+.rl-textarea { resize: vertical; min-height: 4.2rem; }
+
+.rl-input--error,
+.rl-textarea--error,
+.rl-select--error {
+  border-color: #f2b3af;
+}
+.rl-input--error:focus,
+.rl-textarea--error:focus,
+.rl-select--error:focus {
+  border-color: var(--rl-danger-text);
+  box-shadow: 0 0 0 3px rgba(180, 35, 24, 0.18);
+}
+
+.rl-checkbox-field {
+  display: flex;
+  gap: 0.45rem;
+  align-items: flex-start;
+  font-size: 0.88rem;
+  color: var(--rl-fg-2);
+  padding: 0.25rem 0;
+}
+.rl-checkbox-field input { margin-top: 0.2rem; }
+
+/* ------------------------------------------------------------
+   Card / Panel / SectionHeader
+   ------------------------------------------------------------ */
+.rl-panel {
+  --rl-panel-bg: var(--rl-surface);
+  --rl-panel-border: var(--rl-line);
+  --rl-panel-radius: var(--rl-radius-soft);
+  background: var(--rl-panel-bg);
+  border: 1px solid var(--rl-panel-border);
+  border-radius: var(--rl-panel-radius);
+  padding: 1rem 1.2rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+.rl-panel--flush { padding: 0; }
+
+.rl-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.rl-section-header__title {
+  margin: 0;
+  font-family: var(--rl-font-serif);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+.rl-section-header__meta {
+  font-size: 0.75rem;
+  color: var(--rl-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.rl-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+/* ------------------------------------------------------------
+   Tabs (.rl-tabs / .rl-tab)
+   ------------------------------------------------------------ */
+.rl-tabs {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.55rem 1.1rem;
+  border-bottom: 1px solid var(--rl-hairline);
+  background: var(--rl-soft);
+}
+.rl-tabs--plain {
+  background: transparent;
+  padding: 0;
+  border-bottom-color: var(--rl-line);
+}
+.rl-tabs-right { margin-left: auto; }
+
+.rl-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0;
+  font-family: var(--rl-font-sans);
+  font-size: 0.82rem;
+  color: var(--rl-muted);
+  letter-spacing: 0.04em;
+  position: relative;
+  cursor: pointer;
+}
+.rl-tab:hover { color: var(--rl-ink); }
+.rl-tab[aria-selected="true"],
+.rl-tab.is-active {
+  color: var(--rl-ink);
+  font-weight: 600;
+}
+.rl-tab[aria-selected="true"]::after,
+.rl-tab.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.58rem;
+  height: 2px;
+  background: var(--rl-green);
+}
+.rl-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(79, 111, 82, 0.35);
+  border-radius: 4px;
+}
+
+.rl-tab-panel {
+  padding: 1.1rem 0;
+}
+
+/* ------------------------------------------------------------
+   Modal / Dialog
+   ------------------------------------------------------------ */
+.rl-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 23, 30, 0.48);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: var(--rl-z-modal);
+}
+.rl-modal {
+  --rl-modal-width: min(560px, 100%);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
+  border-radius: var(--rl-radius-lg);
+  padding: 1.3rem 1.4rem 1.4rem;
+  width: var(--rl-modal-width);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  box-shadow: var(--rl-shadow-float);
+  max-height: calc(100vh - 3rem);
+  overflow: auto;
+}
+.rl-modal--wide  { --rl-modal-width: min(820px, 100%); }
+.rl-modal--narrow { --rl-modal-width: min(420px, 100%); }
+
+.rl-modal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.rl-modal-head h2 {
+  margin: 0;
+  font-family: var(--rl-font-serif);
+  font-size: 1.2rem;
+}
+.rl-modal-close {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--rl-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.4rem;
+}
+.rl-modal-close:hover { color: var(--rl-ink); }
+
+.rl-modal-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--rl-muted);
+}
+.rl-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* ------------------------------------------------------------
+   Table
+   ------------------------------------------------------------ */
+.rl-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.rl-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--rl-soft);
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  font-family: var(--rl-font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--rl-muted);
+  border-bottom: 1px solid var(--rl-line);
+  z-index: var(--rl-z-sticky);
+}
+.rl-table tbody td {
+  padding: 0.65rem 0.8rem;
+  border-bottom: 1px solid var(--rl-hairline);
+  vertical-align: top;
+}
+.rl-table tbody tr:hover td {
+  background: rgba(79, 111, 82, 0.04);
+}
+.rl-table tbody tr:last-child td { border-bottom: none; }
+
+.rl-table-empty,
+.rl-table-loading {
+  padding: 1.4rem;
+  text-align: center;
+  color: var(--rl-muted);
+  font-size: 0.9rem;
+}
+
+/* ------------------------------------------------------------
+   Badge / StatusPill
+   ------------------------------------------------------------ */
+.rl-badge {
+  --rl-badge-bg: var(--rl-lab-gray);
+  --rl-badge-fg: var(--rl-muted);
+  --rl-badge-border: var(--rl-line);
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--rl-radius-pill);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  background: var(--rl-badge-bg);
+  color: var(--rl-badge-fg);
+  border: 1px solid var(--rl-badge-border);
+}
+.rl-badge--info    { --rl-badge-bg: #eaf1f6; --rl-badge-fg: #2c4f71; --rl-badge-border: #bed0e0; }
+.rl-badge--success { --rl-badge-bg: var(--rl-green-soft); --rl-badge-fg: var(--rl-green); --rl-badge-border: rgba(55, 86, 59, 0.2); }
+.rl-badge--warning { --rl-badge-bg: var(--rl-warn-bg); --rl-badge-fg: var(--rl-warn); --rl-badge-border: var(--rl-warn-border); }
+.rl-badge--danger  { --rl-badge-bg: var(--rl-error-c); --rl-badge-fg: var(--rl-error-deep); --rl-badge-border: #f2b3af; }
+.rl-badge--neutral { --rl-badge-bg: #ece7dc; --rl-badge-fg: #5b584f; --rl-badge-border: #d5cfc1; }
+
+/* StatusPill — workflow statuses extracted from Protocol + Project */
+.rl-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.22rem 0.6rem;
+  border-radius: var(--rl-radius-pill);
+  font-family: var(--rl-font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+.rl-status--draft      { background: #fbf2e4; color: #8a4900; border-color: #d7bca1; }
+.rl-status--submitted  { background: #f8edcf; color: #7c5c16; border-color: #e7d39a; }
+.rl-status--reviewing  { background: #f8edcf; color: #7c5c16; border-color: #e7d39a; }
+.rl-status--reviewed   { background: #dfeaf7; color: #335983; border-color: #b5cbe7; }
+.rl-status--published  { background: var(--rl-green-soft); color: var(--rl-green); border-color: rgba(55, 86, 59, 0.2); }
+.rl-status--validated  { background: #dcefe8; color: #24564b; border-color: #b2d8ca; }
+.rl-status--active     { background: #e2efe1; color: #24533c; border-color: #b6d1b4; }
+.rl-status--archived   { background: #efe6db; color: #74563f; border-color: #d7bfa7; }
+.rl-status--rejected,
+.rl-status--failed,
+.rl-status--blocked    { background: var(--rl-error-c); color: var(--rl-error-deep); border-color: #f2b3af; }
+.rl-status--proposed   { background: #f3e4f3; color: #6d4470; border-color: #d9bfdc; }
+.rl-status--cancelled,
+.rl-status--deleted,
+.rl-status--neutral    { background: #ece7dc; color: #5b584f; border-color: #d5cfc1; }
+
+/* ------------------------------------------------------------
+   EmptyState / ErrorBanner / InlineNote
+   ------------------------------------------------------------ */
+.rl-empty {
+  color: var(--rl-muted);
+  font-size: 0.92rem;
+  margin: 0.4rem 0;
+  padding: 1rem 0;
+  text-align: center;
+}
+.rl-empty--boxed {
+  border: 1px dashed var(--rl-line);
+  border-radius: var(--rl-radius-soft);
+  padding: 1.5rem;
+}
+.rl-empty-title {
+  font-family: var(--rl-font-serif);
+  font-size: 1.1rem;
+  color: var(--rl-ink);
+  margin: 0 0 0.3rem;
+}
+.rl-empty-description {
+  font-size: 0.9rem;
+  color: var(--rl-muted);
+  margin: 0 0 0.75rem;
+}
+
+.rl-error-banner {
+  background: var(--rl-error-c);
+  border: 1px solid #f2b3af;
+  color: var(--rl-danger-text);
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--rl-radius-sm);
+  margin: 0;
+  font-size: 0.9rem;
+}
+.rl-inline-error {
+  color: var(--rl-danger-text);
+  font-size: 0.85rem;
+  margin: 0;
+}
+.rl-inline-note {
+  background: var(--rl-warn-bg);
+  border: 1px solid var(--rl-warn-border);
+  color: var(--rl-warn);
+  border-radius: var(--rl-radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary

- Phase B of the shared UI kit: primitives land in `packages/ui/src/primitives/` with styles in `@ilm/ui/primitives.css`, all scoped under `.rl-*`.
- Shipped: `Button`, `FormField` + `Input` / `Textarea` / `Select` / `CheckboxField` + `FormRow`, `Panel` + `SectionHeader` + `CardGrid`, `Tabs` + `TabButton` + `TabPanel`, `Modal` + `ConfirmDialog`, `Table` + `TableEmpty` + `TableLoading`, `Badge` + `StatusPill`, `EmptyState` + `ErrorBanner` + `InlineError` + `InlineNote`.
- Every primitive exposes CSS custom-property slots (`--rl-btn-bg`, `--rl-panel-bg`, `--rl-badge-fg`, `--rl-modal-width`, …) so apps can restyle a single usage without forking the primitive.
- Dropped unused legacy `Panel` / `Tag` helpers from the `@ilm/ui` index (no app imports them); the names now belong to the new primitives.

## Why

Supply Manager (Stage 4c) is the next app to build; without shared primitives it would clone another 1000+ lines of app CSS. This PR makes Supply Manager the first consumer of the kit instead of another donor.

## Sources

- **Project Manager** — forms (`.pm-field`), panels (`.pm-panel-section`), tabs (`.pm-tab-nav`), modal (`.pm-modal*`), feedback (`.pm-page-error`, `.pm-inline-note`).
- **Protocol Manager** — button treatments (`.protocol-primary-action` et al.) and workflow status badges (`.protocol-status-badge-*`).

## Scope notes

- Existing apps keep their local CSS. Phase D (separate PRs) will migrate Account, Project Manager, and Protocol Manager in that order of risk.
- `Drawer`, `InlineToast`, and column-sort affordances are deferred under the kit's "first use local, second use promote" rule.
- `docs/features.md` gets a new "Shared UI kit (Stage 4c-pre)" section; `docs/ui-alignment.md` marks Phase B shipped with the final exported surface.

## Test plan

- [x] `npm run typecheck` across all workspaces
- [x] `npm run build --workspace=@ilm/ui` (declarations emit under `dist/src/primitives/`)
- [ ] Visual verification happens when Supply Manager starts consuming the kit in the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)