### PR TITLE
Fix Supply Manager warehouse "unexpected error" on item create

### DIFF
--- a/apps/supply-manager/src/App.tsx
+++ b/apps/supply-manager/src/App.tsx
@@ -83,8 +83,22 @@ type ModalState =
 const statusLabel = (value: string) =>
   value.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
-const errorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : "Unexpected error";
+const errorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const candidate = error as { message?: unknown; details?: unknown; hint?: unknown };
+    if (typeof candidate.message === "string" && candidate.message.trim() !== "") {
+      const detail =
+        typeof candidate.details === "string" && candidate.details.trim() !== ""
+          ? ` (${candidate.details})`
+          : typeof candidate.hint === "string" && candidate.hint.trim() !== ""
+          ? ` (${candidate.hint})`
+          : "";
+      return candidate.message + detail;
+    }
+  }
+  return "Unexpected error";
+};
 
 const formatDate = (value: string | null | undefined) => {
   if (!value) return "—";

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ilm/ui": "file:../../packages/ui",
+        "@ilm/utils": "file:../../packages/utils",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/supabase/migrations/20260430010000_supply_item_access_fix.sql
+++ b/supabase/migrations/20260430010000_supply_item_access_fix.sql
@@ -1,0 +1,57 @@
+-- Fix: Supply Manager item visibility regressions
+--
+-- The original `can_access_supply_item` had two gaps that surfaced the moment
+-- a non-admin lab member created a new item and linked it to a specific
+-- project:
+--
+--   1. The check joined `item_projects` to `project_members` directly, so
+--      project *leads* (who are not always rows in `project_members`) were
+--      treated as outsiders and lost visibility of items in their own
+--      projects.
+--   2. There was no fallback for the item's creator. As soon as the
+--      `INSERT items` was followed by an `INSERT item_projects` with a
+--      non-null `project_id`, RLS hid the just-inserted row from the user
+--      that created it — which made the `RETURNING *` after the link insert
+--      return zero rows and PostgREST throw PGRST116 ("JSON object requested,
+--      multiple (or no) rows returned"). The frontend surfaced this as an
+--      opaque "Unexpected error" on the warehouse page.
+--
+-- Allowing the creator to always read their own item closes the regression
+-- without weakening the project-scoped visibility rule for other users, and
+-- routing project visibility through `is_project_member` keeps leads in
+-- sync with members.
+
+create or replace function public.can_access_supply_item(p_item_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.items i
+    where i.id = p_item_id
+      and public.is_lab_member(i.lab_id)
+      and (
+        public.is_lab_admin(i.lab_id)
+        or i.created_by = auth.uid()
+        or (
+          i.is_active
+          and (
+            not exists (
+              select 1 from public.item_projects ip
+              where ip.item_id = i.id and ip.project_id is not null
+            )
+            or exists (
+              select 1 from public.item_projects ip
+              where ip.item_id = i.id
+                and (ip.association_type = 'general' or ip.project_id is null)
+            )
+            or exists (
+              select 1 from public.item_projects ip
+              where ip.item_id = i.id
+                and ip.project_id is not null
+                and public.is_project_member(ip.project_id)
+            )
+          )
+        )
+      )
+  );
+$$;


### PR DESCRIPTION
Two bugs combined to make item creation appear to fail outright on the warehouse "+ New item" form when the user picked a specific project for association:

* `can_access_supply_item` joined `item_projects` straight to `project_members`, so the moment we inserted the project link, RLS hid the just-inserted row from its own creator. The `RETURNING *` after the link insert returned zero rows and PostgREST raised PGRST116 — which the frontend surfaced as "Unexpected error" because the error helper only unwrapped real `Error` instances, not PostgREST's plain-object errors.

* The same RLS check excluded project leads who weren't explicit `project_members` rows.

Adds migration `20260430010000_supply_item_access_fix.sql` that lets the item creator always see their own item, and routes project access through `is_project_member` so leads stay in sync with members. Also teaches the supply-manager `errorMessage` helper to extract the `message`/`details`/`hint` fields off Supabase errors so future failures show the underlying cause instead of the opaque fallback.