### PR TITLE
Inline items_select RLS to fix INSERT...RETURNING recursion

### DIFF
--- a/supabase/migrations/20260430010000_supply_item_access_fix.sql
+++ b/supabase/migrations/20260430010000_supply_item_access_fix.sql
@@ -1,26 +1,66 @@
 -- Fix: Supply Manager item visibility regressions
 --
--- The original `can_access_supply_item` had two gaps that surfaced the moment
--- a non-admin lab member created a new item and linked it to a specific
--- project:
+-- Two interacting bugs made `INSERT items ... RETURNING *` fail outright on
+-- the warehouse "+ New item" form, surfacing as "new row violates row-level
+-- security policy for table items" (a misleading message — INSERT without
+-- RETURNING actually succeeds; it's the SELECT RLS on RETURNING that
+-- denies the row).
 --
---   1. The check joined `item_projects` to `project_members` directly, so
---      project *leads* (who are not always rows in `project_members`) were
---      treated as outsiders and lost visibility of items in their own
---      projects.
---   2. There was no fallback for the item's creator. As soon as the
---      `INSERT items` was followed by an `INSERT item_projects` with a
---      non-null `project_id`, RLS hid the just-inserted row from the user
---      that created it — which made the `RETURNING *` after the link insert
---      return zero rows and PostgREST throw PGRST116 ("JSON object requested,
---      multiple (or no) rows returned"). The frontend surfaced this as an
---      opaque "Unexpected error" on the warehouse page.
+--   1. The `items_select` policy delegated to `can_access_supply_item(id)`,
+--      which re-queries `public.items` to check the row's lab_id /
+--      is_active / created_by. Inside RLS evaluation of RETURNING from
+--      the very same INSERT, that re-query does not see the just-inserted
+--      row in the function's STABLE snapshot, so EXISTS returns false and
+--      access is denied — even though the insert itself was authorized by
+--      the WITH CHECK policy. Inlining the visibility logic so the policy
+--      reads the new row's columns directly removes the recursion.
 --
--- Allowing the creator to always read their own item closes the regression
--- without weakening the project-scoped visibility rule for other users, and
--- routing project visibility through `is_project_member` keeps leads in
--- sync with members.
+--   2. `can_access_supply_item` joined `item_projects` to `project_members`
+--      directly, leaving project leads (who are not always rows in
+--      `project_members`) without visibility of items in their own
+--      projects. Routing the check through `is_project_member` keeps leads
+--      and members in sync.
+--
+-- We also extend the visibility rule so the item's creator can always read
+-- their own item — otherwise a non-admin who creates an item linked to a
+-- single non-general project loses access the moment the link is added,
+-- because the item no longer satisfies the "general/lab-wide" branch and
+-- they are not yet a project_member.
 
+drop policy if exists items_select on public.items;
+create policy items_select on public.items
+  for select using (
+    public.is_lab_member(lab_id)
+    and (
+      public.is_lab_admin(lab_id)
+      or created_by = auth.uid()
+      or (
+        is_active
+        and (
+          not exists (
+            select 1 from public.item_projects ip
+            where ip.item_id = items.id and ip.project_id is not null
+          )
+          or exists (
+            select 1 from public.item_projects ip
+            where ip.item_id = items.id
+              and (ip.association_type = 'general' or ip.project_id is null)
+          )
+          or exists (
+            select 1 from public.item_projects ip
+            where ip.item_id = items.id
+              and ip.project_id is not null
+              and public.is_project_member(ip.project_id)
+          )
+        )
+      )
+    )
+  );
+
+-- Keep `can_access_supply_item` in sync for the dependent policies on
+-- `item_projects`, `inventory_checks`, and `stock_lots`. These are not
+-- subject to the RETURNING recursion because the parent items row is
+-- already committed by the time those rows are inserted.
 create or replace function public.can_access_supply_item(p_item_id uuid)
 returns boolean
 language sql stable security definer set search_path = public as $$


### PR DESCRIPTION
Confirmed against the live DB: INSERT into items succeeds with the existing WITH CHECK policy, but INSERT...RETURNING fails. The cause is that items_select delegates to can_access_supply_item(id), which re-queries public.items inside its STABLE snapshot — and that snapshot does not see the row PostgreSQL is in the middle of inserting. EXISTS returns false, RLS denies the RETURNING, and PostgREST surfaces it as the (misleading) "new row violates row-level security policy" error that the user reported.

Inline the visibility logic into items_select so it reads the new row's columns directly (no recursion through items). Keep can_access_supply_item on the same shape for the dependent policies on item_projects / inventory_checks / stock_lots, where the parent items row is always already committed.

Verified end-to-end against the live DB: a non-admin lab member can now insert an item, link it to a general or to a non-member project, and still read their own row back.