### PR TITLE
UI kit Phase A.1: tokenize remaining font-family + auth.css colors

### DIFF
--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -30,7 +30,7 @@
   border-bottom: 1px solid var(--rl-hairline);
 }
 .acct-side-header strong {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.05rem;
   color: var(--rl-ink);
 }
@@ -111,7 +111,7 @@
   text-align: center;
 }
 .acct-stat-value {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.25rem;
   color: var(--rl-ink);
   line-height: 1;
@@ -193,7 +193,7 @@
 }
 .acct-topbar-copy h1 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.6rem;
   color: var(--rl-ink);
 }

--- a/apps/project-manager/src/styles.css
+++ b/apps/project-manager/src/styles.css
@@ -30,7 +30,7 @@
   border-bottom: 1px solid var(--rl-hairline);
 }
 .pm-side-rail-header strong {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.05rem;
   color: var(--rl-ink);
 }
@@ -170,7 +170,7 @@
 }
 .pm-topbar-copy h1 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.7rem;
   color: var(--rl-ink);
 }
@@ -229,7 +229,7 @@
 }
 .pm-panel-header h2 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.35rem;
 }
 .pm-panel-header p { margin: 0.15rem 0 0; color: var(--rl-muted); }
@@ -250,7 +250,7 @@
 }
 .pm-panel-section-head h3 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.05rem;
 }
 .pm-panel-section-head span {
@@ -273,7 +273,7 @@
   align-items: center;
   cursor: pointer;
   color: var(--rl-ink);
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1rem;
 }
 .pm-collapsible-section summary::-webkit-details-marker { display: none; }
@@ -304,7 +304,7 @@
   letter-spacing: 0.12em;
 }
 .pm-summary-card strong {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.35rem;
   color: var(--rl-ink);
 }
@@ -333,7 +333,7 @@
 }
 .pm-library-card-head strong {
   display: block;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.05rem;
   color: var(--rl-ink);
 }
@@ -514,7 +514,7 @@
 }
 .pm-outline-root strong {
   display: block;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.05rem;
   color: var(--rl-ink);
 }
@@ -748,7 +748,7 @@
 }
 .pm-draft-actions strong {
   display: block;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 0.98rem;
 }
 .pm-draft-actions p {
@@ -817,7 +817,7 @@
 }
 .pm-roadmap-section-head h3 {
   margin: 0.18rem 0 0.18rem;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.1rem;
 }
 .pm-roadmap-section-head p {
@@ -882,7 +882,7 @@
 }
 .pm-form-head h3 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.02rem;
 }
 .pm-form-head small { color: var(--rl-muted); font-size: 0.78rem; }
@@ -996,7 +996,7 @@
 }
 .pm-modal-head h2 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.2rem;
 }
 .pm-modal-note {

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -345,7 +345,7 @@ label {
   border: 1px solid rgba(39, 39, 39, 0.1);
   border-radius: 999px;
   color: #677166;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.64rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -488,7 +488,7 @@ label {
   padding: 0;
   background: transparent;
   font-size: 0.74rem;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
 }
 
 .outline-step-pill.selected .outline-step-index,
@@ -797,7 +797,7 @@ label {
   width: 3rem;
   height: 3rem;
   border: 1px solid var(--rl-line);
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.9rem;
   letter-spacing: 0.2em;
 }
@@ -807,7 +807,7 @@ label {
 .dashboard-card-header h2,
 .dashboard-core-node p {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
 }
 
 .dashboard-brand-title {
@@ -837,7 +837,7 @@ label {
 .protocol-workspace-meta,
 .protocol-inline-link,
 .protocol-panel-header span {
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   text-transform: uppercase;
   letter-spacing: 0.14em;
 }
@@ -1029,7 +1029,7 @@ label {
 }
 
 .dashboard-metric-row strong {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 2.2rem;
   font-style: italic;
   font-weight: 900;
@@ -1116,7 +1116,7 @@ label {
 }
 
 .dashboard-core-node strong {
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.8rem;
   color: var(--rl-green);
   letter-spacing: 0.18em;
@@ -1248,7 +1248,7 @@ label {
 
 .protocol-wordmark-module {
   color: #6f756d;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.18em;
@@ -1292,7 +1292,7 @@ label {
   margin: 0;
   color: #6f756d;
   font-size: 0.78rem;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -1480,7 +1480,7 @@ label {
 .protocol-side-account-header strong,
 .protocol-side-account-meta span,
 .protocol-side-account-action {
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -1534,7 +1534,7 @@ label {
 
 .home-hero-title {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: clamp(2.6rem, 5.2vw, 4.3rem);
   line-height: 0.98;
   letter-spacing: -0.04em;
@@ -1646,7 +1646,7 @@ label {
 
 .protocol-page-header h1 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: clamp(2.2rem, 4vw, 3.4rem);
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -1655,7 +1655,7 @@ label {
 .protocol-page-kicker {
   margin: 0 0 0.45rem;
   color: #6f756d;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.16em;
@@ -1690,7 +1690,7 @@ label {
 .protocol-card-heading h3,
 .protocol-panel-header h3 {
   margin: 0;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
 }
 
 .protocol-outline-header h2 {
@@ -1996,7 +1996,7 @@ label {
 
 .protocol-data-table th {
   color: #7a8179;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.76rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -2121,7 +2121,7 @@ label {
 .protocol-summary-grid span,
 .protocol-timeline-stage span {
   color: #7b817a;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.76rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -2130,7 +2130,7 @@ label {
 .protocol-summary-grid strong,
 .protocol-timeline-stage strong {
   font-size: 1.3rem;
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
 }
 
 .protocol-summary-grid small,
@@ -2185,7 +2185,7 @@ label {
   align-items: center;
   cursor: pointer;
   color: var(--rl-green);
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--rl-font-sans);
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2275,7 +2275,7 @@ label {
   align-items: center;
   padding: 0.22rem 0.48rem;
   border: 1px solid transparent;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.66rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -2312,7 +2312,7 @@ label {
   align-items: center;
   border: 1px solid #d6ddd3;
   padding: 0.22rem 0.45rem;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--rl-font-mono);
   font-size: 0.66rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -2388,7 +2388,7 @@ label {
 }
 
 .protocol-new-choice strong {
-  font-family: "Noto Serif", Georgia, serif;
+  font-family: var(--rl-font-serif);
   font-size: 1.1rem;
   color: var(--rl-green);
 }
@@ -2397,7 +2397,7 @@ label {
   color: #5b6459;
   text-transform: none;
   letter-spacing: normal;
-  font-family: "Space Grotesk", Arial, sans-serif;
+  font-family: var(--rl-font-sans);
 }
 
 .protocol-tab-panel .section-intro {

--- a/packages/ui/src/auth/auth.css
+++ b/packages/ui/src/auth/auth.css
@@ -4,14 +4,14 @@
   align-items: center;
   justify-content: center;
   padding: 2rem 1rem;
-  background: var(--ilm-color-bg, #f6f7f9);
+  background: var(--rl-paper);
 }
 
 .ilm-auth-card {
   width: 100%;
   max-width: 26rem;
-  background: var(--ilm-color-surface, #ffffff);
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  background: var(--rl-surface);
+  border: 1px solid var(--rl-line);
   border-radius: 12px;
   padding: 2rem;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
@@ -27,7 +27,7 @@
   display: flex;
   gap: 0.25rem;
   margin-bottom: 1.5rem;
-  border-bottom: 1px solid var(--ilm-color-border, #e2e5ea);
+  border-bottom: 1px solid var(--rl-line);
 }
 
 .ilm-auth-tab {
@@ -37,14 +37,14 @@
   padding: 0.5rem 0.75rem;
   font-size: 0.9rem;
   cursor: pointer;
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
 }
 
 .ilm-auth-tab-active {
-  color: var(--ilm-color-text, #0f172a);
-  border-bottom-color: var(--ilm-color-accent, #2563eb);
+  color: var(--rl-ink);
+  border-bottom-color: var(--rl-green-2);
   font-weight: 600;
 }
 
@@ -62,21 +62,21 @@
 }
 
 .ilm-auth-field span {
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
   font-weight: 500;
 }
 
 .ilm-auth-field input {
   padding: 0.55rem 0.65rem;
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border: 1px solid var(--rl-line);
   border-radius: 6px;
   font-size: 0.95rem;
-  background: var(--ilm-color-surface, #ffffff);
-  color: var(--ilm-color-text, #0f172a);
+  background: var(--rl-surface);
+  color: var(--rl-ink);
 }
 
 .ilm-auth-field input:focus {
-  outline: 2px solid var(--ilm-color-accent, #2563eb);
+  outline: 2px solid var(--rl-green-2);
   outline-offset: 1px;
   border-color: transparent;
 }
@@ -84,7 +84,7 @@
 .ilm-auth-submit {
   appearance: none;
   border: 0;
-  background: var(--ilm-color-accent, #2563eb);
+  background: var(--rl-green-2);
   color: #ffffff;
   padding: 0.6rem 0.9rem;
   border-radius: 6px;
@@ -105,13 +105,13 @@
 }
 
 .ilm-auth-note {
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
   font-size: 0.9rem;
   margin: 0;
 }
 
 .ilm-auth-hint {
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
   font-size: 0.8rem;
   margin: 0.25rem 0 0;
 }
@@ -120,7 +120,7 @@
   appearance: none;
   border: 0;
   background: transparent;
-  color: var(--ilm-color-accent, #2563eb);
+  color: var(--rl-green-2);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0.25rem 0.5rem;
@@ -163,8 +163,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 0.9rem;
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
-  background: var(--ilm-color-surface, #ffffff);
+  border: 1px solid var(--rl-line);
+  background: var(--rl-surface);
   border-radius: 8px;
   cursor: pointer;
   font-size: 0.95rem;
@@ -172,17 +172,17 @@
 }
 
 .ilm-lab-list-item:hover {
-  border-color: var(--ilm-color-accent, #2563eb);
+  border-color: var(--rl-green-2);
 }
 
 .ilm-lab-list-name {
   font-weight: 500;
-  color: var(--ilm-color-text, #0f172a);
+  color: var(--rl-ink);
 }
 
 .ilm-lab-list-meta {
   font-size: 0.8rem;
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
   text-transform: capitalize;
 }
 
@@ -196,28 +196,28 @@
   display: inline-flex;
   align-items: center;
   padding: 0.45rem 0.8rem;
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border: 1px solid var(--rl-line);
   border-radius: 999px;
-  background: var(--ilm-color-surface, #ffffff);
-  color: var(--ilm-color-text-muted, #64748b);
+  background: var(--rl-surface);
+  color: var(--rl-muted);
   text-decoration: none;
   font-size: 0.85rem;
   font-weight: 500;
 }
 
 .ilm-app-switcher-link:hover {
-  border-color: var(--ilm-color-accent, #2563eb);
-  color: var(--ilm-color-text, #0f172a);
+  border-color: var(--rl-green-2);
+  color: var(--rl-ink);
 }
 
 .ilm-app-switcher-link-active {
-  background: var(--ilm-color-accent, #2563eb);
-  border-color: var(--ilm-color-accent, #2563eb);
+  background: var(--rl-green-2);
+  border-color: var(--rl-green-2);
   color: #ffffff;
 }
 
 .ilm-admin-card {
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border: 1px solid var(--rl-line);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.9);
   padding: 1.25rem;
@@ -306,7 +306,7 @@
 
 .ilm-admin-list-item {
   padding: 0.9rem 1rem;
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border: 1px solid var(--rl-line);
   border-radius: 14px;
   background: rgba(248, 250, 252, 0.75);
 }
@@ -318,7 +318,7 @@
 }
 
 .ilm-admin-list-copy strong {
-  color: var(--ilm-color-text, #0f172a);
+  color: var(--rl-ink);
 }
 
 .ilm-admin-list-copy span,
@@ -326,7 +326,7 @@
 .ilm-admin-helper,
 .ilm-admin-empty,
 .ilm-admin-project-meta span {
-  color: var(--ilm-color-text-muted, #64748b);
+  color: var(--rl-muted);
 }
 
 .ilm-admin-actions {
@@ -339,7 +339,7 @@
 .ilm-admin-invitations {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--ilm-color-border, #e2e5ea);
+  border-top: 1px solid var(--rl-line);
 }
 
 .ilm-admin-field-row {
@@ -353,11 +353,11 @@
 
 .ilm-admin-form select {
   padding: 0.55rem 0.65rem;
-  border: 1px solid var(--ilm-color-border, #e2e5ea);
+  border: 1px solid var(--rl-line);
   border-radius: 6px;
   font-size: 0.95rem;
-  background: var(--ilm-color-surface, #ffffff);
-  color: var(--ilm-color-text, #0f172a);
+  background: var(--rl-surface);
+  color: var(--rl-ink);
 }
 
 .ilm-admin-project-meta {


### PR DESCRIPTION
## Summary
Follow-up to Phase A (#47). A review noticed Phase A left font-family hardcodes in the three legacy app stylesheets and `--ilm-color-*` fallbacks in the shared auth.css. This finishes the token-hygiene pass.

- Replace `"Noto Serif", Georgia, serif` with `var(--rl-font-serif)` across account / project-manager / protocol-manager styles.
- Replace `"JetBrains Mono", monospace` with `var(--rl-font-mono)` and the remaining `"Space Grotesk"` hardcodes with `var(--rl-font-sans)` in protocol-manager.
- Swap `--ilm-color-*` var fallbacks in `packages/ui/src/auth/auth.css` for `--rl-*` tokens (`--rl-paper`, `--rl-surface`, `--rl-line`, `--rl-ink`, `--rl-muted`, `--rl-green-2`).

## Why
The Phase A plan (docs/ui-alignment.md) explicitly called for all apps to read font-family from `var(--rl-font-sans/serif/mono)` and for app CSS to reference `--rl-*` directly rather than aliased fallbacks. Phase A tokenized the sans stack and removed per-app alias layers but missed these spots — leaving future theme swaps partially bypassed.

Pure CSS custom-property substitution; no visual change intended. Tokens already existed in `packages/ui/src/tokens.css` since Phase A, so no token additions were needed.

The `Helvetica Neue` string in `apps/protocol-manager/src/App.tsx:2583` is intentionally left — it lives inside a print-window CSS template that runs in a detached window that doesn't load the shared tokens.

## Test plan
- [ ] `npm run typecheck` / `npm run lint` green
- [ ] Visual parity spot-check: Account, Project Manager, Protocol Manager (dashboard, editor, modals) look unchanged
- [ ] Auth screen still renders with Rhine Lab palette (no jarring blue accent from old `--ilm-color-accent` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)