### PR TITLE
Rebuild Account home as ILM overview dashboard

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -1,41 +1,22 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
-  AppContent,
-  AppShell,
-  AppSidebarSection,
-  AppSubbar,
-  AppSwitcher,
-  AppTopbar,
   AuthScreen,
   LabPicker,
-  TabButton,
-  approveLabJoin,
-  buildLabShareUrl,
+  appUrl,
   cancelLabJoin,
-  demoteAdminToMember,
-  inviteMemberToLab,
-  listLabInvitations,
-  listLabJoinRequests,
-  listLabMembers,
   lookupLabById,
-  promoteMemberToAdmin,
-  rejectLabJoin,
-  removeLabMember,
   requestLabJoin,
   useAuth,
-  type LabInvitationRecord,
-  type LabJoinRequestRecord,
   type LabLookupResult,
-  type LabMemberRecord,
 } from "@ilm/ui";
-import { getSupabaseClient } from "@ilm/utils";
+import { OverviewView } from "./views/OverviewView";
+import { TeamView } from "./views/TeamView";
+import { SettingsView } from "./views/SettingsView";
+import { PlaceholderView } from "./views/PlaceholderView";
 
 const APP_BASE_URL = import.meta.env.BASE_URL || "/";
 
 const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
-
-const formatDate = (value: string) =>
-  new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(new Date(value));
 
 const parseJoinLabId = (pathname: string, base: string): string | null => {
   const normalizedBase = base.endsWith("/") ? base : `${base}/`;
@@ -49,677 +30,352 @@ const isUuid = (value: string): boolean =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 
 // ---------------------------------------------------------------------------
-// Left panel
+// Hash-based routing for internal home views.
 // ---------------------------------------------------------------------------
 
-type ProjectCounts = { led: number; drafts: number; pendingReview: number };
+type HomeRoute =
+  | { kind: "overview" }
+  | { kind: "calendar" }
+  | { kind: "team" }
+  | { kind: "analytics" }
+  | { kind: "reports" }
+  | { kind: "settings" };
 
-// User-specific project stats within the active lab:
-//   led            = published projects where the user is creator OR a project lead
-//   drafts         = the user's own unsubmitted drafts
-//   pendingReview  = the user's own drafts with a review submission pending
-const useProjectCounts = (labId: string | null, userId: string | null): ProjectCounts | null => {
-  const [counts, setCounts] = useState<ProjectCounts | null>(null);
+const ROUTE_HASHES: Record<HomeRoute["kind"], string> = {
+  overview: "",
+  calendar: "#/calendar",
+  team: "#/team",
+  analytics: "#/analytics",
+  reports: "#/reports",
+  settings: "#/settings",
+};
+
+const parseHash = (hash: string): HomeRoute => {
+  const normalized = hash.replace(/^#\/?/, "");
+  switch (normalized) {
+    case "calendar":
+      return { kind: "calendar" };
+    case "team":
+      return { kind: "team" };
+    case "analytics":
+      return { kind: "analytics" };
+    case "reports":
+      return { kind: "reports" };
+    case "settings":
+      return { kind: "settings" };
+    default:
+      return { kind: "overview" };
+  }
+};
+
+const useHomeRoute = (): HomeRoute => {
+  const [route, setRoute] = useState<HomeRoute>(() =>
+    typeof window === "undefined" ? { kind: "overview" } : parseHash(window.location.hash)
+  );
   useEffect(() => {
-    if (!labId || !userId) {
-      setCounts(null);
-      return;
-    }
-    let cancelled = false;
-    const supabase = getSupabaseClient();
-    (async () => {
-      try {
-        const [projectsRes, leadsRes] = await Promise.all([
-          supabase
-            .from("projects")
-            .select("id, state, review_requested_at, created_by")
-            .eq("lab_id", labId),
-          supabase
-            .from("project_leads")
-            .select("project_id, projects!inner(lab_id, state)")
-            .eq("user_id", userId)
-            .eq("projects.lab_id", labId)
-            .eq("projects.state", "published"),
-        ]);
-        if (cancelled) return;
-        if (projectsRes.error || !projectsRes.data) {
-          setCounts({ led: 0, drafts: 0, pendingReview: 0 });
-          return;
-        }
-        type Row = { id: string; state: string; review_requested_at: string | null; created_by: string | null };
-        const rows = projectsRes.data as Row[];
-        const ledAsCreator = new Set(
-          rows.filter((r) => r.state === "published" && r.created_by === userId).map((r) => r.id)
-        );
-        const ledAsLead = new Set(((leadsRes.data as { project_id: string }[] | null) ?? []).map((r) => r.project_id));
-        const led = new Set([...ledAsCreator, ...ledAsLead]).size;
-        const myDrafts = rows.filter((r) => r.state === "draft" && r.created_by === userId);
-        setCounts({
-          led,
-          drafts: myDrafts.length,
-          pendingReview: myDrafts.filter((r) => r.review_requested_at !== null).length,
-        });
-      } catch {
-        if (!cancelled) setCounts({ led: 0, drafts: 0, pendingReview: 0 });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [labId, userId]);
-  return counts;
+    const onHashChange = () => setRoute(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+  return route;
 };
 
-type MembershipTier = "owner" | "admin" | "member";
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
 
-const TIER_LABEL: Record<MembershipTier, string> = {
-  owner: "Owner",
-  admin: "Admin",
-  member: "Member",
+type NavTone = "internal" | "external" | "soon";
+
+type NavItem = {
+  id: string;
+  label: string;
+  glyph: ReactNode;
+  href: string;
+  tone: NavTone;
+  match?: (route: HomeRoute) => boolean;
 };
 
-const TIER_DESCRIPTION: Record<MembershipTier, string> = {
-  owner: "Full control: promote or demote admins, remove any non-owner, and manage the lab.",
-  admin: "Can promote members to admin and remove members. Cannot touch other admins.",
-  member: "Read-only in the lab management surface.",
-};
+const SIDEBAR_GROUPS: { items: NavItem[] }[] = [
+  {
+    items: [
+      {
+        id: "overview",
+        label: "Overview",
+        glyph: <span className="ovw-nav-glyph">▢</span>,
+        href: ROUTE_HASHES.overview || "#/",
+        tone: "internal",
+        match: (r) => r.kind === "overview",
+      },
+      {
+        id: "projects",
+        label: "Projects",
+        glyph: <span className="ovw-nav-glyph">⊞</span>,
+        href: appUrl("project-manager/", APP_BASE_URL),
+        tone: "external",
+      },
+      {
+        id: "protocols",
+        label: "Protocols",
+        glyph: <span className="ovw-nav-glyph">▤</span>,
+        href: appUrl("protocol-manager/", APP_BASE_URL),
+        tone: "external",
+      },
+      {
+        id: "inventory",
+        label: "Inventory",
+        glyph: <span className="ovw-nav-glyph">◇</span>,
+        href: appUrl("supply-manager/", APP_BASE_URL),
+        tone: "external",
+      },
+      {
+        id: "funding",
+        label: "Funding",
+        glyph: <span className="ovw-nav-glyph">$</span>,
+        href: appUrl("funding-manager/", APP_BASE_URL),
+        tone: "external",
+      },
+      {
+        id: "calendar",
+        label: "Calendar",
+        glyph: <span className="ovw-nav-glyph">▣</span>,
+        href: ROUTE_HASHES.calendar,
+        tone: "soon",
+        match: (r) => r.kind === "calendar",
+      },
+      {
+        id: "team",
+        label: "Team",
+        glyph: <span className="ovw-nav-glyph">⊙</span>,
+        href: ROUTE_HASHES.team,
+        tone: "internal",
+        match: (r) => r.kind === "team",
+      },
+      {
+        id: "analytics",
+        label: "Analytics",
+        glyph: <span className="ovw-nav-glyph">∿</span>,
+        href: ROUTE_HASHES.analytics,
+        tone: "soon",
+        match: (r) => r.kind === "analytics",
+      },
+      {
+        id: "reports",
+        label: "Reports",
+        glyph: <span className="ovw-nav-glyph">≡</span>,
+        href: ROUTE_HASHES.reports,
+        tone: "soon",
+        match: (r) => r.kind === "reports",
+      },
+      {
+        id: "settings",
+        label: "Settings",
+        glyph: <span className="ovw-nav-glyph">⚙</span>,
+        href: ROUTE_HASHES.settings,
+        tone: "internal",
+        match: (r) => r.kind === "settings",
+      },
+    ],
+  },
+];
 
-const SidePanelContent = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
+const Sidebar = ({
+  route,
+  onOpenLabPicker,
+}: {
+  route: HomeRoute;
+  onOpenLabPicker: () => void;
+}) => {
   const { profile, user, activeLab, signOut } = useAuth();
-  const counts = useProjectCounts(activeLab?.id ?? null, user?.id ?? null);
   const displayName = profile?.display_name ?? user?.email ?? "Signed in";
-  const email = profile?.email ?? user?.email ?? "";
-  const tier: MembershipTier | null = (activeLab?.role as MembershipTier | undefined) ?? null;
+  const labName = activeLab?.name ?? "No lab";
+  const role = (activeLab?.role ?? "—").toString().toUpperCase();
+
+  const initials = displayName
+    .split(" ")
+    .map((p) => p.charAt(0))
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
 
   return (
-    <>
-      <div className="acct-side-header">
-        <strong>Account</strong>
-        <small>Integrated Lab Manager</small>
+    <aside className="ovw-sidebar" aria-label="Primary navigation">
+      <div className="ovw-brand">
+        <div className="ovw-brand-mark">
+          <strong>{labName}</strong>
+          <span>— ∞</span>
+        </div>
+        <p className="ovw-brand-tag">
+          INTEGRATED LAB MANAGER <b>OS</b>
+        </p>
       </div>
 
-      <AppSidebarSection title="Profile" className="acct-side-section acct-side-profile">
-        <strong>{displayName}</strong>
-        <span>{email}</span>
-      </AppSidebarSection>
-
-      <AppSidebarSection title="Active Lab" className="acct-side-section acct-lab-switcher">
-        {activeLab && tier ? (
-          <>
-            <h3>{activeLab.name}</h3>
-            <span className={`acct-lab-role ${tier}`}>{TIER_LABEL[tier]}</span>
-            <small style={{ color: "var(--rl-muted)" }}>{TIER_DESCRIPTION[tier]}</small>
-          </>
-        ) : (
-          <h3>No lab selected</h3>
-        )}
-        <button
-          type="button"
-          className="rl-btn rl-btn--secondary rl-btn--sm"
-          style={{ marginTop: "0.35rem", alignSelf: "flex-start" }}
-          onClick={onOpenLabPicker}
-        >
-          Join or create another lab…
-        </button>
-      </AppSidebarSection>
-
-      <AppSidebarSection title="Your projects in this lab" className="acct-side-section">
-        <div className="acct-stat-row">
-          <div className="acct-stat">
-            <span className="acct-stat-value">{counts?.led ?? "–"}</span>
-            <span className="acct-stat-label">Led</span>
-          </div>
-          <div className="acct-stat">
-            <span className="acct-stat-value">{counts?.pendingReview ?? "–"}</span>
-            <span className="acct-stat-label">In review</span>
-          </div>
-          <div className="acct-stat">
-            <span className="acct-stat-value">{counts?.drafts ?? "–"}</span>
-            <span className="acct-stat-label">My drafts</span>
-          </div>
-        </div>
-      </AppSidebarSection>
-
-      <AppSidebarSection title="Working status" className="acct-side-section">
-        <span style={{ fontSize: "0.85rem", color: "var(--rl-muted)" }}>
-          {activeLab && tier
-            ? `Signed in as ${TIER_LABEL[tier]} of ${activeLab.name}. Use the top-right switcher to open another app.`
-            : "Pick a lab to get started."}
-        </span>
-      </AppSidebarSection>
-
-      <div className="acct-side-footer">
-        <button
-          type="button"
-          className="rl-btn rl-btn--secondary rl-btn--sm"
-          onClick={() => void signOut()}
-        >
-          Sign out
-        </button>
-      </div>
-    </>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Members tab
-// ---------------------------------------------------------------------------
-
-const MembersTab = () => {
-  const { activeLab, user, refreshLabs } = useAuth();
-  const labId = activeLab?.id ?? null;
-  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
-  // Strict stratification: owner > admin > member. Each user has exactly one
-  // tier per lab (enforced by the `(lab_id, user_id)` PK on lab_memberships).
-  const isOwner = tier === "owner";
-  const isAdmin = tier === "admin";
-  const canManageMembers = isOwner || isAdmin; // promote member → admin, remove member
-  const canManageAdmins = isOwner;              // demote admin → member, remove admin
-  const [members, setMembers] = useState<LabMemberRecord[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [busyUserId, setBusyUserId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!labId) {
-      setMembers([]);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      setMembers(await listLabMembers(labId));
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [labId]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  // After any role change, refresh both the member list (affects other rows'
-  // badges) and the AuthProvider labs array (affects the sidebar badge when
-  // the caller changed their own role).
-  const refreshAfterAction = useCallback(async () => {
-    await Promise.all([load(), refreshLabs()]);
-  }, [load, refreshLabs]);
-
-  const doPromote = async (member: LabMemberRecord) => {
-    if (!labId) return;
-    setBusyUserId(member.user_id);
-    setError(null);
-    try {
-      await promoteMemberToAdmin(labId, member.user_id);
-      await refreshAfterAction();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyUserId(null);
-    }
-  };
-
-  const doDemote = async (member: LabMemberRecord) => {
-    if (!labId) return;
-    setBusyUserId(member.user_id);
-    setError(null);
-    try {
-      await demoteAdminToMember(labId, member.user_id);
-      await refreshAfterAction();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyUserId(null);
-    }
-  };
-
-  const doRemove = async (member: LabMemberRecord) => {
-    if (!labId) return;
-    const label = member.display_name || member.email || "this member";
-    if (!window.confirm(`Remove ${label} from ${activeLab?.name ?? "the lab"}?`)) return;
-    setBusyUserId(member.user_id);
-    setError(null);
-    try {
-      await removeLabMember(labId, member.user_id);
-      await refreshAfterAction();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyUserId(null);
-    }
-  };
-
-  if (!activeLab) {
-    return <p className="acct-empty">Pick a lab from the left panel to see its members.</p>;
-  }
-
-  return (
-    <section className="acct-card">
-      <div className="acct-card-header">
-        <div>
-          <h2>Lab members</h2>
-          <p>
-            {canManageMembers
-              ? "Owner &gt; admin &gt; member. Admins and the owner can promote members and remove members. Only the owner can demote or remove an admin."
-              : "Only admins and the owner can edit membership."}
-          </p>
-        </div>
-        <span className="acct-card-pill">{members.length} total</span>
-      </div>
-
-      {error ? <p className="acct-error">{error}</p> : null}
-      {loading ? <p className="acct-empty">Loading roster…</p> : null}
-
-      {!loading && members.length > 0 ? (
-        <ul className="acct-member-list">
-          {members.map((member) => {
-            const label = member.display_name || member.email || member.user_id;
-            const isSelf = member.user_id === user?.id;
-            const busy = busyUserId === member.user_id;
-            const targetTier = member.role as MembershipTier;
-            // Promote member → admin: any manager (owner or admin) can do this
-            // to non-self members.
-            const canPromote = canManageMembers && targetTier === "member" && !isSelf;
-            // Demote admin → member: owner only.
-            const canDemote = canManageAdmins && targetTier === "admin";
-            // Remove: owner cannot be removed; admins can only be removed by the
-            // owner; members can be removed by any manager.
-            const canRemove =
-              !isSelf &&
-              targetTier !== "owner" &&
-              (targetTier === "admin" ? canManageAdmins : canManageMembers);
-
-            return (
-              <li className="acct-member" key={member.user_id}>
-                <div className="acct-member-copy">
-                  <strong>
-                    {label}
-                    {isSelf ? " (you)" : ""}
-                  </strong>
-                  <span>{member.email || "No email available"}</span>
-                  <small>Joined {formatDate(member.joined_at)}</small>
-                </div>
-                <div className="acct-member-actions">
-                  <span className={`acct-badge ${targetTier}`}>{TIER_LABEL[targetTier]}</span>
-                  {canPromote ? (
-                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doPromote(member)}>
-                      Promote to admin
-                    </button>
-                  ) : null}
-                  {canDemote ? (
-                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doDemote(member)}>
-                      Demote to member
-                    </button>
-                  ) : null}
-                  {canRemove ? (
-                    <button type="button" className="acct-danger-button" disabled={busy} onClick={() => void doRemove(member)}>
-                      Remove
-                    </button>
-                  ) : null}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
-
-      {!loading && members.length === 0 ? <p className="acct-empty">No members yet.</p> : null}
-    </section>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Invitations tab
-// ---------------------------------------------------------------------------
-
-const InvitationsTab = () => {
-  const { activeLab } = useAuth();
-  const labId = activeLab?.id ?? null;
-  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
-  const canManageMembers = tier === "owner" || tier === "admin";
-
-  const [invitations, setInvitations] = useState<LabInvitationRecord[]>([]);
-  const [requests, setRequests] = useState<LabJoinRequestRecord[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
-  const [submittingInvite, setSubmittingInvite] = useState(false);
-
-  const [busyRequestId, setBusyRequestId] = useState<string | null>(null);
-  const [rejectOpen, setRejectOpen] = useState<string | null>(null);
-  const [rejectComment, setRejectComment] = useState("");
-
-  const [copied, setCopied] = useState(false);
-
-  const load = useCallback(async () => {
-    if (!labId || !canManageMembers) {
-      setInvitations([]);
-      setRequests([]);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const [nextInvitations, nextRequests] = await Promise.all([
-        listLabInvitations(labId),
-        listLabJoinRequests(labId, "pending"),
-      ]);
-      setInvitations(nextInvitations);
-      setRequests(nextRequests);
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [labId, canManageMembers]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  const pendingInvitations = useMemo(
-    () => invitations.filter((invitation) => invitation.status === "pending"),
-    [invitations]
-  );
-
-  const shareUrl = useMemo(() => (activeLab ? buildLabShareUrl(activeLab.id, APP_BASE_URL) : ""), [activeLab]);
-
-  const handleInvite = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!labId || !inviteEmail.trim()) return;
-    setSubmittingInvite(true);
-    setError(null);
-    try {
-      await inviteMemberToLab(labId, inviteEmail.trim(), inviteRole);
-      setInviteEmail("");
-      setInviteRole("member");
-      await load();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setSubmittingInvite(false);
-    }
-  };
-
-  const handleApprove = async (request: LabJoinRequestRecord) => {
-    setBusyRequestId(request.id);
-    setError(null);
-    try {
-      await approveLabJoin(request.id);
-      await load();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyRequestId(null);
-    }
-  };
-
-  const handleReject = async (request: LabJoinRequestRecord) => {
-    const comment = rejectComment.trim();
-    if (!comment) {
-      setError("A comment is required to reject a request.");
-      return;
-    }
-    setBusyRequestId(request.id);
-    setError(null);
-    try {
-      await rejectLabJoin(request.id, comment);
-      setRejectOpen(null);
-      setRejectComment("");
-      await load();
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setBusyRequestId(null);
-    }
-  };
-
-  const handleCopy = async () => {
-    if (!shareUrl || typeof navigator === "undefined" || !navigator.clipboard) return;
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setCopied(false);
-    }
-  };
-
-  if (!activeLab) {
-    return <p className="acct-empty">Pick a lab from the left panel first.</p>;
-  }
-  if (!canManageMembers) {
-    return <p className="acct-empty">Only admins and the owner can send invitations or review join requests.</p>;
-  }
-
-  return (
-    <>
-      {error ? <p className="acct-error">{error}</p> : null}
-
-      <section className="acct-card">
-        <div className="acct-card-header">
-          <div>
-            <h2>Invite by email</h2>
-            <p>Invited users are added automatically when they sign in with this email.</p>
-          </div>
-        </div>
-        <form className="acct-form" onSubmit={handleInvite}>
-          <div className="acct-field-row">
-            <label className="acct-field">
-              <span>Email</span>
-              <input
-                type="email"
-                value={inviteEmail}
-                onChange={(event) => setInviteEmail(event.target.value)}
-                placeholder="scientist@lab.org"
-                required
-              />
-            </label>
-            <label className="acct-field">
-              <span>Role</span>
-              <select value={inviteRole} onChange={(event) => setInviteRole(event.target.value as "admin" | "member")}>
-                <option value="member">Member</option>
-                <option value="admin">Admin</option>
-              </select>
-            </label>
-          </div>
-          <div>
-            <button type="submit" className="acct-primary-button" disabled={submittingInvite}>
-              {submittingInvite ? "Saving…" : "Save invitation"}
-            </button>
-          </div>
-        </form>
-
-        {pendingInvitations.length > 0 ? (
-          <div className="acct-invitations">
-            <div style={{ fontSize: "0.72rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--rl-muted)" }}>
-              {pendingInvitations.length} pending
-            </div>
-            {pendingInvitations.map((invitation) => (
-              <div className="acct-invitation" key={invitation.id}>
-                <div>
-                  <strong>{invitation.email}</strong>
-                  <div><small>Saved {formatDate(invitation.created_at)}</small></div>
-                </div>
-                <span className="acct-badge">{invitation.role}</span>
-                <span className="acct-badge">{invitation.status}</span>
-              </div>
-            ))}
-          </div>
-        ) : null}
-      </section>
-
-      <section className="acct-card">
-        <div className="acct-card-header">
-          <div>
-            <h2>Share link</h2>
-            <p>Anyone who opens this link can sign in and request to join {activeLab.name}.</p>
-          </div>
-        </div>
-        <div className="acct-share-row">
-          <input type="text" readOnly value={shareUrl} onFocus={(event) => event.currentTarget.select()} />
-          <button type="button" className="acct-text-button" onClick={() => void handleCopy()}>
-            {copied ? "Copied!" : "Copy link"}
-          </button>
-        </div>
-      </section>
-
-      <section className="acct-card">
-        <div className="acct-card-header">
-          <div>
-            <h2>Join requests</h2>
-            <p>Approve or reject people who asked to join via the share link.</p>
-          </div>
-          <span className="acct-card-pill">{requests.length} pending</span>
-        </div>
-        {loading ? <p className="acct-empty">Loading…</p> : null}
-        {!loading && requests.length === 0 ? <p className="acct-empty">No pending join requests.</p> : null}
-        {requests.length > 0 ? (
-          <div>
-            {requests.map((request) => {
-              const busy = busyRequestId === request.id;
-              const label = request.display_name || request.email || request.user_id;
-              const rejecting = rejectOpen === request.id;
+      <nav className="ovw-nav">
+        {SIDEBAR_GROUPS.map((group, groupIndex) => (
+          <div className="ovw-nav-group" key={groupIndex}>
+            {group.items.map((item) => {
+              const active = item.match?.(route) ?? false;
+              const isExternal = item.tone === "external";
+              const className = `ovw-nav-item${active ? " is-active" : ""}${
+                item.tone === "soon" ? " is-soon" : ""
+              }`;
               return (
-                <div className="acct-request-item" key={request.id}>
-                  <div>
-                    <strong>{label}</strong>
-                    <div><small>{request.email || "No email available"} · requested {formatDate(request.created_at)}</small></div>
-                    {request.message ? <p className="acct-request-message">"{request.message}"</p> : null}
-                  </div>
-                  {rejecting ? (
-                    <div className="acct-reject-form">
-                      <textarea
-                        value={rejectComment}
-                        onChange={(event) => setRejectComment(event.target.value)}
-                        placeholder="Reason (required)"
-                        rows={2}
-                      />
-                      <div className="acct-row-actions">
-                        <button
-                          type="button"
-                          className="acct-danger-button"
-                          disabled={busy}
-                          onClick={() => void handleReject(request)}
-                        >
-                          Confirm reject
-                        </button>
-                        <button
-                          type="button"
-                          className="acct-text-button"
-                          disabled={busy}
-                          onClick={() => {
-                            setRejectOpen(null);
-                            setRejectComment("");
-                          }}
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="acct-row-actions">
-                      <button
-                        type="button"
-                        className="acct-primary-button"
-                        disabled={busy}
-                        onClick={() => void handleApprove(request)}
-                      >
-                        Approve
-                      </button>
-                      <button
-                        type="button"
-                        className="acct-text-button"
-                        disabled={busy}
-                        onClick={() => {
-                          setRejectOpen(request.id);
-                          setRejectComment("");
-                        }}
-                      >
-                        Reject
-                      </button>
-                    </div>
-                  )}
-                </div>
+                <a
+                  key={item.id}
+                  href={item.href}
+                  className={className}
+                  aria-current={active ? "page" : undefined}
+                  rel={isExternal ? "noopener" : undefined}
+                >
+                  <span className="ovw-nav-glyph-cell">{item.glyph}</span>
+                  <span className="ovw-nav-label">{item.label}</span>
+                  {item.tone === "soon" ? <span className="ovw-nav-pip">SOON</span> : null}
+                  {active ? <span className="ovw-nav-dot" aria-hidden="true" /> : null}
+                </a>
               );
             })}
           </div>
-        ) : null}
-      </section>
-    </>
+        ))}
+      </nav>
+
+      <div className="ovw-side-status">
+        <div className="ovw-side-status-mark" aria-hidden="true">
+          <span className="ovw-side-status-dot" />
+        </div>
+        <div>
+          <p className="ovw-side-status-title">SYSTEM STATUS</p>
+          <p className="ovw-side-status-copy">All systems nominal</p>
+        </div>
+      </div>
+
+      <button type="button" className="ovw-side-profile" onClick={onOpenLabPicker}>
+        <span className="ovw-side-orb" aria-hidden="true">
+          {initials || "·"}
+        </span>
+        <span className="ovw-side-profile-copy">
+          <strong>{displayName}</strong>
+          <span>{role}</span>
+        </span>
+        <span className="ovw-side-profile-chev" aria-hidden="true">
+          ⌄
+        </span>
+      </button>
+
+      <button type="button" className="ovw-side-signout" onClick={() => void signOut()}>
+        Sign out
+      </button>
+    </aside>
   );
 };
 
 // ---------------------------------------------------------------------------
-// Dashboard + join routes + root
+// Main shell
 // ---------------------------------------------------------------------------
 
-type ManagementTab = "members" | "invitations";
+const ROUTE_TITLE: Record<HomeRoute["kind"], string> = {
+  overview: "INTEGRATED LAB. INTELLIGENTLY MANAGED.",
+  calendar: "CALENDAR",
+  team: "TEAM",
+  analytics: "ANALYTICS",
+  reports: "REPORTS",
+  settings: "SETTINGS",
+};
 
-const AccountDashboard = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
+const ROUTE_KICKER: Record<HomeRoute["kind"], string> = {
+  overview: "OVERVIEW",
+  calendar: "CALENDAR",
+  team: "TEAM",
+  analytics: "ANALYTICS",
+  reports: "REPORTS",
+  settings: "SETTINGS",
+};
+
+const ROUTE_SUBTITLE: Record<HomeRoute["kind"], string> = {
+  overview: "Project data. Protocol systems. Resource orchestration.",
+  calendar: "Schedule, equipment slots, and review windows.",
+  team: "Lab members, invitations, and join requests.",
+  analytics: "Cross-app metrics and trends.",
+  reports: "Exports, audits, and shareable summaries.",
+  settings: "Profile, lab, and workspace configuration.",
+};
+
+const TopBar = ({ route }: { route: HomeRoute }) => {
   const { activeLab } = useAuth();
-  const [tab, setTab] = useState<ManagementTab>("members");
-  const [pendingCount, setPendingCount] = useState<number>(0);
-  const labId = activeLab?.id ?? null;
-  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
-  const canManageMembers = tier === "owner" || tier === "admin";
-
-  useEffect(() => {
-    if (!labId || !canManageMembers) {
-      setPendingCount(0);
-      return;
-    }
-    let cancelled = false;
-    listLabJoinRequests(labId, "pending")
-      .then((rows) => {
-        if (!cancelled) setPendingCount(rows.length);
-      })
-      .catch(() => {
-        if (!cancelled) setPendingCount(0);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [labId, canManageMembers, tab]);
-
   return (
-    <AppShell
-      sidebar={<SidePanelContent onOpenLabPicker={onOpenLabPicker} />}
-      sidebarAriaLabel="Account summary"
-      className="acct-shell"
-    >
-      <AppTopbar
-        kicker="Integrated Lab Manager"
-        title="Account & Lab Management"
-        actions={<AppSwitcher currentApp="home" baseUrl={APP_BASE_URL} />}
-      />
-      <AppSubbar
-        className="acct-subbar"
-        tabs={
-          <nav className="acct-tabs" aria-label="Lab management tabs">
-            <TabButton active={tab === "members"} onClick={() => setTab("members")}>
-              Members
-            </TabButton>
-            <TabButton active={tab === "invitations"} onClick={() => setTab("invitations")}>
-              Invitations &amp; Requests
-              {pendingCount > 0 ? <span className="acct-tab-badge">{pendingCount}</span> : null}
-            </TabButton>
-          </nav>
-        }
-      />
-      <AppContent className="acct-main-body">
-        {tab === "members" ? <MembersTab /> : <InvitationsTab />}
-      </AppContent>
-    </AppShell>
+    <header className="ovw-topbar">
+      <div className="ovw-topbar-copy">
+        <span className="ovw-kicker">{ROUTE_KICKER[route.kind]}</span>
+        <h1 className="ovw-title">{ROUTE_TITLE[route.kind]}</h1>
+        <p className="ovw-subtitle">{ROUTE_SUBTITLE[route.kind]}</p>
+      </div>
+      <div className="ovw-search" role="search">
+        <span>Search projects, protocols, inventory…</span>
+        <span aria-hidden="true">⌕</span>
+      </div>
+      <div className="ovw-org">
+        <strong>{activeLab?.name ?? "—"}</strong>
+        <span className="ovw-org-pill">SECTOR OS</span>
+        <small>LAB MANAGER SYSTEM</small>
+      </div>
+    </header>
+  );
+};
+
+const RouteBody = ({
+  route,
+  onOpenLabPicker,
+}: {
+  route: HomeRoute;
+  onOpenLabPicker: () => void;
+}) => {
+  switch (route.kind) {
+    case "overview":
+      return <OverviewView />;
+    case "team":
+      return <TeamView />;
+    case "settings":
+      return <SettingsView onOpenLabPicker={onOpenLabPicker} />;
+    case "calendar":
+      return (
+        <PlaceholderView
+          title="Calendar"
+          blurb="Lab events, equipment booking, and review windows will live here. Currently a future-stage shell."
+        />
+      );
+    case "analytics":
+      return (
+        <PlaceholderView
+          title="Analytics"
+          blurb="Cross-app metrics — protocol throughput, project velocity, supply burn — arriving once the underlying apps stabilize."
+        />
+      );
+    case "reports":
+      return (
+        <PlaceholderView
+          title="Reports"
+          blurb="Exports and shareable lab summaries. Future-stage feature."
+        />
+      );
+  }
+};
+
+const HomeShell = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
+  const route = useHomeRoute();
+  return (
+    <div className="ovw-shell">
+      <Sidebar route={route} onOpenLabPicker={onOpenLabPicker} />
+      <main className="ovw-main">
+        <TopBar route={route} />
+        <div className="ovw-body">
+          <RouteBody route={route} onOpenLabPicker={onOpenLabPicker} />
+        </div>
+      </main>
+    </div>
   );
 };
 
 // ---------------------------------------------------------------------------
-// Join-by-link route
+// Join-by-link route (unchanged)
 // ---------------------------------------------------------------------------
 
 const JoinScreen = ({ labId }: { labId: string }) => {
@@ -829,10 +485,14 @@ const JoinScreen = ({ labId }: { labId: string }) => {
         {loading ? (
           <p className="ilm-auth-note">Looking up lab…</p>
         ) : error ? (
-          <p className="ilm-auth-error" role="alert">{error}</p>
+          <p className="ilm-auth-error" role="alert">
+            {error}
+          </p>
         ) : alreadyMember ? (
           <>
-            <p className="ilm-auth-note">You're already a member of <strong>{labName}</strong>.</p>
+            <p className="ilm-auth-note">
+              You're already a member of <strong>{labName}</strong>.
+            </p>
             <button type="button" className="ilm-auth-submit" onClick={handleOpenLab}>
               Open {labName}
             </button>
@@ -890,8 +550,6 @@ const SignedInShell = () => {
   const { activeLab } = useAuth();
   const [showPicker, setShowPicker] = useState(false);
   const activeLabId = activeLab?.id ?? null;
-  // When the user picks/creates a lab inside LabPicker, activeLabId changes.
-  // Close the picker automatically so the dashboard re-mounts on the new lab.
   const prevIdRef = useRef<string | null>(activeLabId);
   useEffect(() => {
     if (showPicker && activeLabId && activeLabId !== prevIdRef.current) {
@@ -903,7 +561,7 @@ const SignedInShell = () => {
   if (!activeLab || showPicker) {
     return <LabPicker />;
   }
-  return <AccountDashboard onOpenLabPicker={() => setShowPicker(true)} />;
+  return <HomeShell onOpenLabPicker={() => setShowPicker(true)} />;
 };
 
 export const App = () => {

--- a/apps/account/src/lib/dashboardData.ts
+++ b/apps/account/src/lib/dashboardData.ts
@@ -1,0 +1,282 @@
+import { useEffect, useState } from "react";
+import { getSupabaseClient } from "@ilm/utils";
+
+export type ProjectStateCounts = {
+  draft: number;
+  published: number;
+  deleted: number;
+  total: number;
+};
+
+export type ProtocolSummary = {
+  id: string;
+  title: string;
+  description: string | null;
+  lifecycleStatus: string | null;
+  reviewStatus: string | null;
+  updatedAt: string;
+};
+
+export type ProtocolStats = {
+  total: number;
+  active: number;
+  inReview: number;
+  archived: number;
+  recent: ProtocolSummary[];
+};
+
+export type InventoryStats = {
+  total: number;
+  reagents: number;
+  consumables: number;
+  supplies: number;
+  samples: number;
+  other: number;
+  criticalLow: number;
+};
+
+export type TeamStats = {
+  total: number;
+  owners: number;
+  admins: number;
+  members: number;
+  recentAvatars: { id: string; label: string; email: string | null }[];
+};
+
+export type ActivityEntry = {
+  id: string;
+  kind: "protocol" | "project" | "item";
+  label: string;
+  context: string;
+  timestamp: string;
+};
+
+export type DashboardData = {
+  projects: ProjectStateCounts;
+  protocols: ProtocolStats;
+  inventory: InventoryStats;
+  team: TeamStats;
+  activity: ActivityEntry[];
+  loading: boolean;
+  error: string | null;
+};
+
+const empty: DashboardData = {
+  projects: { draft: 0, published: 0, deleted: 0, total: 0 },
+  protocols: { total: 0, active: 0, inReview: 0, archived: 0, recent: [] },
+  inventory: { total: 0, reagents: 0, consumables: 0, supplies: 0, samples: 0, other: 0, criticalLow: 0 },
+  team: { total: 0, owners: 0, admins: 0, members: 0, recentAvatars: [] },
+  activity: [],
+  loading: true,
+  error: null,
+};
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
+
+const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffMs = Date.now() - ts;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diffMs < minute) return "just now";
+  if (diffMs < hour) return `${Math.floor(diffMs / minute)}m ago`;
+  if (diffMs < day) return `${Math.floor(diffMs / hour)}h ago`;
+  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)}d ago`;
+  return new Date(iso).toLocaleDateString();
+};
+
+type ProtocolRow = {
+  id: string;
+  title: string;
+  description: string | null;
+  lifecycle_status: string | null;
+  review_status: string | null;
+  updated_at: string;
+  document_json: { protocol?: { metadata?: Record<string, unknown> } } | null;
+};
+
+const readDocStatus = (doc: ProtocolRow["document_json"]): { lifecycle: string | null; review: string | null } => {
+  const meta = doc?.protocol?.metadata;
+  return {
+    lifecycle: typeof meta?.lifecycleStatus === "string" ? (meta.lifecycleStatus as string) : null,
+    review: typeof meta?.reviewStatus === "string" ? (meta.reviewStatus as string) : null,
+  };
+};
+
+export const useDashboardData = (labId: string | null): DashboardData => {
+  const [data, setData] = useState<DashboardData>(empty);
+
+  useEffect(() => {
+    if (!labId) {
+      setData({ ...empty, loading: false });
+      return;
+    }
+    let cancelled = false;
+    setData((prev) => ({ ...prev, loading: true, error: null }));
+
+    const supabase = getSupabaseClient();
+
+    (async () => {
+      try {
+        const [projectsRes, protocolsRes, itemsRes, lowChecksRes, membersRes] = await Promise.all([
+          supabase.from("projects").select("id, state, updated_at, name").eq("lab_id", labId),
+          supabase
+            .from("protocols")
+            .select("id, title, description, lifecycle_status, review_status, updated_at, document_json")
+            .eq("lab_id", labId)
+            .order("updated_at", { ascending: false }),
+          supabase
+            .from("items")
+            .select("id, classification, updated_at, name")
+            .eq("lab_id", labId)
+            .eq("is_active", true),
+          supabase
+            .from("inventory_checks")
+            .select("item_id, stock_status, checked_at, items!inner(lab_id)")
+            .eq("items.lab_id", labId)
+            .in("stock_status", ["low", "out"])
+            .order("checked_at", { ascending: false })
+            .limit(200),
+          supabase.rpc("list_lab_members", { p_lab_id: labId }),
+        ]);
+
+        if (cancelled) return;
+
+        // Projects
+        type ProjectRow = { id: string; state: string; updated_at: string; name: string };
+        const projectRows = (projectsRes.data as ProjectRow[] | null) ?? [];
+        const projects: ProjectStateCounts = {
+          draft: projectRows.filter((r) => r.state === "draft").length,
+          published: projectRows.filter((r) => r.state === "published").length,
+          deleted: projectRows.filter((r) => r.state === "deleted").length,
+          total: projectRows.filter((r) => r.state !== "deleted").length,
+        };
+
+        // Protocols
+        const protocolRows = (protocolsRes.data as ProtocolRow[] | null) ?? [];
+        let active = 0;
+        let inReview = 0;
+        let archived = 0;
+        const recent: ProtocolSummary[] = [];
+        for (const row of protocolRows) {
+          const fromDoc = readDocStatus(row.document_json);
+          const lifecycle = (row.lifecycle_status ?? fromDoc.lifecycle ?? "").toLowerCase();
+          const review = (row.review_status ?? fromDoc.review ?? "").toLowerCase();
+          if (lifecycle === "archived") archived += 1;
+          else if (lifecycle === "active") active += 1;
+          if (review === "reviewing" || review === "pending" || review === "submitted") inReview += 1;
+          if (recent.length < 4) {
+            recent.push({
+              id: row.id,
+              title: row.title,
+              description: row.description,
+              lifecycleStatus: row.lifecycle_status ?? fromDoc.lifecycle,
+              reviewStatus: row.review_status ?? fromDoc.review,
+              updatedAt: row.updated_at,
+            });
+          }
+        }
+        const protocols: ProtocolStats = {
+          total: protocolRows.length,
+          active,
+          inReview,
+          archived,
+          recent,
+        };
+
+        // Inventory
+        type ItemRow = { id: string; classification: string; updated_at: string; name: string };
+        const itemRows = (itemsRes.data as ItemRow[] | null) ?? [];
+        const byClass = (c: string) => itemRows.filter((r) => r.classification === c).length;
+        const inventory: InventoryStats = {
+          total: itemRows.length,
+          reagents: byClass("reagent"),
+          consumables: byClass("consumable"),
+          supplies: byClass("supply"),
+          samples: byClass("sample"),
+          other: byClass("other"),
+          criticalLow: 0,
+        };
+
+        // Critical low: latest inventory_check per item with status low|out
+        type LowRow = { item_id: string; stock_status: string; checked_at: string };
+        const lowRows = (lowChecksRes.data as LowRow[] | null) ?? [];
+        const seenLow = new Set<string>();
+        for (const r of lowRows) {
+          if (seenLow.has(r.item_id)) continue;
+          seenLow.add(r.item_id);
+        }
+        inventory.criticalLow = seenLow.size;
+
+        // Team
+        type MemberRow = { user_id: string; role: "owner" | "admin" | "member"; display_name: string | null; email: string | null; joined_at: string };
+        const memberRows = ((membersRes.data as MemberRow[] | null) ?? []).filter(Boolean);
+        const team: TeamStats = {
+          total: memberRows.length,
+          owners: memberRows.filter((m) => m.role === "owner").length,
+          admins: memberRows.filter((m) => m.role === "admin").length,
+          members: memberRows.filter((m) => m.role === "member").length,
+          recentAvatars: memberRows.slice(0, 7).map((m) => ({
+            id: m.user_id,
+            label: (m.display_name || m.email || "?").slice(0, 2).toUpperCase(),
+            email: m.email,
+          })),
+        };
+
+        // Activity feed: union recent updates across protocols/projects/items.
+        const stream: ActivityEntry[] = [];
+        for (const r of protocolRows.slice(0, 6)) {
+          stream.push({
+            id: `protocol-${r.id}`,
+            kind: "protocol",
+            label: `Protocol "${r.title}" was updated`,
+            context: formatRelative(r.updated_at),
+            timestamp: r.updated_at,
+          });
+        }
+        for (const r of [...projectRows].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 6)) {
+          stream.push({
+            id: `project-${r.id}`,
+            kind: "project",
+            label: `Project "${r.name}" was updated`,
+            context: formatRelative(r.updated_at),
+            timestamp: r.updated_at,
+          });
+        }
+        for (const r of [...itemRows].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 6)) {
+          stream.push({
+            id: `item-${r.id}`,
+            kind: "item",
+            label: `Inventory item "${r.name}" was updated`,
+            context: formatRelative(r.updated_at),
+            timestamp: r.updated_at,
+          });
+        }
+        stream.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+        setData({
+          projects,
+          protocols,
+          inventory,
+          team,
+          activity: stream.slice(0, 5),
+          loading: false,
+          error: null,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setData({ ...empty, loading: false, error: errorMessage(err) });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [labId]);
+
+  return data;
+};
+
+export const formatRelativeTime = formatRelative;

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -2,223 +2,1044 @@
 @import "../../../packages/ui/src/reset.css";
 @import "../../../packages/ui/src/primitives/primitives.css";
 
-/* Shell: tighter sidebar + soft backdrop matches prior Account look. */
-.acct-shell {
-  --rl-shell-sidebar-width: 320px;
-  --rl-shell-sidebar-bg: var(--rl-soft);
+/* ============================================================
+   Home shell — sidebar + overview dashboard
+   ============================================================ */
+
+html,
+body {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(78, 159, 146, 0.10), transparent 35%),
+    radial-gradient(circle at 95% 85%, rgba(92, 125, 143, 0.08), transparent 35%),
+    var(--ilm-canvas);
+  min-height: 100vh;
 }
-/* Keep the sidebar stickily pinned so long main content scrolls past it. */
-.acct-shell > .rl-shell-sidebar {
+
+.ovw-shell {
+  display: grid;
+  grid-template-columns: 264px 1fr;
+  min-height: 100vh;
+  color: var(--ilm-ink);
+  font-family: var(--rl-font-body);
+}
+
+/* ----- Sidebar ------------------------------------------------ */
+.ovw-sidebar {
   position: sticky;
   top: 0;
   align-self: start;
   height: 100vh;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.6rem 1rem 1rem;
+  background: rgba(249, 250, 248, 0.85);
+  border-right: 1px solid var(--ilm-line);
+  backdrop-filter: blur(6px);
 }
 
-/* Left-panel sections keep their boxed look on top of the shared sidebar. */
-.acct-side-header {
-  display: grid;
-  gap: 0.2rem;
-  padding: 0.1rem 0.4rem 0.6rem;
-  border-bottom: 1px solid var(--rl-hairline);
+.ovw-brand {
+  padding: 0 0.4rem 0.4rem;
 }
-.acct-side-header strong {
-  font-family: var(--rl-font-display);
-  font-size: 1.05rem;
-  color: var(--rl-ink);
-}
-.acct-side-header small {
-  color: var(--rl-muted);
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.acct-side-section {
-  background: var(--rl-surface);
-  border: 1px solid var(--rl-line);
-  border-radius: 12px;
-  padding: 0.8rem 0.9rem;
-  gap: 0.5rem;
-}
-.acct-side-section h3 {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--rl-ink);
-}
-
-.acct-side-profile strong {
-  font-size: 0.95rem;
-  color: var(--rl-ink);
-}
-.acct-side-profile span {
-  font-size: 0.8rem;
-  color: var(--rl-muted);
-}
-
-.acct-lab-switcher {
-  display: grid;
+.ovw-brand-mark {
+  display: flex;
+  align-items: baseline;
   gap: 0.4rem;
-}
-.acct-lab-switcher select {
-  padding: 0.45rem 0.55rem;
-  border: 1px solid var(--rl-line);
-  border-radius: 8px;
-  background: #fff;
-  color: var(--rl-ink);
-}
-.acct-lab-role {
-  display: inline-block;
-  align-self: start;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  background: var(--rl-green-soft);
-  color: var(--rl-green);
-}
-.acct-lab-role.admin { background: #e8eddc; color: #4a5a33; }
-.acct-lab-role.member { background: var(--rl-surface-2); color: var(--rl-muted); }
-
-.acct-stat-row {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-}
-.acct-stat {
-  background: var(--rl-soft);
-  border: 1px solid var(--rl-hairline);
-  border-radius: 10px;
-  padding: 0.55rem 0.6rem;
-  display: grid;
-  gap: 0.1rem;
-  text-align: center;
-}
-.acct-stat-value {
   font-family: var(--rl-font-display);
-  font-size: 1.25rem;
-  color: var(--rl-ink);
+}
+.ovw-brand-mark strong {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ilm-ink);
+}
+.ovw-brand-mark span {
+  color: var(--ilm-fg-4);
+  font-weight: 500;
+}
+.ovw-brand-tag {
+  margin: 0.35rem 0 0;
+  font-family: var(--rl-font-display);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--ilm-muted);
+}
+.ovw-brand-tag b {
+  color: var(--ilm-viridian);
+  font-weight: 700;
+}
+
+.ovw-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.2rem;
+}
+.ovw-nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.ovw-nav-item {
+  display: grid;
+  grid-template-columns: 26px 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid transparent;
+  border-radius: var(--rl-radius-sm);
+  text-decoration: none;
+  color: var(--ilm-ink);
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.ovw-nav-item:hover {
+  background: rgba(255, 255, 255, 0.6);
+  border-color: var(--ilm-hairline);
+}
+.ovw-nav-item.is-active {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: var(--ilm-line);
+  color: var(--ilm-viridian);
+  box-shadow: 0 12px 22px rgba(30, 46, 30, 0.05);
+}
+.ovw-nav-item.is-soon {
+  color: var(--ilm-muted);
+}
+.ovw-nav-glyph-cell {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 1.5px solid currentColor;
+  border-radius: 4px;
+  font-size: 0.7rem;
+}
+.ovw-nav-glyph {
+  font-family: var(--rl-font-display);
   line-height: 1;
 }
-.acct-stat-label {
-  font-size: 0.62rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--rl-muted);
+.ovw-nav-pip {
+  font-size: 0.55rem;
+  letter-spacing: 0.15em;
+  background: var(--ilm-surface-soft);
+  color: var(--ilm-muted);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--rl-radius-pill);
+  border: 1px solid var(--ilm-hairline);
+}
+.ovw-nav-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
-.acct-side-footer {
+.ovw-side-status {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 0.7rem;
+  align-items: center;
   margin-top: auto;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--ilm-mint-dim);
+  border-radius: var(--rl-radius-sm);
+  background: rgba(244, 249, 241, 0.78);
+}
+.ovw-side-status-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 40% 40%, rgba(78,159,146,0.45), transparent 60%),
+    var(--ilm-surface);
+  border: 1px solid var(--ilm-mint-dim);
+  display: grid;
+  place-items: center;
+}
+.ovw-side-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ilm-viridian);
+  box-shadow: 0 0 0 4px rgba(78,159,146,0.2);
+}
+.ovw-side-status-title {
+  margin: 0;
+  font-family: var(--rl-font-display);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  color: var(--ilm-muted);
+}
+.ovw-side-status-copy {
+  margin: 0.1rem 0 0;
+  font-size: 0.78rem;
+  color: var(--ilm-viridian);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.ovw-side-profile {
+  display: grid;
+  grid-template-columns: 38px 1fr 14px;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--ilm-line);
+  border-radius: var(--rl-radius-sm);
+  background: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  text-align: left;
+}
+.ovw-side-profile:hover {
+  background: var(--ilm-surface);
+}
+.ovw-side-orb {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #ffffff 0 18%, var(--ilm-viridian) 22% 60%, #1f2a28 62% 100%);
+  color: rgba(255,255,255,0.95);
+  font-family: var(--rl-font-display);
+  font-size: 0.72rem;
+  display: grid;
+  place-items: center;
+  box-shadow: inset -5px -6px 12px rgba(0,0,0,0.2), 0 6px 12px rgba(0,0,0,0.1);
+}
+.ovw-side-profile-copy {
+  display: grid;
+  gap: 0.05rem;
+}
+.ovw-side-profile-copy strong {
+  font-family: var(--rl-font-display);
+  font-size: 0.85rem;
+  color: var(--ilm-ink);
+}
+.ovw-side-profile-copy span {
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  color: var(--ilm-muted);
+}
+.ovw-side-profile-chev {
+  color: var(--ilm-fg-4);
+}
+
+.ovw-side-signout {
+  appearance: none;
+  border: 1px solid var(--ilm-line);
+  background: transparent;
+  color: var(--ilm-muted);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--rl-radius-sm);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.ovw-side-signout:hover {
+  background: var(--ilm-surface);
+  color: var(--ilm-ink);
+}
+
+/* ----- Main column ------------------------------------------- */
+.ovw-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.ovw-topbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px) auto;
+  align-items: end;
+  gap: 1.2rem;
+  padding: 2rem 2.2rem 1.2rem;
+}
+.ovw-topbar-copy {
+  min-width: 0;
+}
+.ovw-kicker {
+  display: inline-block;
+  padding: 0.18rem 0.55rem;
+  margin-bottom: 0.45rem;
+  background: var(--ilm-ink);
+  color: #fff;
+  font-family: var(--rl-font-display);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.ovw-title {
+  margin: 0;
+  font-family: var(--rl-font-display);
+  font-size: clamp(1.4rem, 1.8vw + 0.4rem, 1.95rem);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: 0;
+  color: var(--ilm-ink);
+}
+.ovw-subtitle {
+  margin: 0.4rem 0 0;
+  color: var(--ilm-muted);
+  font-size: 0.85rem;
+}
+
+.ovw-search {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 36px;
+  padding: 0 0.8rem;
+  border: 1px solid var(--ilm-line);
+  border-radius: var(--rl-radius-sm);
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--ilm-fg-4);
+  font-size: 0.78rem;
+}
+
+.ovw-org {
+  text-align: right;
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--ilm-ink);
+}
+.ovw-org-pill {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.35rem;
+  background: var(--ilm-ink);
+  color: #fff;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+}
+.ovw-org small {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--ilm-muted);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+}
+
+.ovw-body {
+  padding: 0.6rem 2.2rem 2.5rem;
+}
+
+/* ============================================================
+   Overview grid
+   ============================================================ */
+
+.ovw-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  grid-auto-rows: minmax(0, auto);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.ovw-card {
+  position: relative;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid var(--ilm-line);
+  border-radius: var(--rl-radius-sm);
+  padding: 1rem 1.1rem;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ovw-card header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.ovw-card h3 {
+  margin: 0;
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ilm-ink);
+}
+.ovw-card-link {
+  color: var(--ilm-viridian);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.ovw-card-pill {
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ilm-muted);
+  border: 1px solid var(--ilm-hairline);
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--rl-radius-pill);
+}
+
+.ovw-empty {
+  margin: 0;
+  color: var(--ilm-fg-4);
+  font-size: 0.85rem;
+}
+.ovw-error {
+  grid-column: 1 / -1;
+  background: var(--ilm-red-soft);
+  border: 1px solid var(--ilm-amber-line);
+  color: var(--ilm-red-deep);
+  padding: 0.55rem 0.8rem;
+  border-radius: var(--rl-radius-sm);
+  font-size: 0.85rem;
+}
+
+/* Hero: spans 3 cols, with status copy left and SVG art right */
+.ovw-hero {
+  grid-column: span 3;
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 2rem 2.2rem;
+  min-height: 280px;
+}
+.ovw-label {
+  display: inline-block;
+  padding: 0.2rem 0.45rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid var(--ilm-line);
+  font-family: var(--rl-font-display);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ilm-ink);
+}
+.ovw-status {
+  margin: 0.7rem 0 0.3rem;
+  font-family: var(--rl-font-display);
+  font-size: 2.4rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--ilm-ink);
+  letter-spacing: 0;
+}
+.ovw-status-copy {
+  margin: 0;
+  color: var(--ilm-muted);
+  font-size: 0.85rem;
+}
+.ovw-metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  margin-top: 1.6rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ilm-line);
+}
+.ovw-metric {
+  padding: 0 0.8rem;
+  border-right: 1px solid var(--ilm-line);
+}
+.ovw-metric:first-child { padding-left: 0; }
+.ovw-metric:last-child { border-right: 0; padding-right: 0; }
+.ovw-metric span {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--ilm-muted);
+  text-transform: uppercase;
+}
+.ovw-metric b {
+  display: block;
+  margin-top: 0.4rem;
+  font-family: var(--rl-font-display);
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--ilm-ink);
+}
+.ovw-metric-accent {
+  color: var(--ilm-viridian) !important;
+}
+
+.ovw-hero-art {
+  position: relative;
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  min-height: 220px;
+}
+.ovw-hero-art svg {
+  width: 100%;
+  height: auto;
+  max-height: 240px;
+  display: block;
+}
+.ovw-node-label {
+  position: absolute;
+  font-size: 0.7rem;
+  line-height: 1.1;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--rl-radius-xs);
+  border: 1px solid var(--ilm-hairline);
+}
+.ovw-node-label strong {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  color: var(--ilm-ink);
+}
+.ovw-node-label em {
+  display: block;
+  margin-top: 0.1rem;
+  color: var(--ilm-muted);
+  font-style: normal;
+}
+.ovw-node-1 { top: 8%; left: 22%; }
+.ovw-node-2 { top: 18%; right: 6%; }
+.ovw-node-3 { bottom: 10%; right: 8%; }
+
+/* Schedule */
+.ovw-schedule {
+  grid-column: span 1;
+}
+.ovw-schedule-date {
+  margin: 0.4rem 0 0.4rem;
+  font-family: var(--rl-font-display);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  color: var(--ilm-muted);
+}
+.ovw-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+.ovw-timeline li {
+  display: grid;
+  grid-template-columns: 56px 14px 1fr;
+  align-items: start;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--ilm-ink);
+}
+.ovw-time {
+  font-size: 0.7rem;
+  color: var(--ilm-muted);
+}
+.ovw-ring {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid var(--ilm-hairline);
+  background: #fff;
+  margin-top: 3px;
+}
+.ovw-timeline strong {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 0.1rem;
+}
+.ovw-timeline span {
+  color: var(--ilm-muted);
+  font-size: 0.72rem;
+}
+
+/* Projects donut */
+.ovw-projects {}
+.ovw-donut-wrap {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+.ovw-donut {
+  width: 110px;
+  height: 110px;
+}
+.ovw-donut-num {
+  font-family: var(--rl-font-display);
+  font-size: 26px;
+  fill: var(--ilm-ink);
+}
+.ovw-donut-label {
+  font-family: var(--rl-font-display);
+  font-size: 7px;
+  letter-spacing: 0.2em;
+  fill: var(--ilm-muted);
+}
+.ovw-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.7rem;
+}
+.ovw-legend li {
+  display: grid;
+  grid-template-columns: 10px auto 1fr;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ovw-legend i {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.ovw-legend strong {
+  font-family: var(--rl-font-display);
+  font-size: 0.95rem;
+  color: var(--ilm-ink);
+}
+.ovw-legend span {
+  color: var(--ilm-muted);
+}
+
+/* Protocols list */
+.ovw-protocols {}
+.ovw-protocol-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+.ovw-protocol-list li {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--ilm-hairline);
+  border-radius: var(--rl-radius-xs);
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.76rem;
+}
+.ovw-square-glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--ilm-hairline);
+  border-radius: 4px;
+  font-size: 0.7rem;
+  color: var(--ilm-muted);
+  background: var(--ilm-surface);
+}
+.ovw-protocol-list strong {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ilm-ink);
+}
+.ovw-protocol-list span {
+  display: block;
+  font-size: 0.66rem;
+  color: var(--ilm-muted);
+}
+.ovw-tag {
+  padding: 0.18rem 0.5rem;
+  border-radius: var(--rl-radius-pill);
+  font-family: var(--rl-font-display);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+.ovw-tag--active {
+  background: var(--ilm-viridian-soft);
+  color: var(--ilm-viridian);
+}
+.ovw-tag--review {
+  background: var(--ilm-amber-soft);
+  color: var(--ilm-amber);
+}
+.ovw-tag--muted {
+  background: var(--ilm-surface-soft);
+  color: var(--ilm-muted);
+}
+
+/* Inventory */
+.ovw-radar-wrap {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 0.8rem;
+  align-items: center;
+}
+.ovw-radar {
+  width: 130px;
+  height: 130px;
+  display: block;
+}
+.ovw-inv-stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.66rem;
+}
+.ovw-inv-stats li {
+  display: grid;
+  grid-template-columns: 10px auto 1fr;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--ilm-muted);
+}
+.ovw-inv-stats i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.ovw-inv-stats strong {
+  font-family: var(--rl-font-display);
+  font-size: 0.95rem;
+  color: var(--ilm-ink);
+}
+
+/* Funding */
+.ovw-funding {
+  position: relative;
+  overflow: hidden;
+}
+.ovw-fund-amount {
+  margin: 0.3rem 0 0;
+  font-family: var(--rl-font-display);
+  font-size: 1.8rem;
+  font-weight: 500;
+  color: var(--ilm-ink);
+}
+.ovw-fund-sub {
+  margin: 0 0 0.6rem;
+  font-family: var(--rl-font-display);
+  font-size: 0.6rem;
+  color: var(--ilm-muted);
+  letter-spacing: 0.1em;
+}
+.ovw-fund-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
   gap: 0.5rem;
 }
+.ovw-fund-rows li {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.7rem;
+}
+.ovw-fund-rows strong {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.85rem;
+  color: var(--ilm-ink);
+}
+.ovw-fund-rows span {
+  color: var(--ilm-muted);
+}
+.ovw-bars {
+  position: absolute;
+  right: 1rem;
+  bottom: 0.8rem;
+  display: flex;
+  align-items: end;
+  gap: 6px;
+  height: 90px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+.ovw-bars i {
+  display: block;
+  width: 8px;
+  border-radius: 6px 6px 0 0;
+  background: var(--ilm-mint-dim);
+}
+.ovw-bars i:nth-child(3),
+.ovw-bars i:nth-child(6) {
+  background: var(--ilm-viridian-2);
+}
 
-.acct-primary-button {
-  appearance: none;
-  border: 1px solid var(--rl-green);
-  background: var(--rl-green);
-  color: #fff;
-  padding: 0.55rem 0.9rem;
-  border-radius: 8px;
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
+/* Activity */
+.ovw-activity {
+  grid-column: span 1;
+}
+.ovw-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+.ovw-activity-list li {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 0.5rem;
+  align-items: start;
+  font-size: 0.72rem;
+}
+.ovw-activity-list strong {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
   font-weight: 600;
+  color: var(--ilm-ink);
+  margin-bottom: 0.1rem;
 }
-.acct-primary-button:hover:not(:disabled) { background: var(--rl-green-2); border-color: var(--rl-green-2); }
-.acct-primary-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.ovw-activity-list span {
+  color: var(--ilm-muted);
+  font-size: 0.66rem;
+}
+.ovw-activity-dot {
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--ilm-viridian);
+  box-shadow: 0 0 8px rgba(47,125,114,0.45);
+}
 
-.acct-danger-button {
-  appearance: none;
-  border: 1px solid #d89593;
-  background: #fff;
-  color: var(--rl-danger-text);
-  padding: 0.4rem 0.65rem;
-  border-radius: 8px;
-  font-size: 0.8rem;
+/* Resource */
+.ovw-resource {
+  grid-column: span 2;
 }
-.acct-danger-button:hover:not(:disabled) { background: var(--rl-error-c); }
-.acct-danger-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.ovw-resource-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+.ovw-resource-grid li {
+  padding: 0.4rem 1rem;
+  border-left: 1px solid var(--ilm-line);
+  font-size: 0.68rem;
+  color: var(--ilm-muted);
+}
+.ovw-resource-grid li:first-child {
+  border-left: none;
+  padding-left: 0;
+}
+.ovw-resource-label {
+  display: block;
+  font-family: var(--rl-font-display);
+  font-size: 0.58rem;
+  letter-spacing: 0.12em;
+}
+.ovw-resource-grid strong {
+  display: block;
+  margin: 0.4rem 0;
+  font-family: var(--rl-font-display);
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--ilm-ink);
+}
+.ovw-spark {
+  display: block;
+  width: 64px;
+  height: 22px;
+  border-radius: 4px;
+  background: rgba(78,159,146,0.30);
+  clip-path: polygon(0 80%, 12% 75%, 20% 46%, 31% 63%, 42% 22%, 54% 58%, 66% 51%, 78% 65%, 88% 44%, 100% 69%, 100% 100%, 0 100%);
+}
+.ovw-spark--green { background: rgba(78,159,146,0.32); }
+.ovw-spark--orange { background: rgba(154,91,30,0.32); }
+.ovw-spark--neutral { background: rgba(96,113,110,0.30); }
 
-.acct-text-button {
-  appearance: none;
-  border: 1px solid var(--rl-line);
-  background: #fff;
-  color: var(--rl-ink);
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  font-size: 0.82rem;
+/* Team */
+.ovw-team {
+  grid-column: span 1;
 }
-.acct-text-button:hover:not(:disabled) { background: var(--rl-soft); }
-.acct-text-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.ovw-avatars {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.3rem 0;
+}
+.ovw-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 50% 30%, #f1dfc8 0 18%, transparent 19%),
+              linear-gradient(90deg, var(--ilm-viridian) 0 40%, #dbe8d6 40% 60%, var(--ilm-viridian) 60% 100%);
+  color: rgba(255,255,255,0.95);
+  font-family: var(--rl-font-display);
+  font-size: 0.65rem;
+  border: 2px solid var(--ilm-mint-dim);
+  box-shadow: 0 5px 10px rgba(41,95,47,0.14);
+  text-shadow: 0 1px 1px rgba(0,0,0,0.3);
+}
+.ovw-avatar--more {
+  background: var(--ilm-surface);
+  color: var(--ilm-viridian);
+  border-color: var(--ilm-hairline);
+  text-shadow: none;
+}
+.ovw-team-stats {
+  list-style: none;
+  margin: 0.3rem 0 0;
+  padding: 0.5rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--ilm-line);
+  gap: 0.4rem;
+  font-size: 0.62rem;
+  color: var(--ilm-muted);
+}
+.ovw-team-stats li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.ovw-team-stats strong {
+  font-family: var(--rl-font-display);
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--ilm-ink);
+}
+.ovw-team-stats-accent {
+  color: var(--ilm-amber) !important;
+}
 
-/* Subbar overrides so Account's tab strip reads as a plain tab bar. */
-.acct-subbar {
-  padding-top: 0;
-  padding-bottom: 0;
-  background: rgba(249, 248, 244, 0.92);
+/* ============================================================
+   Responsive — collapse to one column on narrow screens
+   ============================================================ */
+
+@media (max-width: 1280px) {
+  .ovw-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .ovw-hero {
+    grid-column: span 3;
+  }
+  .ovw-resource {
+    grid-column: span 3;
+  }
 }
-.acct-subbar .rl-subbar__tabs {
-  margin-left: 0;
+
+@media (max-width: 960px) {
+  .ovw-shell {
+    grid-template-columns: 1fr;
+  }
+  .ovw-sidebar {
+    position: static;
+    height: auto;
+  }
+  .ovw-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .ovw-hero,
+  .ovw-resource {
+    grid-column: span 2;
+  }
+  .ovw-topbar {
+    grid-template-columns: 1fr;
+  }
+  .ovw-org { text-align: left; }
 }
+
+@media (max-width: 640px) {
+  .ovw-grid {
+    grid-template-columns: 1fr;
+  }
+  .ovw-hero,
+  .ovw-resource {
+    grid-column: span 1;
+  }
+  .ovw-hero {
+    grid-template-columns: 1fr;
+  }
+  .ovw-hero-art { display: none; }
+  .ovw-metric-row {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.6rem 0;
+  }
+  .ovw-metric {
+    border-right: none;
+    padding: 0;
+  }
+  .ovw-body { padding: 0.6rem 1rem 2rem; }
+  .ovw-topbar { padding: 1.2rem 1rem; }
+}
+
+/* ============================================================
+   Team / Settings / Placeholder pages
+   ============================================================ */
+
+.acct-team-page,
+.acct-settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 920px;
+}
+
 .acct-tabs {
   display: flex;
   gap: 0.3rem;
-  margin-left: 0;
+  border-bottom: 1px solid var(--ilm-line);
+  margin-bottom: 0.4rem;
 }
-.acct-tabs .rl-tab {
-  padding: 0.75rem 1rem;
+.acct-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0.7rem 1rem;
+  font-family: var(--rl-font-display);
   font-size: 0.78rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  color: var(--ilm-muted);
+  cursor: pointer;
+  position: relative;
 }
-.acct-tabs .rl-tab.is-active,
-.acct-tabs .rl-tab[aria-selected="true"] {
-  color: var(--rl-green);
+.acct-tab.is-active {
+  color: var(--ilm-viridian);
   font-weight: 600;
 }
-.acct-tabs .rl-tab.is-active::after,
-.acct-tabs .rl-tab[aria-selected="true"]::after {
-  bottom: -0.1rem;
-  background: var(--rl-green);
+.acct-tab.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--ilm-viridian);
 }
 .acct-tab-badge {
   display: inline-block;
   margin-left: 0.4rem;
-  background: var(--rl-green);
+  background: var(--ilm-viridian);
   color: #fff;
   border-radius: 999px;
   padding: 0.05rem 0.4rem;
-  font-size: 0.65rem;
-  letter-spacing: 0.04em;
+  font-size: 0.6rem;
 }
 
-/* Extra breathing room matching the previous main body padding. */
-.acct-main-body {
-  gap: 1rem;
-}
-
-.acct-error {
-  background: var(--rl-error-c);
-  border: 1px solid #f2b3af;
-  color: var(--rl-danger-text);
-  padding: 0.55rem 0.8rem;
-  border-radius: 8px;
-  margin: 0;
-  font-size: 0.88rem;
-}
-.acct-empty {
-  color: var(--rl-muted);
-  font-size: 0.92rem;
-  margin: 0.4rem 0;
-}
-
-/* Cards/Tables */
 .acct-card {
-  background: var(--rl-surface);
-  border: 1px solid var(--rl-line);
-  border-radius: 12px;
+  background: var(--ilm-surface);
+  border: 1px solid var(--ilm-line);
+  border-radius: var(--rl-radius-soft);
   padding: 1rem 1.1rem;
   display: flex;
   flex-direction: column;
@@ -234,21 +1055,37 @@
 .acct-card-header h2 {
   margin: 0;
   font-size: 1.05rem;
-  color: var(--rl-ink);
+  color: var(--ilm-ink);
 }
 .acct-card-header p {
   margin: 0.15rem 0 0;
-  color: var(--rl-muted);
+  color: var(--ilm-muted);
   font-size: 0.85rem;
 }
 .acct-card-pill {
-  background: var(--rl-soft);
-  border: 1px solid var(--rl-hairline);
-  color: var(--rl-muted);
+  background: var(--ilm-surface-soft);
+  border: 1px solid var(--ilm-hairline);
+  color: var(--ilm-muted);
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
   font-size: 0.72rem;
   letter-spacing: 0.08em;
+}
+
+.acct-empty {
+  color: var(--ilm-muted);
+  font-size: 0.92rem;
+  margin: 0.4rem 0;
+}
+
+.acct-error {
+  background: var(--ilm-red-soft);
+  border: 1px solid #f2b3af;
+  color: var(--ilm-red);
+  padding: 0.55rem 0.8rem;
+  border-radius: 8px;
+  margin: 0;
+  font-size: 0.88rem;
 }
 
 .acct-member-list {
@@ -263,14 +1100,14 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
   padding: 0.7rem 0;
-  border-top: 1px solid var(--rl-hairline);
+  border-top: 1px solid var(--ilm-hairline);
   align-items: center;
 }
 .acct-member:first-child { border-top: none; }
 .acct-member-copy { display: grid; gap: 0.15rem; min-width: 0; }
-.acct-member-copy strong { font-size: 0.95rem; color: var(--rl-ink); }
-.acct-member-copy span { font-size: 0.82rem; color: var(--rl-muted); }
-.acct-member-copy small { font-size: 0.72rem; color: var(--rl-muted); }
+.acct-member-copy strong { font-size: 0.95rem; color: var(--ilm-ink); }
+.acct-member-copy span { font-size: 0.82rem; color: var(--ilm-muted); }
+.acct-member-copy small { font-size: 0.72rem; color: var(--ilm-muted); }
 .acct-member-actions {
   display: flex;
   gap: 0.4rem;
@@ -286,34 +1123,28 @@
   font-size: 0.7rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  background: var(--rl-surface-2);
-  color: var(--rl-muted);
+  background: var(--ilm-surface-soft);
+  color: var(--ilm-muted);
 }
-.acct-badge.owner { background: var(--rl-green-soft); color: var(--rl-green); }
+.acct-badge.owner { background: var(--ilm-viridian-soft); color: var(--ilm-viridian); }
 .acct-badge.admin { background: #e8eddc; color: #4a5a33; }
 
-.acct-form {
-  display: grid;
-  gap: 0.6rem;
-}
-.acct-field {
-  display: grid;
-  gap: 0.25rem;
-}
+.acct-form { display: grid; gap: 0.6rem; }
+.acct-field { display: grid; gap: 0.25rem; }
 .acct-field span {
   font-size: 0.72rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--rl-muted);
+  color: var(--ilm-muted);
 }
 .acct-field input,
 .acct-field select,
 .acct-field textarea {
   padding: 0.5rem 0.6rem;
-  border: 1px solid var(--rl-line);
+  border: 1px solid var(--ilm-line);
   border-radius: 8px;
   background: #fff;
-  color: var(--rl-ink);
+  color: var(--ilm-ink);
 }
 .acct-field-row {
   display: grid;
@@ -324,14 +1155,6 @@
   .acct-field-row { grid-template-columns: 1fr; }
 }
 
-@media (max-width: 900px) {
-  .acct-shell > .rl-shell-sidebar {
-    position: static;
-    height: auto;
-    overflow-y: visible;
-  }
-}
-
 .acct-share-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -340,10 +1163,10 @@
 }
 .acct-share-row input {
   padding: 0.5rem 0.6rem;
-  border: 1px solid var(--rl-line);
+  border: 1px solid var(--ilm-line);
   border-radius: 8px;
   background: #fff;
-  color: var(--rl-ink);
+  color: var(--ilm-ink);
 }
 
 .acct-request-item {
@@ -351,13 +1174,13 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
   padding: 0.7rem 0;
-  border-top: 1px solid var(--rl-hairline);
+  border-top: 1px solid var(--ilm-hairline);
   align-items: flex-start;
 }
 .acct-request-item:first-child { border-top: none; }
 .acct-request-message {
   margin-top: 0.35rem;
-  color: var(--rl-muted);
+  color: var(--ilm-muted);
   font-size: 0.85rem;
   font-style: italic;
 }
@@ -368,20 +1191,108 @@
 }
 .acct-reject-form textarea { min-height: 3rem; }
 
-.acct-invitations {
-  display: grid;
-  gap: 0.4rem;
-}
+.acct-invitations { display: grid; gap: 0.4rem; }
 .acct-invitation {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 0.75rem;
   padding: 0.55rem 0;
-  border-top: 1px solid var(--rl-hairline);
+  border-top: 1px solid var(--ilm-hairline);
   align-items: center;
 }
 .acct-invitation:first-child { border-top: none; }
-.acct-invitation strong { font-size: 0.9rem; color: var(--rl-ink); }
-.acct-invitation small { font-size: 0.72rem; color: var(--rl-muted); }
+.acct-invitation strong { font-size: 0.9rem; color: var(--ilm-ink); }
+.acct-invitation small { font-size: 0.72rem; color: var(--ilm-muted); }
 
-.acct-row-actions { display: flex; gap: 0.35rem; }
+.acct-row-actions { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+
+.acct-primary-button {
+  appearance: none;
+  border: 1px solid var(--ilm-viridian);
+  background: var(--ilm-viridian);
+  color: #fff;
+  padding: 0.55rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  cursor: pointer;
+}
+.acct-primary-button:hover:not(:disabled) {
+  background: var(--ilm-viridian-2);
+  border-color: var(--ilm-viridian-2);
+}
+.acct-primary-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.acct-danger-button {
+  appearance: none;
+  border: 1px solid #d89593;
+  background: #fff;
+  color: var(--ilm-red);
+  padding: 0.4rem 0.65rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.acct-danger-button:hover:not(:disabled) { background: var(--ilm-red-soft); }
+.acct-danger-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.acct-text-button {
+  appearance: none;
+  border: 1px solid var(--ilm-line);
+  background: #fff;
+  color: var(--ilm-ink);
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.acct-text-button:hover:not(:disabled) { background: var(--ilm-surface-soft); }
+.acct-text-button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.acct-side-profile {
+  display: grid;
+  gap: 0.2rem;
+}
+.acct-side-profile strong {
+  font-family: var(--rl-font-display);
+  font-size: 0.95rem;
+  color: var(--ilm-ink);
+}
+.acct-side-profile span {
+  font-size: 0.82rem;
+  color: var(--ilm-muted);
+}
+
+.acct-placeholder {
+  background: var(--ilm-surface);
+  border: 1px dashed var(--ilm-line);
+  border-radius: var(--rl-radius-soft);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: flex-start;
+  max-width: 720px;
+}
+.acct-placeholder-tag {
+  font-family: var(--rl-font-display);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  background: var(--ilm-surface-soft);
+  color: var(--ilm-muted);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+.acct-placeholder h2 {
+  margin: 0;
+  font-family: var(--rl-font-display);
+  font-size: 1.4rem;
+  color: var(--ilm-ink);
+}
+.acct-placeholder p {
+  margin: 0;
+  color: var(--ilm-muted);
+  font-size: 0.95rem;
+  max-width: 60ch;
+}

--- a/apps/account/src/views/OverviewView.tsx
+++ b/apps/account/src/views/OverviewView.tsx
@@ -1,0 +1,474 @@
+import { useMemo } from "react";
+import { useAuth } from "@ilm/ui";
+import { useDashboardData, type ProjectStateCounts, type ProtocolStats, type InventoryStats, type TeamStats } from "../lib/dashboardData";
+
+const formatNumber = (n: number) => new Intl.NumberFormat().format(n);
+
+const today = () =>
+  new Intl.DateTimeFormat(undefined, { weekday: "long", month: "long", day: "numeric", year: "numeric" }).format(new Date());
+
+const StatusBlock = ({
+  projects,
+  protocols,
+  team,
+  inventory,
+}: {
+  projects: ProjectStateCounts;
+  protocols: ProtocolStats;
+  team: TeamStats;
+  inventory: InventoryStats;
+}) => {
+  const compliance = useMemo(() => {
+    if (protocols.total === 0) return 100;
+    const compliant = protocols.total - protocols.inReview;
+    return Math.max(0, Math.min(100, Math.round((compliant / protocols.total) * 100)));
+  }, [protocols.total, protocols.inReview]);
+
+  const hasCritical = inventory.criticalLow > 0;
+  const status = hasCritical ? "ATTENTION" : protocols.inReview > 0 ? "STEADY" : "OPTIMAL";
+  const statusCopy = hasCritical
+    ? "Some inventory items need reordering."
+    : protocols.inReview > 0
+      ? "Reviews pending across active protocols."
+      : "All systems running within normal parameters.";
+
+  return (
+    <section className="ovw-card ovw-hero">
+      <div className="ovw-hero-copy">
+        <span className="ovw-label">LAB OPERATING STATUS</span>
+        <h2 className="ovw-status">{status}</h2>
+        <p className="ovw-status-copy">{statusCopy}</p>
+        <div className="ovw-metric-row">
+          <div className="ovw-metric">
+            <span>ACTIVE PROJECTS</span>
+            <b>{formatNumber(projects.total)}</b>
+          </div>
+          <div className="ovw-metric">
+            <span>PROTOCOLS</span>
+            <b>{formatNumber(protocols.total)}</b>
+          </div>
+          <div className="ovw-metric">
+            <span>TEAM MEMBERS</span>
+            <b>{formatNumber(team.total)}</b>
+          </div>
+          <div className="ovw-metric">
+            <span>COMPLIANCE</span>
+            <b className="ovw-metric-accent">{compliance}%</b>
+          </div>
+        </div>
+      </div>
+      <div className="ovw-hero-art" aria-hidden="true">
+        <svg viewBox="0 0 560 260" preserveAspectRatio="xMidYMid meet">
+          <defs>
+            <linearGradient id="ovw-flow" x1="0" x2="1">
+              <stop offset="0" stopColor="rgba(78,159,146,0.0)" />
+              <stop offset=".4" stopColor="rgba(78,159,146,0.45)" />
+              <stop offset=".6" stopColor="rgba(78,159,146,0.45)" />
+              <stop offset="1" stopColor="rgba(78,159,146,0.0)" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M55 135 C142 28 222 35 282 132 C342 228 423 230 506 126"
+            fill="none"
+            stroke="url(#ovw-flow)"
+            strokeWidth="22"
+            strokeLinecap="round"
+          />
+          <path
+            d="M55 125 C142 232 222 225 282 128 C342 32 423 30 506 134"
+            fill="none"
+            stroke="rgba(47,125,114,0.22)"
+            strokeWidth="18"
+            strokeLinecap="round"
+          />
+          <circle cx="151" cy="50" r="3" fill="var(--ilm-ink)" />
+          <circle cx="446" cy="68" r="3" fill="var(--ilm-ink)" />
+          <circle cx="458" cy="200" r="3" fill="var(--ilm-ink)" />
+        </svg>
+        <div className="ovw-node-label ovw-node-1">
+          <strong>SYSTEMS</strong>
+          <em>Synced</em>
+        </div>
+        <div className="ovw-node-label ovw-node-2">
+          <strong>PROTOCOLS</strong>
+          <em>{protocols.inReview > 0 ? `${protocols.inReview} in review` : "Up to date"}</em>
+        </div>
+        <div className="ovw-node-label ovw-node-3">
+          <strong>DATA INTEGRITY</strong>
+          <em>Verified</em>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const ScheduleCard = () => (
+  <section className="ovw-card ovw-schedule">
+    <header>
+      <h3>UPCOMING SCHEDULE</h3>
+      <span className="ovw-card-link">View calendar</span>
+    </header>
+    <p className="ovw-schedule-date">{today().toUpperCase()}</p>
+    <ol className="ovw-timeline">
+      <li>
+        <span className="ovw-time">--</span>
+        <span className="ovw-ring" />
+        <div>
+          <strong>Calendar coming soon</strong>
+          <span>Lab events, equipment slots, and reviews</span>
+        </div>
+      </li>
+      <li>
+        <span className="ovw-time">--</span>
+        <span className="ovw-ring" />
+        <div>
+          <strong>Protocol reviews</strong>
+          <span>Pending items will surface here</span>
+        </div>
+      </li>
+      <li>
+        <span className="ovw-time">--</span>
+        <span className="ovw-ring" />
+        <div>
+          <strong>Equipment maintenance</strong>
+          <span>Track from inventory once enabled</span>
+        </div>
+      </li>
+    </ol>
+  </section>
+);
+
+const Donut = ({ counts }: { counts: ProjectStateCounts }) => {
+  const total = counts.total || 1;
+  const segments = [
+    { value: counts.published, color: "var(--ilm-viridian)" },
+    { value: counts.draft, color: "var(--ilm-viridian-2)" },
+    { value: counts.deleted, color: "var(--ilm-fg-4)" },
+  ];
+  const radius = 38;
+  const circumference = 2 * Math.PI * radius;
+  let offset = 0;
+  const arcs = segments.map((s, i) => {
+    const length = (s.value / total) * circumference;
+    const node = (
+      <circle
+        key={i}
+        r={radius}
+        cx="50"
+        cy="50"
+        fill="none"
+        stroke={s.color}
+        strokeWidth="14"
+        strokeDasharray={`${length} ${circumference - length}`}
+        strokeDashoffset={-offset}
+        transform="rotate(-90 50 50)"
+      />
+    );
+    offset += length;
+    return node;
+  });
+  return (
+    <svg viewBox="0 0 100 100" className="ovw-donut">
+      <circle r={radius} cx="50" cy="50" fill="none" stroke="var(--ilm-line)" strokeWidth="14" />
+      {arcs}
+      <text x="50" y="49" textAnchor="middle" className="ovw-donut-num">
+        {counts.total}
+      </text>
+      <text x="50" y="62" textAnchor="middle" className="ovw-donut-label">
+        TOTAL
+      </text>
+    </svg>
+  );
+};
+
+const ProjectsCard = ({ counts }: { counts: ProjectStateCounts }) => (
+  <section className="ovw-card ovw-projects">
+    <header>
+      <h3>PROJECTS OVERVIEW</h3>
+      <span className="ovw-card-link">View all projects</span>
+    </header>
+    <div className="ovw-donut-wrap">
+      <Donut counts={counts} />
+      <ul className="ovw-legend">
+        <li>
+          <i style={{ background: "var(--ilm-viridian)" }} />
+          <strong>{counts.published}</strong>
+          <span>Published</span>
+        </li>
+        <li>
+          <i style={{ background: "var(--ilm-viridian-2)" }} />
+          <strong>{counts.draft}</strong>
+          <span>Drafts</span>
+        </li>
+        <li>
+          <i style={{ background: "var(--ilm-fg-4)" }} />
+          <strong>{counts.deleted}</strong>
+          <span>In recycle</span>
+        </li>
+      </ul>
+    </div>
+  </section>
+);
+
+const ProtocolsCard = ({ stats }: { stats: ProtocolStats }) => {
+  const lifecycleTone = (status: string | null): "active" | "review" | "muted" => {
+    const lc = (status ?? "").toLowerCase();
+    if (lc === "active") return "active";
+    if (lc === "archived") return "muted";
+    return "review";
+  };
+  return (
+    <section className="ovw-card ovw-protocols">
+      <header>
+        <h3>PROTOCOLS</h3>
+        <span className="ovw-card-link">View all protocols</span>
+      </header>
+      {stats.recent.length === 0 ? (
+        <p className="ovw-empty">No protocols yet.</p>
+      ) : (
+        <ul className="ovw-protocol-list">
+          {stats.recent.map((p) => (
+            <li key={p.id}>
+              <span className="ovw-square-glyph" aria-hidden="true" />
+              <div>
+                <strong>{p.title}</strong>
+                <span>{p.description?.slice(0, 48) || (p.lifecycleStatus ?? "Draft")}</span>
+              </div>
+              <span className={`ovw-tag ovw-tag--${lifecycleTone(p.lifecycleStatus)}`}>
+                {(p.lifecycleStatus ?? "draft").toUpperCase()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+const InventoryCard = ({ stats }: { stats: InventoryStats }) => (
+  <section className="ovw-card ovw-inventory">
+    <header>
+      <h3>INVENTORY STATUS</h3>
+      <span className="ovw-card-link">View inventory</span>
+    </header>
+    <div className="ovw-radar-wrap">
+      <svg viewBox="0 0 150 150" className="ovw-radar" aria-hidden="true">
+        <g transform="translate(75 75)" fill="none" stroke="var(--ilm-line)">
+          <polygon points="0,-65 56,-32 56,32 0,65 -56,32 -56,-32" />
+          <polygon points="0,-50 43,-25 43,25 0,50 -43,25 -43,-25" />
+          <polygon points="0,-35 30,-17 30,17 0,35 -30,17 -30,-17" />
+          <line x1="0" y1="-70" x2="0" y2="70" />
+          <line x1="-61" y1="-35" x2="61" y2="35" />
+          <line x1="-61" y1="35" x2="61" y2="-35" />
+          <polygon
+            points="0,-51 40,-15 33,29 0,44 -45,22 -34,-28"
+            fill="rgba(78,159,146,0.30)"
+            stroke="var(--ilm-viridian-2)"
+          />
+          <polygon
+            points="0,-35 28,-10 23,20 0,30 -31,15 -23,-19"
+            fill="rgba(47,125,114,0.45)"
+            stroke="var(--ilm-viridian)"
+          />
+        </g>
+      </svg>
+      <ul className="ovw-inv-stats">
+        <li>
+          <i style={{ background: "var(--ilm-viridian)" }} />
+          <strong>{stats.reagents}</strong>
+          <span>Reagents · in stock</span>
+        </li>
+        <li>
+          <i style={{ background: "var(--ilm-viridian-2)" }} />
+          <strong>{stats.consumables}</strong>
+          <span>Consumables</span>
+        </li>
+        <li>
+          <i style={{ background: "var(--ilm-blue)" }} />
+          <strong>{stats.supplies + stats.samples + stats.other}</strong>
+          <span>Other supplies</span>
+        </li>
+        <li>
+          <i style={{ background: "var(--ilm-amber)" }} />
+          <strong>{stats.criticalLow}</strong>
+          <span>Critical low · reorder</span>
+        </li>
+      </ul>
+    </div>
+  </section>
+);
+
+const FundingCard = () => (
+  <section className="ovw-card ovw-funding">
+    <header>
+      <h3>FUNDING OVERVIEW</h3>
+      <span className="ovw-card-link">View funding</span>
+    </header>
+    <p className="ovw-fund-amount">$0.00</p>
+    <p className="ovw-fund-sub">FUNDING MANAGER ARRIVING IN STAGE 4D</p>
+    <ul className="ovw-fund-rows">
+      <li>
+        <span className="ovw-square-glyph">$</span>
+        <div>
+          <strong>$0</strong>
+          <span>Active grants</span>
+        </div>
+      </li>
+      <li>
+        <span className="ovw-square-glyph">~</span>
+        <div>
+          <strong>$0</strong>
+          <span>Pending</span>
+        </div>
+      </li>
+      <li>
+        <span className="ovw-square-glyph">!</span>
+        <div>
+          <strong>$0</strong>
+          <span>Expiring (90 days)</span>
+        </div>
+      </li>
+    </ul>
+    <div className="ovw-bars" aria-hidden="true">
+      {[35, 50, 72, 28, 60, 98].map((h, i) => (
+        <i key={i} style={{ height: `${h}px` }} />
+      ))}
+    </div>
+  </section>
+);
+
+const ActivityCard = ({ entries }: { entries: { id: string; label: string; context: string }[] }) => (
+  <section className="ovw-card ovw-activity">
+    <header>
+      <h3>ACTIVITY FEED</h3>
+      <span className="ovw-card-pill">All activity</span>
+    </header>
+    {entries.length === 0 ? (
+      <p className="ovw-empty">No recent activity.</p>
+    ) : (
+      <ul className="ovw-activity-list">
+        {entries.map((e) => (
+          <li key={e.id}>
+            <span className="ovw-activity-dot" aria-hidden="true" />
+            <div>
+              <strong>{e.label}</strong>
+              <span>{e.context}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+);
+
+const ResourceCard = ({
+  projects,
+  protocols,
+  inventory,
+  team,
+}: {
+  projects: ProjectStateCounts;
+  protocols: ProtocolStats;
+  inventory: InventoryStats;
+  team: TeamStats;
+}) => {
+  const cells = [
+    {
+      label: "ACTIVE PROJECT MIX",
+      value: `${projects.total ? Math.round((projects.published / Math.max(1, projects.total)) * 100) : 0}%`,
+      tone: "ovw-spark--green",
+    },
+    {
+      label: "PROTOCOL ACTIVATION",
+      value: `${protocols.total ? Math.round((protocols.active / Math.max(1, protocols.total)) * 100) : 0}%`,
+      tone: "ovw-spark--green",
+    },
+    {
+      label: "STOCK COVERAGE",
+      value:
+        inventory.total > 0
+          ? `${Math.round(((inventory.total - inventory.criticalLow) / inventory.total) * 100)}%`
+          : "—",
+      tone: inventory.criticalLow > 0 ? "ovw-spark--orange" : "ovw-spark--green",
+    },
+    {
+      label: "TEAM PARTICIPATION",
+      value: team.total > 0 ? `${team.total}` : "—",
+      tone: "ovw-spark--neutral",
+    },
+  ];
+  return (
+    <section className="ovw-card ovw-resource">
+      <header>
+        <h3>RESOURCE UTILIZATION</h3>
+        <span className="ovw-card-pill">This week</span>
+      </header>
+      <ul className="ovw-resource-grid">
+        {cells.map((c) => (
+          <li key={c.label}>
+            <span className="ovw-resource-label">{c.label}</span>
+            <strong>{c.value}</strong>
+            <span className={`ovw-spark ${c.tone}`} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+const TeamCard = ({ team }: { team: TeamStats }) => (
+  <section className="ovw-card ovw-team">
+    <header>
+      <h3>TEAM OVERVIEW</h3>
+      <span className="ovw-card-link">View team</span>
+    </header>
+    <div className="ovw-avatars">
+      {team.recentAvatars.map((m) => (
+        <span className="ovw-avatar" key={m.id} title={m.email ?? ""}>
+          {m.label}
+        </span>
+      ))}
+      {team.total > team.recentAvatars.length ? (
+        <span className="ovw-avatar ovw-avatar--more">+{team.total - team.recentAvatars.length}</span>
+      ) : null}
+    </div>
+    <ul className="ovw-team-stats">
+      <li>
+        <strong>{team.total}</strong>
+        <span>Active members</span>
+      </li>
+      <li>
+        <strong>{team.owners}</strong>
+        <span>Owner{team.owners === 1 ? "" : "s"}</span>
+      </li>
+      <li>
+        <strong className="ovw-team-stats-accent">{team.admins}</strong>
+        <span>Admin{team.admins === 1 ? "" : "s"}</span>
+      </li>
+      <li>
+        <strong>{team.members}</strong>
+        <span>Member{team.members === 1 ? "" : "s"}</span>
+      </li>
+    </ul>
+  </section>
+);
+
+export const OverviewView = () => {
+  const { activeLab } = useAuth();
+  const data = useDashboardData(activeLab?.id ?? null);
+
+  return (
+    <div className="ovw-grid">
+      {data.error ? <p className="ovw-error">{data.error}</p> : null}
+      <StatusBlock projects={data.projects} protocols={data.protocols} team={data.team} inventory={data.inventory} />
+      <ScheduleCard />
+      <ProjectsCard counts={data.projects} />
+      <ProtocolsCard stats={data.protocols} />
+      <InventoryCard stats={data.inventory} />
+      <FundingCard />
+      <ActivityCard entries={data.activity} />
+      <ResourceCard projects={data.projects} protocols={data.protocols} inventory={data.inventory} team={data.team} />
+      <TeamCard team={data.team} />
+    </div>
+  );
+};

--- a/apps/account/src/views/PlaceholderView.tsx
+++ b/apps/account/src/views/PlaceholderView.tsx
@@ -1,0 +1,13 @@
+export const PlaceholderView = ({
+  title,
+  blurb,
+}: {
+  title: string;
+  blurb: string;
+}) => (
+  <div className="acct-placeholder">
+    <span className="acct-placeholder-tag">FUTURE STAGE</span>
+    <h2>{title}</h2>
+    <p>{blurb}</p>
+  </div>
+);

--- a/apps/account/src/views/SettingsView.tsx
+++ b/apps/account/src/views/SettingsView.tsx
@@ -1,0 +1,77 @@
+import { useAuth } from "@ilm/ui";
+
+type MembershipTier = "owner" | "admin" | "member";
+
+const TIER_LABEL: Record<MembershipTier, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+};
+
+const TIER_DESCRIPTION: Record<MembershipTier, string> = {
+  owner: "Full control: promote or demote admins, remove any non-owner, and manage the lab.",
+  admin: "Can promote members to admin and remove members. Cannot touch other admins.",
+  member: "Read-only in the lab management surface.",
+};
+
+export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
+  const { activeLab, profile, user, signOut } = useAuth();
+  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
+  const displayName = profile?.display_name ?? user?.email ?? "Signed in";
+  const email = profile?.email ?? user?.email ?? "";
+
+  return (
+    <div className="acct-settings-page">
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Profile</h2>
+            <p>Your personal account info as visible to lab co-workers.</p>
+          </div>
+        </div>
+        <div className="acct-side-profile">
+          <strong>{displayName}</strong>
+          <span>{email}</span>
+        </div>
+        <div className="acct-row-actions">
+          <button type="button" className="acct-danger-button" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Active lab</h2>
+            <p>Switch labs or join another workspace from the picker.</p>
+          </div>
+          {activeLab ? <span className={`acct-badge ${tier}`}>{TIER_LABEL[tier]}</span> : null}
+        </div>
+        {activeLab ? (
+          <>
+            <h3 style={{ margin: 0 }}>{activeLab.name}</h3>
+            <small style={{ color: "var(--rl-muted)" }}>{TIER_DESCRIPTION[tier]}</small>
+          </>
+        ) : (
+          <p className="acct-empty">No lab selected.</p>
+        )}
+        <div className="acct-row-actions">
+          <button type="button" className="acct-text-button" onClick={onOpenLabPicker}>
+            Join or create another lab…
+          </button>
+        </div>
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Lab settings</h2>
+            <p>Lab name, slug, and ownership transfer arrive in a future stage.</p>
+          </div>
+        </div>
+        <p className="acct-empty">Nothing configurable here yet.</p>
+      </section>
+    </div>
+  );
+};

--- a/apps/account/src/views/TeamView.tsx
+++ b/apps/account/src/views/TeamView.tsx
@@ -1,0 +1,529 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  approveLabJoin,
+  buildLabShareUrl,
+  cancelLabJoin,
+  demoteAdminToMember,
+  inviteMemberToLab,
+  listLabInvitations,
+  listLabJoinRequests,
+  listLabMembers,
+  promoteMemberToAdmin,
+  rejectLabJoin,
+  removeLabMember,
+  useAuth,
+  type LabInvitationRecord,
+  type LabJoinRequestRecord,
+  type LabMemberRecord,
+} from "@ilm/ui";
+
+const APP_BASE_URL = import.meta.env.BASE_URL || "/";
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : "Unexpected error");
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(new Date(value));
+
+type MembershipTier = "owner" | "admin" | "member";
+
+const TIER_LABEL: Record<MembershipTier, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+};
+
+const MembersPanel = () => {
+  const { activeLab, user, refreshLabs } = useAuth();
+  const labId = activeLab?.id ?? null;
+  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
+  const isOwner = tier === "owner";
+  const isAdmin = tier === "admin";
+  const canManageMembers = isOwner || isAdmin;
+  const canManageAdmins = isOwner;
+  const [members, setMembers] = useState<LabMemberRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!labId) {
+      setMembers([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setMembers(await listLabMembers(labId));
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refreshAfterAction = useCallback(async () => {
+    await Promise.all([load(), refreshLabs()]);
+  }, [load, refreshLabs]);
+
+  const doPromote = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await promoteMemberToAdmin(labId, member.user_id);
+      await refreshAfterAction();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const doDemote = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await demoteAdminToMember(labId, member.user_id);
+      await refreshAfterAction();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const doRemove = async (member: LabMemberRecord) => {
+    if (!labId) return;
+    const label = member.display_name || member.email || "this member";
+    if (!window.confirm(`Remove ${label} from ${activeLab?.name ?? "the lab"}?`)) return;
+    setBusyUserId(member.user_id);
+    setError(null);
+    try {
+      await removeLabMember(labId, member.user_id);
+      await refreshAfterAction();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  if (!activeLab) {
+    return <p className="acct-empty">Pick a lab to see its members.</p>;
+  }
+
+  return (
+    <section className="acct-card">
+      <div className="acct-card-header">
+        <div>
+          <h2>Lab members</h2>
+          <p>
+            {canManageMembers
+              ? "Owner > admin > member. Admins and the owner can promote members and remove members. Only the owner can demote or remove an admin."
+              : "Only admins and the owner can edit membership."}
+          </p>
+        </div>
+        <span className="acct-card-pill">{members.length} total</span>
+      </div>
+
+      {error ? <p className="acct-error">{error}</p> : null}
+      {loading ? <p className="acct-empty">Loading roster…</p> : null}
+
+      {!loading && members.length > 0 ? (
+        <ul className="acct-member-list">
+          {members.map((member) => {
+            const label = member.display_name || member.email || member.user_id;
+            const isSelf = member.user_id === user?.id;
+            const busy = busyUserId === member.user_id;
+            const targetTier = member.role as MembershipTier;
+            const canPromote = canManageMembers && targetTier === "member" && !isSelf;
+            const canDemote = canManageAdmins && targetTier === "admin";
+            const canRemove =
+              !isSelf &&
+              targetTier !== "owner" &&
+              (targetTier === "admin" ? canManageAdmins : canManageMembers);
+
+            return (
+              <li className="acct-member" key={member.user_id}>
+                <div className="acct-member-copy">
+                  <strong>
+                    {label}
+                    {isSelf ? " (you)" : ""}
+                  </strong>
+                  <span>{member.email || "No email available"}</span>
+                  <small>Joined {formatDate(member.joined_at)}</small>
+                </div>
+                <div className="acct-member-actions">
+                  <span className={`acct-badge ${targetTier}`}>{TIER_LABEL[targetTier]}</span>
+                  {canPromote ? (
+                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doPromote(member)}>
+                      Promote to admin
+                    </button>
+                  ) : null}
+                  {canDemote ? (
+                    <button type="button" className="acct-text-button" disabled={busy} onClick={() => void doDemote(member)}>
+                      Demote to member
+                    </button>
+                  ) : null}
+                  {canRemove ? (
+                    <button type="button" className="acct-danger-button" disabled={busy} onClick={() => void doRemove(member)}>
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {!loading && members.length === 0 ? <p className="acct-empty">No members yet.</p> : null}
+    </section>
+  );
+};
+
+const InvitationsPanel = () => {
+  const { activeLab } = useAuth();
+  const labId = activeLab?.id ?? null;
+  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
+  const canManageMembers = tier === "owner" || tier === "admin";
+
+  const [invitations, setInvitations] = useState<LabInvitationRecord[]>([]);
+  const [requests, setRequests] = useState<LabJoinRequestRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
+  const [submittingInvite, setSubmittingInvite] = useState(false);
+
+  const [busyRequestId, setBusyRequestId] = useState<string | null>(null);
+  const [rejectOpen, setRejectOpen] = useState<string | null>(null);
+  const [rejectComment, setRejectComment] = useState("");
+
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!labId || !canManageMembers) {
+      setInvitations([]);
+      setRequests([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextInvitations, nextRequests] = await Promise.all([
+        listLabInvitations(labId),
+        listLabJoinRequests(labId, "pending"),
+      ]);
+      setInvitations(nextInvitations);
+      setRequests(nextRequests);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [labId, canManageMembers]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pendingInvitations = useMemo(
+    () => invitations.filter((invitation) => invitation.status === "pending"),
+    [invitations]
+  );
+
+  const shareUrl = useMemo(() => (activeLab ? buildLabShareUrl(activeLab.id, APP_BASE_URL) : ""), [activeLab]);
+
+  const handleInvite = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!labId || !inviteEmail.trim()) return;
+    setSubmittingInvite(true);
+    setError(null);
+    try {
+      await inviteMemberToLab(labId, inviteEmail.trim(), inviteRole);
+      setInviteEmail("");
+      setInviteRole("member");
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmittingInvite(false);
+    }
+  };
+
+  const handleApprove = async (request: LabJoinRequestRecord) => {
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await approveLabJoin(request.id);
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  const handleReject = async (request: LabJoinRequestRecord) => {
+    const comment = rejectComment.trim();
+    if (!comment) {
+      setError("A comment is required to reject a request.");
+      return;
+    }
+    setBusyRequestId(request.id);
+    setError(null);
+    try {
+      await rejectLabJoin(request.id, comment);
+      setRejectOpen(null);
+      setRejectComment("");
+      await load();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusyRequestId(null);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl || typeof navigator === "undefined" || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  if (!activeLab) {
+    return <p className="acct-empty">Pick a lab first.</p>;
+  }
+  if (!canManageMembers) {
+    return <p className="acct-empty">Only admins and the owner can send invitations or review join requests.</p>;
+  }
+
+  return (
+    <>
+      {error ? <p className="acct-error">{error}</p> : null}
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Invite by email</h2>
+            <p>Invited users are added automatically when they sign in with this email.</p>
+          </div>
+        </div>
+        <form className="acct-form" onSubmit={handleInvite}>
+          <div className="acct-field-row">
+            <label className="acct-field">
+              <span>Email</span>
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => setInviteEmail(event.target.value)}
+                placeholder="scientist@lab.org"
+                required
+              />
+            </label>
+            <label className="acct-field">
+              <span>Role</span>
+              <select value={inviteRole} onChange={(event) => setInviteRole(event.target.value as "admin" | "member")}>
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+          </div>
+          <div>
+            <button type="submit" className="acct-primary-button" disabled={submittingInvite}>
+              {submittingInvite ? "Saving…" : "Save invitation"}
+            </button>
+          </div>
+        </form>
+
+        {pendingInvitations.length > 0 ? (
+          <div className="acct-invitations">
+            <div style={{ fontSize: "0.72rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--rl-muted)" }}>
+              {pendingInvitations.length} pending
+            </div>
+            {pendingInvitations.map((invitation) => (
+              <div className="acct-invitation" key={invitation.id}>
+                <div>
+                  <strong>{invitation.email}</strong>
+                  <div>
+                    <small>Saved {formatDate(invitation.created_at)}</small>
+                  </div>
+                </div>
+                <span className="acct-badge">{invitation.role}</span>
+                <span className="acct-badge">{invitation.status}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Share link</h2>
+            <p>Anyone who opens this link can sign in and request to join {activeLab.name}.</p>
+          </div>
+        </div>
+        <div className="acct-share-row">
+          <input type="text" readOnly value={shareUrl} onFocus={(event) => event.currentTarget.select()} />
+          <button type="button" className="acct-text-button" onClick={() => void handleCopy()}>
+            {copied ? "Copied!" : "Copy link"}
+          </button>
+        </div>
+      </section>
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Join requests</h2>
+            <p>Approve or reject people who asked to join via the share link.</p>
+          </div>
+          <span className="acct-card-pill">{requests.length} pending</span>
+        </div>
+        {loading ? <p className="acct-empty">Loading…</p> : null}
+        {!loading && requests.length === 0 ? <p className="acct-empty">No pending join requests.</p> : null}
+        {requests.length > 0 ? (
+          <div>
+            {requests.map((request) => {
+              const busy = busyRequestId === request.id;
+              const label = request.display_name || request.email || request.user_id;
+              const rejecting = rejectOpen === request.id;
+              return (
+                <div className="acct-request-item" key={request.id}>
+                  <div>
+                    <strong>{label}</strong>
+                    <div>
+                      <small>
+                        {request.email || "No email available"} · requested {formatDate(request.created_at)}
+                      </small>
+                    </div>
+                    {request.message ? <p className="acct-request-message">"{request.message}"</p> : null}
+                  </div>
+                  {rejecting ? (
+                    <div className="acct-reject-form">
+                      <textarea
+                        value={rejectComment}
+                        onChange={(event) => setRejectComment(event.target.value)}
+                        placeholder="Reason (required)"
+                        rows={2}
+                      />
+                      <div className="acct-row-actions">
+                        <button
+                          type="button"
+                          className="acct-danger-button"
+                          disabled={busy}
+                          onClick={() => void handleReject(request)}
+                        >
+                          Confirm reject
+                        </button>
+                        <button
+                          type="button"
+                          className="acct-text-button"
+                          disabled={busy}
+                          onClick={() => {
+                            setRejectOpen(null);
+                            setRejectComment("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="acct-row-actions">
+                      <button
+                        type="button"
+                        className="acct-primary-button"
+                        disabled={busy}
+                        onClick={() => void handleApprove(request)}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        className="acct-text-button"
+                        disabled={busy}
+                        onClick={() => {
+                          setRejectOpen(request.id);
+                          setRejectComment("");
+                        }}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </section>
+    </>
+  );
+};
+
+export const TeamView = () => {
+  const { activeLab } = useAuth();
+  const [tab, setTab] = useState<"members" | "invitations">("members");
+  const labId = activeLab?.id ?? null;
+  const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
+  const canManageMembers = tier === "owner" || tier === "admin";
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    if (!labId || !canManageMembers) {
+      setPendingCount(0);
+      return;
+    }
+    let cancelled = false;
+    listLabJoinRequests(labId, "pending")
+      .then((rows) => {
+        if (!cancelled) setPendingCount(rows.length);
+      })
+      .catch(() => {
+        if (!cancelled) setPendingCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [labId, canManageMembers, tab]);
+
+  return (
+    <div className="acct-team-page">
+      <div className="acct-tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          className={`acct-tab${tab === "members" ? " is-active" : ""}`}
+          aria-selected={tab === "members"}
+          onClick={() => setTab("members")}
+        >
+          Members
+        </button>
+        <button
+          type="button"
+          role="tab"
+          className={`acct-tab${tab === "invitations" ? " is-active" : ""}`}
+          aria-selected={tab === "invitations"}
+          onClick={() => setTab("invitations")}
+        >
+          Invitations &amp; Requests
+          {pendingCount > 0 ? <span className="acct-tab-badge">{pendingCount}</span> : null}
+        </button>
+      </div>
+
+      {tab === "members" ? <MembersPanel /> : <InvitationsPanel />}
+    </div>
+  );
+};

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,12 +34,15 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 ## Account app (Stage 4a — production)
 
 - Dedicated app at `/account/`, reachable by clicking the login status box in any other app.
-- **Flat two-panel layout**: left sidebar with profile, active lab tier (owner / admin / member) + capability blurb, project counts, and a "Join or create another lab…" shortcut that reopens `LabPicker` without clearing the current active lab. Right main area with tabbed Lab Management (Members / Invitations & Requests).
+- **Home dashboard layout**: persistent sidebar with the full ILM nav (Overview, Projects, Protocols, Inventory, Funding, Calendar, Team, Analytics, Reports, Settings) plus a system-status card and profile/orb at the bottom. External nav items deep-link to sibling apps via `appUrl(...)`; internal items use hash routing (`#/team`, `#/settings`, `#/calendar`, `#/analytics`, `#/reports`) so the static deploy keeps a single `/account/` entry point. Calendar / Analytics / Reports render `PlaceholderView` "future stage" cards.
+- **Overview dashboard** (#/) is a status monitor patterned on `design/web.png`: a hero `LAB OPERATING STATUS` block (status word + active-projects / protocols / team-members / compliance% metrics + flow-line SVG), Upcoming Schedule placeholder, Projects donut by state, recent Protocols list, Inventory radar with classification counts + critical-low pulled from the latest `inventory_checks`, Funding placeholder (Stage 4d shell), Activity Feed unioning recent `protocols` / `projects` / `items` updates, Resource Utilization sparklines, and a Team Overview card with avatars + role breakdown. Card data is fetched in parallel by `useDashboardData(labId)` and gracefully reports an inline error.
+- **Team page** (#/team) hosts the Members + Invitations & Requests tabs (previously the Account dashboard).
+- **Settings page** (#/settings) covers the profile, active-lab tier blurb, lab-picker shortcut, and a placeholder for future lab settings.
 - **Strict tier hierarchy** (owner > admin > member; one tier per user per lab, enforced by PK on `lab_memberships`):
   - Admins + owner can promote members to admin and remove members.
   - Only the owner can demote admins to member or remove admins.
   - Owner is immutable via RPCs (`promote_member_to_admin`, `demote_admin_to_member`, `remove_lab_member`).
-- **Invitations & requests** in one tab: invite-by-email with role choice, pending-invitation list, copyable `/account/join/<uuid>` share link, and join-request queue with approve / reject-with-required-comment.
+- **Invitations & requests** under the Team tab: invite-by-email with role choice, pending-invitation list, copyable `/account/join/<uuid>` share link, and join-request queue with approve / reject-with-required-comment.
 - **Auto-claim on sign-in**: `claim_pending_invitations` RPC converts matching-email pending invitations to memberships when the user signs in.
 - **Join-by-link route** at `/account/join/<lab-uuid>`: signed-out users hit the auth shell; existing members get "Open this lab"; non-members see a lab-name preview + "Request to join" form with optional message + self-cancel.
 - **GitHub Pages SPA fallback** routed to the Account shell so deep links like `/account/join/<uuid>` resolve.


### PR DESCRIPTION
## Summary

Reshape the Account app from a flat Members/Invitations layout into the lab-wide status monitor patterned on `design/web.png` and `design/web-review.html`.

- **Sidebar nav** with the full ILM map: Overview, Projects, Protocols, Inventory, Funding, Calendar, Team, Analytics, Reports, Settings. External items deep-link to sibling apps via `appUrl(...)`. Internal items use hash routing (`#/team`, `#/settings`, …) so the static deploy keeps a single `/account/` entry point. Plus a SYSTEM STATUS card and profile orb (opens lab picker) at the bottom.
- **Overview dashboard** with nine cards driven by one parallel query batch in `useDashboardData(labId)`:
  - Hero `LAB OPERATING STATUS` — status word switches OPTIMAL / STEADY / ATTENTION based on critical-low items + protocols in review; metrics for active projects, protocols, team members, compliance %; flow-line SVG with three node labels.
  - Upcoming Schedule placeholder (calendar future shell).
  - Projects donut by state (published / draft / recycle).
  - Protocols list (latest 4) with active / review / archived tone tags.
  - Inventory radar with classification counts; critical-low count is derived from the latest `inventory_checks` per item.
  - Funding placeholder for Stage 4d.
  - Activity Feed unioning recent `protocols` / `projects` / `items` updates with relative timestamps.
  - Resource Utilization sparklines (project mix %, protocol activation %, stock coverage %, team participation).
  - Team Overview avatars + role breakdown (owners / admins / members).
- **Routing split**: Members + Invitations & Requests move to `#/team`; profile / lab tier / lab-picker shortcut move to `#/settings`. Calendar / Analytics / Reports render `PlaceholderView` future-stage cards. Existing `/account/join/<uuid>` flow is untouched.

## Why

The old Account dashboard was member-management only; the home app needs to act as the lab's overall status monitor and primary navigation surface for the rest of ILM, per the reference design.

## File map

- New: `apps/account/src/lib/dashboardData.ts` (parallel data hook)
- New: `apps/account/src/views/{OverviewView,TeamView,SettingsView,PlaceholderView}.tsx`
- Refactored: `apps/account/src/App.tsx` (sidebar shell + hash routing)
- Refactored: `apps/account/src/styles.css` (new `ovw-*` shell + dashboard CSS; existing `acct-*` rules retained for Team / Settings)
- Updated: `docs/features.md`

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] `npm run build` passes for the whole monorepo (verified locally)
- [ ] Deploy to GitHub Pages and Ctrl+Shift+R; sign in and confirm the Overview dashboard renders with live counts pulled from the active lab
- [ ] Sidebar links: Projects / Protocols / Inventory / Funding open the corresponding apps; Calendar / Analytics / Reports show the placeholder
- [ ] `#/team` shows the Members + Invitations & Requests tabs and pending-request badge updates
- [ ] `#/settings` shows profile + lab tier + opens `LabPicker`; sign-out works
- [ ] `/account/join/<uuid>` deep-link still resolves (RLS / share-link flow unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)