### PR TITLE
Stage 4e foundation: Scheduler schema + app scaffold

### DIFF
--- a/.github/workflows/deploy-protocol-manager-pages.yml
+++ b/.github/workflows/deploy-protocol-manager-pages.yml
@@ -66,15 +66,23 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
+      - name: Build Scheduler for Pages
+        run: npm run build -w @ilm/scheduler
+        env:
+          VITE_BASE_PATH: /ILM/scheduler/
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
       - name: Assemble Pages artifact
         run: |
           rm -rf .pages-dist
-          mkdir -p .pages-dist/protocol-manager .pages-dist/project-manager .pages-dist/supply-manager .pages-dist/funding-manager
+          mkdir -p .pages-dist/protocol-manager .pages-dist/project-manager .pages-dist/supply-manager .pages-dist/funding-manager .pages-dist/scheduler
           cp -R apps/account/dist/. .pages-dist/
           cp -R apps/protocol-manager/dist/. .pages-dist/protocol-manager/
           cp -R apps/project-manager/dist/. .pages-dist/project-manager/
           cp -R apps/supply-manager/dist/. .pages-dist/supply-manager/
           cp -R apps/funding-manager/dist/. .pages-dist/funding-manager/
+          cp -R apps/scheduler/dist/. .pages-dist/scheduler/
           # SPA fallback: GitHub Pages serves /<site>/404.html for any missing
           # path under the site. The Account shell now lives at the site root
           # and owns client-side routes (`/join/<uuid>`, `#/team`, ...), so

--- a/apps/scheduler/index.html
+++ b/apps/scheduler/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scheduler</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/scheduler/package.json
+++ b/apps/scheduler/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ilm/scheduler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --pretty false",
+    "lint": "echo 'no lint configured for @ilm/scheduler'"
+  },
+  "dependencies": {
+    "@ilm/ui": "file:../../packages/ui",
+    "@ilm/utils": "file:../../packages/utils",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11"
+  }
+}

--- a/apps/scheduler/src/App.tsx
+++ b/apps/scheduler/src/App.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import {
+  CardGrid,
+  LabShell,
+  LabTopbar,
+  Panel,
+  SectionHeader,
+  useAuth,
+} from "@ilm/ui";
+
+const APP_BASE_URL = import.meta.env.BASE_URL;
+
+type SchedulerTab = "calendar" | "bookings" | "unscheduled" | "resources";
+
+const TAB_LABELS: Record<SchedulerTab, string> = {
+  calendar: "Calendar",
+  bookings: "Bookings",
+  unscheduled: "Unscheduled",
+  resources: "Resources",
+};
+
+export const App = () => {
+  const { activeLab, profile } = useAuth();
+  const [tab, setTab] = useState<SchedulerTab>("calendar");
+
+  return (
+    <LabShell
+      activeNavId="calendar"
+      baseUrl={APP_BASE_URL}
+      topbar={
+        <LabTopbar
+          kicker="SCHEDULER"
+          title="Scheduler"
+          subtitle="Plan lab work, meetings, and equipment usage."
+        />
+      }
+      subbar={
+        <nav className="sch-subbar" aria-label="Scheduler sections">
+          {(Object.keys(TAB_LABELS) as SchedulerTab[]).map((id) => (
+            <button
+              key={id}
+              type="button"
+              className={tab === id ? "sch-subtab is-active" : "sch-subtab"}
+              onClick={() => setTab(id)}
+              aria-current={tab === id ? "page" : undefined}
+            >
+              {TAB_LABELS[id]}
+            </button>
+          ))}
+          <span className="sch-subbar-spacer" aria-hidden="true" />
+        </nav>
+      }
+    >
+      <CardGrid>
+        <Panel>
+          <SectionHeader title="Lab context" meta={activeLab?.role ?? "member"} />
+          <div className="sch-stat-grid">
+            <div>
+              <span>Active lab</span>
+              <strong>{activeLab?.name ?? "No lab selected"}</strong>
+              <small>{activeLab?.slug ?? "Slug pending"}</small>
+            </div>
+            <div>
+              <span>User</span>
+              <strong>{profile?.display_name || profile?.email || "Signed-in user"}</strong>
+              <small>Shared auth shell is active</small>
+            </div>
+            <div>
+              <span>Active tab</span>
+              <strong>{TAB_LABELS[tab]}</strong>
+              <small>Foundation scaffold — view UI lands next</small>
+            </div>
+          </div>
+        </Panel>
+
+        <Panel>
+          <SectionHeader title="Coming up" meta="Stage 4e" />
+          <ul className="sch-list">
+            <li>Weekly calendar with event create / edit / delete and basic recurrence</li>
+            <li>Equipment booking form with server-side conflict detection</li>
+            <li>Unscheduled task queue that converts into events and bookings</li>
+            <li>Resource registry with status, buffers, and policy controls</li>
+          </ul>
+        </Panel>
+
+        <Panel>
+          <SectionHeader title="Schema status" meta="Migrated" />
+          <ul className="sch-list">
+            <li><code>resources</code>, <code>calendar_events</code>, <code>bookings</code>, <code>planned_tasks</code> with RLS</li>
+            <li>
+              <code>book_resource</code>, <code>cancel_booking</code>, <code>complete_booking</code>,
+              <code>approve_booking</code>, <code>deny_booking</code>, <code>schedule_planned_task</code> RPCs
+            </li>
+            <li><code>find_booking_conflicts</code> helper applies setup / cleanup buffers</li>
+          </ul>
+        </Panel>
+      </CardGrid>
+    </LabShell>
+  );
+};

--- a/apps/scheduler/src/lib/cloudAdapter.ts
+++ b/apps/scheduler/src/lib/cloudAdapter.ts
@@ -1,0 +1,560 @@
+import { getSupabaseClient } from "@ilm/utils";
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type ResourceCategory =
+  | "sequencer"
+  | "microscope"
+  | "thermocycler"
+  | "centrifuge"
+  | "incubator"
+  | "qpcr"
+  | "imaging"
+  | "general"
+  | "other";
+
+export type ResourceAvailabilityStatus =
+  | "available"
+  | "offline"
+  | "maintenance"
+  | "restricted";
+
+export type BookingMode = "hard_booking" | "soft_booking";
+
+export type BookingPolicy = "open" | "approval_required" | "admin_only";
+
+export type EventType =
+  | "meeting"
+  | "experiment"
+  | "reminder"
+  | "deadline"
+  | "maintenance"
+  | "general";
+
+export type EventVisibility = "private" | "project" | "lab" | "equipment_visible";
+
+export type EventStatus = "scheduled" | "cancelled" | "completed";
+
+export type BookingType =
+  | "experiment"
+  | "daily_use"
+  | "maintenance"
+  | "calibration"
+  | "training";
+
+export type BookingStatus =
+  | "draft"
+  | "requested"
+  | "approved"
+  | "denied"
+  | "active"
+  | "completed"
+  | "cancelled"
+  | "no_show";
+
+export type PlannedTaskPriority = "low" | "normal" | "high" | "urgent";
+
+export type PlannedTaskStatus =
+  | "planned"
+  | "ready_to_schedule"
+  | "scheduled"
+  | "completed"
+  | "cancelled";
+
+export interface ResourceRecord {
+  id: string;
+  lab_id: string;
+  name: string;
+  description: string | null;
+  category: ResourceCategory;
+  location: string | null;
+  availability_status: ResourceAvailabilityStatus;
+  booking_mode: BookingMode;
+  booking_policy: BookingPolicy;
+  minimum_booking_duration_minutes: number | null;
+  maximum_booking_duration_minutes: number | null;
+  setup_buffer_minutes: number;
+  cleanup_buffer_minutes: number;
+  required_training: boolean;
+  responsible_person_id: string | null;
+  linked_protocol_id: string | null;
+  notes: string | null;
+  is_active: boolean;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CalendarEventRecord {
+  id: string;
+  lab_id: string;
+  title: string;
+  description: string | null;
+  event_type: EventType;
+  start_time: string;
+  end_time: string;
+  location: string | null;
+  linked_project_id: string | null;
+  linked_protocol_id: string | null;
+  linked_task_id: string | null;
+  organizer_user_id: string | null;
+  participant_user_ids: string[];
+  visibility: EventVisibility;
+  recurrence_rule: string | null;
+  recurrence_exceptions: string[];
+  status: EventStatus;
+  notes: string | null;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BookingRecord {
+  id: string;
+  resource_id: string;
+  lab_id: string;
+  calendar_event_id: string | null;
+  user_id: string | null;
+  project_id: string | null;
+  protocol_id: string | null;
+  planned_task_id: string | null;
+  title: string | null;
+  start_time: string;
+  end_time: string;
+  setup_buffer_minutes: number;
+  cleanup_buffer_minutes: number;
+  booking_type: BookingType;
+  status: BookingStatus;
+  approval_user_id: string | null;
+  purpose: string | null;
+  sample_count: number | null;
+  notes: string | null;
+  actual_start_time: string | null;
+  actual_end_time: string | null;
+  usage_record: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PlannedTaskRecord {
+  id: string;
+  lab_id: string;
+  title: string;
+  description: string | null;
+  project_id: string | null;
+  protocol_id: string | null;
+  experiment_id: string | null;
+  assigned_user_id: string | null;
+  estimated_duration_minutes: number | null;
+  required_resource_ids: string[];
+  preferred_start_date: string | null;
+  preferred_end_date: string | null;
+  priority: PlannedTaskPriority;
+  status: PlannedTaskStatus;
+  generated_from_protocol_step_id: string | null;
+  scheduled_event_id: string | null;
+  scheduled_booking_id: string | null;
+  notes: string | null;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+export interface ProtocolOption {
+  id: string;
+  name: string;
+}
+
+export interface SchedulerWorkspaceSnapshot {
+  resources: ResourceRecord[];
+  events: CalendarEventRecord[];
+  bookings: BookingRecord[];
+  plannedTasks: PlannedTaskRecord[];
+  projects: ProjectOption[];
+  protocols: ProtocolOption[];
+}
+
+const client = () => getSupabaseClient();
+
+const RESOURCE_FIELDS =
+  "id, lab_id, name, description, category, location, availability_status, booking_mode, booking_policy, minimum_booking_duration_minutes, maximum_booking_duration_minutes, setup_buffer_minutes, cleanup_buffer_minutes, required_training, responsible_person_id, linked_protocol_id, notes, is_active, created_by, updated_by, created_at, updated_at";
+
+const EVENT_FIELDS =
+  "id, lab_id, title, description, event_type, start_time, end_time, location, linked_project_id, linked_protocol_id, linked_task_id, organizer_user_id, participant_user_ids, visibility, recurrence_rule, recurrence_exceptions, status, notes, created_by, updated_by, created_at, updated_at";
+
+const BOOKING_FIELDS =
+  "id, resource_id, lab_id, calendar_event_id, user_id, project_id, protocol_id, planned_task_id, title, start_time, end_time, setup_buffer_minutes, cleanup_buffer_minutes, booking_type, status, approval_user_id, purpose, sample_count, notes, actual_start_time, actual_end_time, usage_record, created_at, updated_at";
+
+const PLANNED_TASK_FIELDS =
+  "id, lab_id, title, description, project_id, protocol_id, experiment_id, assigned_user_id, estimated_duration_minutes, required_resource_ids, preferred_start_date, preferred_end_date, priority, status, generated_from_protocol_step_id, scheduled_event_id, scheduled_booking_id, notes, created_by, updated_by, created_at, updated_at";
+
+// ---------------------------------------------------------------------------
+// Hydration
+// ---------------------------------------------------------------------------
+
+export async function listSchedulerWorkspace(
+  labId: string
+): Promise<SchedulerWorkspaceSnapshot> {
+  const [
+    resourcesResult,
+    eventsResult,
+    bookingsResult,
+    tasksResult,
+    projectsResult,
+    protocolsResult,
+  ] = await Promise.all([
+    client()
+      .from("resources")
+      .select(RESOURCE_FIELDS)
+      .eq("lab_id", labId)
+      .order("name", { ascending: true }),
+    client()
+      .from("calendar_events")
+      .select(EVENT_FIELDS)
+      .eq("lab_id", labId)
+      .order("start_time", { ascending: true }),
+    client()
+      .from("bookings")
+      .select(BOOKING_FIELDS)
+      .eq("lab_id", labId)
+      .order("start_time", { ascending: true }),
+    client()
+      .from("planned_tasks")
+      .select(PLANNED_TASK_FIELDS)
+      .eq("lab_id", labId)
+      .order("created_at", { ascending: false }),
+    client().from("projects").select("id, name").eq("lab_id", labId).order("name"),
+    client().from("protocols").select("id, name").eq("lab_id", labId).order("name"),
+  ]);
+
+  if (resourcesResult.error) throw resourcesResult.error;
+  if (eventsResult.error) throw eventsResult.error;
+  if (bookingsResult.error) throw bookingsResult.error;
+  if (tasksResult.error) throw tasksResult.error;
+  if (projectsResult.error) throw projectsResult.error;
+  if (protocolsResult.error) throw protocolsResult.error;
+
+  return {
+    resources: (resourcesResult.data as ResourceRecord[]) ?? [],
+    events: (eventsResult.data as CalendarEventRecord[]) ?? [],
+    bookings: (bookingsResult.data as BookingRecord[]) ?? [],
+    plannedTasks: (tasksResult.data as PlannedTaskRecord[]) ?? [],
+    projects: (projectsResult.data as ProjectOption[]) ?? [],
+    protocols: (protocolsResult.data as ProtocolOption[]) ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+
+export interface ResourceInput {
+  name: string;
+  description?: string | null;
+  category?: ResourceCategory;
+  location?: string | null;
+  availability_status?: ResourceAvailabilityStatus;
+  booking_mode?: BookingMode;
+  booking_policy?: BookingPolicy;
+  minimum_booking_duration_minutes?: number | null;
+  maximum_booking_duration_minutes?: number | null;
+  setup_buffer_minutes?: number;
+  cleanup_buffer_minutes?: number;
+  required_training?: boolean;
+  responsible_person_id?: string | null;
+  linked_protocol_id?: string | null;
+  notes?: string | null;
+}
+
+export async function createResource(args: {
+  labId: string;
+  userId: string;
+  data: ResourceInput;
+}): Promise<ResourceRecord> {
+  const { data, error } = await client()
+    .from("resources")
+    .insert({
+      lab_id: args.labId,
+      created_by: args.userId,
+      updated_by: args.userId,
+      ...args.data,
+    })
+    .select(RESOURCE_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as ResourceRecord;
+}
+
+export async function updateResource(args: {
+  resourceId: string;
+  userId: string;
+  data: Partial<ResourceInput> & { is_active?: boolean };
+}): Promise<ResourceRecord> {
+  const { data, error } = await client()
+    .from("resources")
+    .update({ ...args.data, updated_by: args.userId })
+    .eq("id", args.resourceId)
+    .select(RESOURCE_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as ResourceRecord;
+}
+
+export async function archiveResource(resourceId: string, userId: string) {
+  return updateResource({ resourceId, userId, data: { is_active: false } });
+}
+
+// ---------------------------------------------------------------------------
+// Calendar events
+// ---------------------------------------------------------------------------
+
+export interface CalendarEventInput {
+  title: string;
+  description?: string | null;
+  event_type?: EventType;
+  start_time: string;
+  end_time: string;
+  location?: string | null;
+  linked_project_id?: string | null;
+  linked_protocol_id?: string | null;
+  linked_task_id?: string | null;
+  participant_user_ids?: string[];
+  visibility?: EventVisibility;
+  recurrence_rule?: string | null;
+  recurrence_exceptions?: string[];
+  notes?: string | null;
+}
+
+export async function createCalendarEvent(args: {
+  labId: string;
+  userId: string;
+  data: CalendarEventInput;
+}): Promise<CalendarEventRecord> {
+  const { data, error } = await client()
+    .from("calendar_events")
+    .insert({
+      lab_id: args.labId,
+      organizer_user_id: args.userId,
+      created_by: args.userId,
+      updated_by: args.userId,
+      ...args.data,
+    })
+    .select(EVENT_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as CalendarEventRecord;
+}
+
+export async function updateCalendarEvent(args: {
+  eventId: string;
+  userId: string;
+  data: Partial<CalendarEventInput> & { status?: EventStatus };
+}): Promise<CalendarEventRecord> {
+  const { data, error } = await client()
+    .from("calendar_events")
+    .update({ ...args.data, updated_by: args.userId })
+    .eq("id", args.eventId)
+    .select(EVENT_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as CalendarEventRecord;
+}
+
+export async function deleteCalendarEvent(eventId: string): Promise<void> {
+  const { error } = await client().from("calendar_events").delete().eq("id", eventId);
+  if (error) throw error;
+}
+
+// ---------------------------------------------------------------------------
+// Bookings (server-side conflict-checked via RPC)
+// ---------------------------------------------------------------------------
+
+export interface BookResourceArgs {
+  resource_id: string;
+  start_time: string;
+  end_time: string;
+  title?: string | null;
+  booking_type?: BookingType;
+  project_id?: string | null;
+  protocol_id?: string | null;
+  planned_task_id?: string | null;
+  calendar_event_id?: string | null;
+  purpose?: string | null;
+  sample_count?: number | null;
+  notes?: string | null;
+}
+
+export async function bookResource(args: BookResourceArgs): Promise<BookingRecord> {
+  const { data, error } = await client().rpc("book_resource", {
+    p_resource_id: args.resource_id,
+    p_start_time: args.start_time,
+    p_end_time: args.end_time,
+    p_title: args.title ?? null,
+    p_booking_type: args.booking_type ?? "experiment",
+    p_project_id: args.project_id ?? null,
+    p_protocol_id: args.protocol_id ?? null,
+    p_planned_task_id: args.planned_task_id ?? null,
+    p_calendar_event_id: args.calendar_event_id ?? null,
+    p_purpose: args.purpose ?? null,
+    p_sample_count: args.sample_count ?? null,
+    p_notes: args.notes ?? null,
+  });
+  if (error) throw error;
+  return data as BookingRecord;
+}
+
+export async function cancelBooking(bookingId: string, note?: string | null) {
+  const { data, error } = await client().rpc("cancel_booking", {
+    p_booking_id: bookingId,
+    p_note: note ?? null,
+  });
+  if (error) throw error;
+  return data as BookingRecord;
+}
+
+export async function completeBooking(args: {
+  bookingId: string;
+  usageRecord?: string | null;
+  actualStartTime?: string | null;
+  actualEndTime?: string | null;
+}) {
+  const { data, error } = await client().rpc("complete_booking", {
+    p_booking_id: args.bookingId,
+    p_usage_record: args.usageRecord ?? null,
+    p_actual_start_time: args.actualStartTime ?? null,
+    p_actual_end_time: args.actualEndTime ?? null,
+  });
+  if (error) throw error;
+  return data as BookingRecord;
+}
+
+export async function approveBooking(bookingId: string, note?: string | null) {
+  const { data, error } = await client().rpc("approve_booking", {
+    p_booking_id: bookingId,
+    p_note: note ?? null,
+  });
+  if (error) throw error;
+  return data as BookingRecord;
+}
+
+export async function denyBooking(bookingId: string, note: string) {
+  const { data, error } = await client().rpc("deny_booking", {
+    p_booking_id: bookingId,
+    p_note: note,
+  });
+  if (error) throw error;
+  return data as BookingRecord;
+}
+
+export async function findBookingConflicts(args: {
+  resourceId: string;
+  startTime: string;
+  endTime: string;
+  excludeBookingId?: string | null;
+}): Promise<BookingRecord[]> {
+  const { data, error } = await client().rpc("find_booking_conflicts", {
+    p_resource_id: args.resourceId,
+    p_start_time: args.startTime,
+    p_end_time: args.endTime,
+    p_exclude_booking_id: args.excludeBookingId ?? null,
+  });
+  if (error) throw error;
+  return (data as BookingRecord[]) ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Planned tasks
+// ---------------------------------------------------------------------------
+
+export interface PlannedTaskInput {
+  title: string;
+  description?: string | null;
+  project_id?: string | null;
+  protocol_id?: string | null;
+  experiment_id?: string | null;
+  assigned_user_id?: string | null;
+  estimated_duration_minutes?: number | null;
+  required_resource_ids?: string[];
+  preferred_start_date?: string | null;
+  preferred_end_date?: string | null;
+  priority?: PlannedTaskPriority;
+  status?: PlannedTaskStatus;
+  notes?: string | null;
+}
+
+export async function createPlannedTask(args: {
+  labId: string;
+  userId: string;
+  data: PlannedTaskInput;
+}): Promise<PlannedTaskRecord> {
+  const { data, error } = await client()
+    .from("planned_tasks")
+    .insert({
+      lab_id: args.labId,
+      created_by: args.userId,
+      updated_by: args.userId,
+      ...args.data,
+    })
+    .select(PLANNED_TASK_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as PlannedTaskRecord;
+}
+
+export async function updatePlannedTask(args: {
+  taskId: string;
+  userId: string;
+  data: Partial<PlannedTaskInput>;
+}): Promise<PlannedTaskRecord> {
+  const { data, error } = await client()
+    .from("planned_tasks")
+    .update({ ...args.data, updated_by: args.userId })
+    .eq("id", args.taskId)
+    .select(PLANNED_TASK_FIELDS)
+    .single();
+  if (error) throw error;
+  return data as PlannedTaskRecord;
+}
+
+export async function deletePlannedTask(taskId: string): Promise<void> {
+  const { error } = await client().from("planned_tasks").delete().eq("id", taskId);
+  if (error) throw error;
+}
+
+export interface SchedulePlannedTaskEventArgs {
+  title?: string;
+  description?: string | null;
+  event_type?: EventType;
+  start_time: string;
+  end_time: string;
+  location?: string | null;
+  project_id?: string | null;
+  protocol_id?: string | null;
+  notes?: string | null;
+}
+
+export interface SchedulePlannedTaskBookingArgs extends BookResourceArgs {}
+
+export async function schedulePlannedTask(args: {
+  taskId: string;
+  event?: SchedulePlannedTaskEventArgs | null;
+  booking?: SchedulePlannedTaskBookingArgs | null;
+}): Promise<PlannedTaskRecord> {
+  const { data, error } = await client().rpc("schedule_planned_task", {
+    p_task_id: args.taskId,
+    p_event_args: args.event ?? null,
+    p_booking_args: args.booking ?? null,
+  });
+  if (error) throw error;
+  return data as PlannedTaskRecord;
+}

--- a/apps/scheduler/src/lib/useSchedulerWorkspace.ts
+++ b/apps/scheduler/src/lib/useSchedulerWorkspace.ts
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  approveBooking as rpcApproveBooking,
+  archiveResource as rpcArchiveResource,
+  bookResource as rpcBookResource,
+  cancelBooking as rpcCancelBooking,
+  completeBooking as rpcCompleteBooking,
+  createCalendarEvent as rpcCreateCalendarEvent,
+  createPlannedTask as rpcCreatePlannedTask,
+  createResource as rpcCreateResource,
+  deleteCalendarEvent as rpcDeleteCalendarEvent,
+  deletePlannedTask as rpcDeletePlannedTask,
+  denyBooking as rpcDenyBooking,
+  findBookingConflicts as rpcFindBookingConflicts,
+  listSchedulerWorkspace,
+  schedulePlannedTask as rpcSchedulePlannedTask,
+  updateCalendarEvent as rpcUpdateCalendarEvent,
+  updatePlannedTask as rpcUpdatePlannedTask,
+  updateResource as rpcUpdateResource,
+  type BookingRecord,
+  type BookResourceArgs,
+  type CalendarEventInput,
+  type CalendarEventRecord,
+  type PlannedTaskInput,
+  type PlannedTaskRecord,
+  type ResourceInput,
+  type ResourceRecord,
+  type SchedulePlannedTaskBookingArgs,
+  type SchedulePlannedTaskEventArgs,
+  type SchedulerWorkspaceSnapshot,
+} from "./cloudAdapter";
+
+export type WorkspaceStatus = "idle" | "loading" | "ready" | "error";
+
+export interface UseSchedulerWorkspaceValue extends SchedulerWorkspaceSnapshot {
+  status: WorkspaceStatus;
+  error: string | null;
+  refresh: () => Promise<void>;
+
+  createResource: (data: ResourceInput) => Promise<ResourceRecord>;
+  updateResource: (
+    resourceId: string,
+    data: Partial<ResourceInput> & { is_active?: boolean }
+  ) => Promise<ResourceRecord>;
+  archiveResource: (resourceId: string) => Promise<ResourceRecord>;
+
+  createCalendarEvent: (data: CalendarEventInput) => Promise<CalendarEventRecord>;
+  updateCalendarEvent: (
+    eventId: string,
+    data: Parameters<typeof rpcUpdateCalendarEvent>[0]["data"]
+  ) => Promise<CalendarEventRecord>;
+  deleteCalendarEvent: (eventId: string) => Promise<void>;
+
+  bookResource: (args: BookResourceArgs) => Promise<BookingRecord>;
+  cancelBooking: (bookingId: string, note?: string | null) => Promise<BookingRecord>;
+  completeBooking: (args: {
+    bookingId: string;
+    usageRecord?: string | null;
+    actualStartTime?: string | null;
+    actualEndTime?: string | null;
+  }) => Promise<BookingRecord>;
+  approveBooking: (bookingId: string, note?: string | null) => Promise<BookingRecord>;
+  denyBooking: (bookingId: string, note: string) => Promise<BookingRecord>;
+  findBookingConflicts: typeof rpcFindBookingConflicts;
+
+  createPlannedTask: (data: PlannedTaskInput) => Promise<PlannedTaskRecord>;
+  updatePlannedTask: (
+    taskId: string,
+    data: Partial<PlannedTaskInput>
+  ) => Promise<PlannedTaskRecord>;
+  deletePlannedTask: (taskId: string) => Promise<void>;
+  schedulePlannedTask: (args: {
+    taskId: string;
+    event?: SchedulePlannedTaskEventArgs | null;
+    booking?: SchedulePlannedTaskBookingArgs | null;
+  }) => Promise<PlannedTaskRecord>;
+}
+
+const EMPTY_SNAPSHOT: SchedulerWorkspaceSnapshot = {
+  resources: [],
+  events: [],
+  bookings: [],
+  plannedTasks: [],
+  projects: [],
+  protocols: [],
+};
+
+export function useSchedulerWorkspace(args: {
+  labId: string | null;
+  userId: string | null;
+}): UseSchedulerWorkspaceValue {
+  const { labId, userId } = args;
+  const [snapshot, setSnapshot] = useState<SchedulerWorkspaceSnapshot>(EMPTY_SNAPSHOT);
+  const [status, setStatus] = useState<WorkspaceStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const hydrate = useCallback(async () => {
+    if (!labId) {
+      setSnapshot(EMPTY_SNAPSHOT);
+      setStatus("idle");
+      return;
+    }
+    setStatus("loading");
+    setError(null);
+    try {
+      const next = await listSchedulerWorkspace(labId);
+      setSnapshot(next);
+      setStatus("ready");
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [labId]);
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  const requireIdentity = useCallback(() => {
+    if (!labId) throw new Error("No active lab selected.");
+    if (!userId) throw new Error("No signed-in user available.");
+    return { labId, userId };
+  }, [labId, userId]);
+
+  const createResource = useCallback<UseSchedulerWorkspaceValue["createResource"]>(
+    async (data) => {
+      const { labId: lab, userId: uid } = requireIdentity();
+      const created = await rpcCreateResource({ labId: lab, userId: uid, data });
+      await hydrate();
+      return created;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const updateResource = useCallback<UseSchedulerWorkspaceValue["updateResource"]>(
+    async (resourceId, data) => {
+      const { userId: uid } = requireIdentity();
+      const updated = await rpcUpdateResource({ resourceId, userId: uid, data });
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const archiveResource = useCallback<UseSchedulerWorkspaceValue["archiveResource"]>(
+    async (resourceId) => {
+      const { userId: uid } = requireIdentity();
+      const updated = await rpcArchiveResource(resourceId, uid);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const createCalendarEvent = useCallback<UseSchedulerWorkspaceValue["createCalendarEvent"]>(
+    async (data) => {
+      const { labId: lab, userId: uid } = requireIdentity();
+      const created = await rpcCreateCalendarEvent({ labId: lab, userId: uid, data });
+      await hydrate();
+      return created;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const updateCalendarEvent = useCallback<UseSchedulerWorkspaceValue["updateCalendarEvent"]>(
+    async (eventId, data) => {
+      const { userId: uid } = requireIdentity();
+      const updated = await rpcUpdateCalendarEvent({ eventId, userId: uid, data });
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const deleteCalendarEvent = useCallback<UseSchedulerWorkspaceValue["deleteCalendarEvent"]>(
+    async (eventId) => {
+      requireIdentity();
+      await rpcDeleteCalendarEvent(eventId);
+      await hydrate();
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const bookResource = useCallback<UseSchedulerWorkspaceValue["bookResource"]>(
+    async (bookArgs) => {
+      requireIdentity();
+      const created = await rpcBookResource(bookArgs);
+      await hydrate();
+      return created;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const cancelBooking = useCallback<UseSchedulerWorkspaceValue["cancelBooking"]>(
+    async (bookingId, note) => {
+      requireIdentity();
+      const updated = await rpcCancelBooking(bookingId, note);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const completeBooking = useCallback<UseSchedulerWorkspaceValue["completeBooking"]>(
+    async (completeArgs) => {
+      requireIdentity();
+      const updated = await rpcCompleteBooking(completeArgs);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const approveBooking = useCallback<UseSchedulerWorkspaceValue["approveBooking"]>(
+    async (bookingId, note) => {
+      requireIdentity();
+      const updated = await rpcApproveBooking(bookingId, note);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const denyBooking = useCallback<UseSchedulerWorkspaceValue["denyBooking"]>(
+    async (bookingId, note) => {
+      requireIdentity();
+      const updated = await rpcDenyBooking(bookingId, note);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const createPlannedTask = useCallback<UseSchedulerWorkspaceValue["createPlannedTask"]>(
+    async (data) => {
+      const { labId: lab, userId: uid } = requireIdentity();
+      const created = await rpcCreatePlannedTask({ labId: lab, userId: uid, data });
+      await hydrate();
+      return created;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const updatePlannedTask = useCallback<UseSchedulerWorkspaceValue["updatePlannedTask"]>(
+    async (taskId, data) => {
+      const { userId: uid } = requireIdentity();
+      const updated = await rpcUpdatePlannedTask({ taskId, userId: uid, data });
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const deletePlannedTask = useCallback<UseSchedulerWorkspaceValue["deletePlannedTask"]>(
+    async (taskId) => {
+      requireIdentity();
+      await rpcDeletePlannedTask(taskId);
+      await hydrate();
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const schedulePlannedTask = useCallback<UseSchedulerWorkspaceValue["schedulePlannedTask"]>(
+    async (scheduleArgs) => {
+      requireIdentity();
+      const updated = await rpcSchedulePlannedTask(scheduleArgs);
+      await hydrate();
+      return updated;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  return {
+    ...snapshot,
+    status,
+    error,
+    refresh: hydrate,
+    createResource,
+    updateResource,
+    archiveResource,
+    createCalendarEvent,
+    updateCalendarEvent,
+    deleteCalendarEvent,
+    bookResource,
+    cancelBooking,
+    completeBooking,
+    approveBooking,
+    denyBooking,
+    findBookingConflicts: rpcFindBookingConflicts,
+    createPlannedTask,
+    updatePlannedTask,
+    deletePlannedTask,
+    schedulePlannedTask,
+  };
+}

--- a/apps/scheduler/src/main.tsx
+++ b/apps/scheduler/src/main.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { AuthGate } from "@ilm/ui";
+import { App } from "./App";
+import "@ilm/ui/auth.css";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Could not find root element for Scheduler.");
+}
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <AuthGate>
+      <App />
+    </AuthGate>
+  </React.StrictMode>
+);

--- a/apps/scheduler/src/styles.css
+++ b/apps/scheduler/src/styles.css
@@ -1,0 +1,91 @@
+@import "../../../packages/ui/src/tokens.css";
+@import "../../../packages/ui/src/reset.css";
+@import "../../../packages/ui/src/primitives/primitives.css";
+@import "../../../packages/ui/src/lab-shell.css";
+
+/* =========================================================
+   Scheduler app-local styles
+   Shared shell + topbar come from lab-shell.css. Scheduler-
+   specific composition uses the .sch- prefix.
+========================================================= */
+
+.sch-subbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.sch-subbar-spacer {
+  flex: 1 1 auto;
+}
+
+.sch-subtab {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.55rem 0.85rem;
+  font: inherit;
+  font-family: var(--rl-font-display);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--rl-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.sch-subtab.is-active {
+  color: var(--rl-ink);
+  border-bottom-color: var(--rl-accent);
+}
+
+.sch-subtab:hover:not(.is-active) {
+  color: var(--rl-fg-2);
+}
+
+.sch-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  color: var(--rl-fg-2);
+}
+
+.sch-stat-grid > div span {
+  color: var(--rl-muted);
+  font-family: var(--rl-font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sch-stat-grid > div strong {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--rl-ink);
+  font-family: var(--rl-font-display);
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.sch-stat-grid > div small {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--rl-muted);
+}
+
+.sch-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.55rem;
+  color: var(--rl-fg-2);
+}
+
+@media (max-width: 900px) {
+  .sch-stat-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/scheduler/src/vite-env.d.ts
+++ b/apps/scheduler/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/scheduler/tsconfig.json
+++ b/apps/scheduler/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/apps/scheduler/vite.config.ts
+++ b/apps/scheduler/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+const base = process.env.VITE_BASE_PATH ?? "/";
+
+export default defineConfig({
+  base,
+  server: { port: 5177 },
+});

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 
 ## Foundation
 
-- **Monorepo**: npm workspaces with apps (`account`, `funding-manager`, `project-manager`, `protocol-manager`, `supply-manager`) and shared packages (`@ilm/ai-import`, `@ilm/types`, `@ilm/ui`, `@ilm/utils`, `@ilm/validation`).
+- **Monorepo**: npm workspaces with apps (`account`, `funding-manager`, `project-manager`, `protocol-manager`, `scheduler`, `supply-manager`) and shared packages (`@ilm/ai-import`, `@ilm/types`, `@ilm/ui`, `@ilm/utils`, `@ilm/validation`).
 - **Supabase backend**: Postgres schema under `supabase/migrations/`, Supabase Auth for identity, RLS on every app table.
 - **Static deploy**: GitHub Pages, no custom backend server; only `VITE_SUPABASE_URL` + anon key ship to the browser.
 
@@ -80,6 +80,14 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
   - **My Items** — project-scoped dashboard: counts of active / low-or-unknown / stale / open-requests, a "Reorder candidates" table with one-click request prefill, and the user's full project-scoped item list.
 - **Modals.** `ItemFormModal` (create + edit), `InventoryCheckModal` (with check history viewer), `LinkProjectsModal` (manage project associations), `NewRequestModal` (creates a draft, optionally seeded from a Warehouse row), `EditRequestModal` (continue draft, add / edit / remove items inline, surfaces ⚠ stale-check warnings per item), `ReviewRequestModal` (approve / deny with note), `PlaceOrderModal`, `UpdateOrderModal`, `ReceiveOrderModal` (multi-lot receipt with optional auto-recorded inventory check).
 
+## Scheduler (Stage 4e — foundation)
+
+- **Schema.** Four lab-scoped tables behind RLS: `resources` (equipment / bookable resources with category, location, availability_status, booking_mode `hard_booking | soft_booking`, booking_policy `open | approval_required | admin_only`, setup / cleanup buffers, min / max duration, required_training, responsible_person, optional `linked_protocol_id`), `calendar_events` (lab events with `event_type`, start / end window with check constraint, optional links to project / protocol / planned task, organizer + participant array, visibility `private | project | lab | equipment_visible`, `recurrence_rule` text + `recurrence_exceptions` timestamptz array, status `scheduled | cancelled | completed`), `bookings` (resource reservations with FK to resource + optional calendar event / planned task / project / protocol, copied setup/cleanup buffers, booking_type `experiment | daily_use | maintenance | calibration | training`, status `draft | requested | approved | denied | active | completed | cancelled | no_show`, actual start/end times + usage_record), `planned_tasks` (unscheduled work queue with priority `low | normal | high | urgent`, status `planned | ready_to_schedule | scheduled | completed | cancelled`, `required_resource_ids` array, `scheduled_event_id` / `scheduled_booking_id` back-links).
+- **Visibility / writes.** Lab members read all four tables. `resources` are admin-write only. `calendar_events` and `planned_tasks` allow members to create / edit / delete their own (organizer / created_by / assigned_user_id); admins manage all. Bookings allow members to create their own and edit non-terminal own bookings; admins override.
+- **Lifecycle RPCs (SECURITY DEFINER + audit-logged).** `book_resource` (server-side conflict + policy + duration check; auto-routes to `requested` for `approval_required` resources, otherwise `approved`), `cancel_booking`, `complete_booking` (records usage_record + actual start/end), `approve_booking`, `deny_booking` (note required), `schedule_planned_task` (converts a task into a calendar event and/or a booking, links the IDs back on the task, marks status `scheduled`).
+- **Conflict detection helper.** `find_booking_conflicts(resource_id, start, end, exclude_booking_id)` returns overlapping bookings using `tstzrange` overlap operator. Setup/cleanup buffers from the resource extend the window on both sides; soft-booking resources short-circuit and never report conflicts. Hard conflicts block non-admin booking; admins can override.
+- **Frontend (foundation).** `apps/scheduler` is a fresh Vite app inside the shared `<LabShell>`, mounted to the `calendar` sidebar slot at `/ILM/scheduler/`. The shell exposes Calendar / Bookings / Unscheduled / Resources subbar tabs (placeholder content for now). `cloudAdapter.ts` types every record + RPC; `useSchedulerWorkspace` hydrates a `{ resources, events, bookings, plannedTasks, projects, protocols }` snapshot and wraps each mutation with `await hydrate()`. View UIs land in the next session.
+
 ## Audit & security
 
 - `audit_log` table captures state transitions only — submit / approve / reject / recycle / restore / purge for projects and protocols, plus submit / withdraw / approve / deny / cancel / place / update / receive for supply orders. Draft edits, roadmap reorders, and inventory checks are not logged.
@@ -88,4 +96,5 @@ Cumulative log of what's shipped. Update after each PR that lands meaningful fun
 ## Known gaps (see `next-stage.md`)
 
 - `funding-manager` (Stage 4d) is deferred — auth-shell stub with no schema or adapter.
+- `scheduler` (Stage 4e) has its schema + RPCs + adapter + shell, but the four views (Calendar / Bookings / Unscheduled / Resources) are still placeholder cards — view UIs and modals are the next session's work.
 - Share-link token is a raw lab UUID; a rotatable HMAC token is a deferred follow-up.

--- a/docs/next-stage.md
+++ b/docs/next-stage.md
@@ -4,65 +4,66 @@ Rewrite this file when priorities change. It always describes *the current plann
 
 ---
 
-## Stage 4d: Funding Manager — grants, budgets, expenses
+## Stage 4e: Scheduler — calendar, bookings, unscheduled tasks
 
-**Why now.** Protocol (Stage 3), Account (Stage 4a), Project (Stage 4b), and Supply (Stage 4c) are all in production. The remaining authorial gap is money: PIs need to know what grants are open, how the budget is allocated across projects, and what's been spent. The `funding-manager` app is currently an auth-shell stub with no schema. Building it on the same UI kit + Supabase RLS + audit pattern that Supply just validated keeps the lift modest.
+**Why now.** Projects + protocols define what needs to happen and supply tracks what's on hand. The remaining authorial gap is *time and equipment* — when work is scheduled, who's holding the microscope on Tuesday, and what's queued but not yet on the calendar. Foundation has shipped (schema + RLS + lifecycle RPCs + Vite app shell on the `calendar` nav slot); the four views and their modals are the remaining work. Funding Manager (Stage 4d) is paused — labs asked for scheduling first.
 
-**Scope for this stage.** Three capabilities:
+**Scope for this stage.** Four views, all hosted inside `apps/scheduler` and bound to `useSchedulerWorkspace`:
 
-1. **Grants** — lab-scoped funding sources (agency, grant number, PI, period, total amount, status).
-2. **Budgets / allocations** — per-grant line items grouped by category (personnel, supplies, equipment, travel, other) and optionally allocated to specific projects so PIs can see how a grant is divided.
-3. **Expenses** — actual charges against an allocation, with date / amount / vendor / description / linked supply order or project. The Supply Manager's `orders` table is the natural feed for supply expenses; this stage adds the manual-entry path and the link.
+1. **Calendar** — weekly grid with day / week / month toggles (week is required, others if practical). Event cards colored by `event_type`. New / edit / delete event. Basic recurrence (none / daily / weekly / biweekly / monthly) — store the rule string, expand instances client-side for the visible window.
+2. **Bookings** — table / card list filtered by resource, project, status, "my bookings", date range. New booking form runs `book_resource` RPC; surfaces hard-conflict errors with a `ConflictWarning` panel. Lifecycle actions: cancel, complete (with usage_record), approve / deny (admins).
+3. **Unscheduled tasks** — task cards from `planned_tasks` where `status in ('planned','ready_to_schedule')`. New task button. "Schedule" opens a converter that calls `schedule_planned_task` with event-only / booking-only / both args.
+4. **Resources** — admin-managed equipment registry with filters (category / location / status / booking mode / active). Add / edit / archive. Resource detail card with current + upcoming bookings.
 
-Out of scope for this stage: invoice scanning, multi-currency, automatic feeds from institutional accounting, payroll burden calculations, cost-share tracking. Deferred to follow-ups.
+Out of scope for this stage: Google Calendar sync, notifications, auto-scheduling, multi-user real-time collaboration, RRULE exception editing beyond the basic `recurrence_exceptions` array, analytics dashboard.
 
-### Step 1 — Schema migration
+### Step 1 — Calendar view
 
-Create `supabase/migrations/YYYYMMDDHHMMSS_funding_manager.sql`:
+- Weekly grid component (Sun/Mon-anchored, configurable later). Render events from `events` snapshot whose `[start_time, end_time]` window intersects the visible week, plus expanded instances of recurring events.
+- `EventForm` modal (create / edit) — title, type, start/end, location, project / protocol / linked task, visibility, recurrence rule. Calls `createCalendarEvent` / `updateCalendarEvent`.
+- Status badge by `event_type` (use existing `Badge` / `StatusPill` primitives). Color tokens added in `styles.css`.
 
-- `grants` — `(id, lab_id, name, agency, grant_number, pi_user_id nullable, status: planning/active/closed/awarded/rejected, total_amount numeric, currency text default 'USD', period_start date, period_end date, notes, created_by, timestamps)`. RLS lab-scoped.
-- `grant_allocations` — `(id, grant_id, lab_id, project_id nullable, category: personnel/supplies/equipment/travel/other, label text, allocated_amount numeric, notes, timestamps)`. A null `project_id` means lab-wide / unassigned.
-- `expenses` — `(id, lab_id, grant_id, allocation_id nullable, project_id nullable, supply_order_id nullable, description, vendor, amount numeric, occurred_at date, recorded_by, notes, timestamps)`.
-- `updated_at` triggers on all three.
-- **RLS** — read for any lab member; create/edit/delete for lab admins. Loosen later if PIs want member-recorded expenses.
-- **RPCs (SECURITY DEFINER, audit-logged)** — `create_grant`, `update_grant`, `archive_grant`; `create_allocation`, `update_allocation`, `delete_allocation`; `record_expense`, `update_expense`, `delete_expense`. Audit each state-changing call.
-- **Audit** — entries on grant status changes, allocation create/delete, expense create/update/delete. Routine field edits on a grant can stay un-logged.
+### Step 2 — Bookings view
 
-### Step 2 — Shared types + adapter
+- Bookings table with the filter bar described above. Existing `Table` / `StatusPill` primitives.
+- `BookingForm` modal that pre-checks for conflicts using `findBookingConflicts` (server RPC) before calling `bookResource`. On conflict-error response, render `ConflictWarning` listing the overlapping bookings.
+- Cancel / complete / approve / deny actions wired to the existing RPCs. Completion modal collects `usage_record` and optional `actual_start_time` / `actual_end_time`.
 
-- `apps/funding-manager/src/lib/cloudAdapter.ts` mirrors `apps/supply-manager/src/lib/cloudAdapter.ts` — exported types + the seven hydration query + per-RPC helpers.
-- `apps/funding-manager/src/lib/useFundingWorkspace.ts` mirrors `useSupplyWorkspace`: snapshot state, identity-aware action wrappers, `hydrate()` after each mutation.
+### Step 3 — Unscheduled tasks view
 
-### Step 3 — Frontend screens
+- Card grid sorted by priority + preferred_start_date.
+- "Schedule" opens a modal with three modes: event only, booking only, both. Both modes share start/end and link the new event to the new booking via `calendar_event_id` (the RPC handles that).
+- Status flips to `scheduled` automatically inside the RPC; UI reflects the new `scheduled_event_id` / `scheduled_booking_id`.
 
-Tabs in `apps/funding-manager` (built on `@ilm/ui` primitives — `AppShell` / `Panel` / `Table` / `Modal` / `Button` / `StatusPill`, etc., same approach Supply Manager just validated):
+### Step 4 — Resources view
 
-- **Grants** — list with search + status filter; cards show agency, grant #, PI, period, totals (allocated vs. spent vs. remaining). Admin actions: New / Edit / Archive.
-- **Budget** — per-grant breakdown: allocations grouped by category, with project breakdown beneath. Spent / remaining bar per allocation.
-- **Expenses** — table with date / vendor / category / project / amount; filters by grant / project / category / date range. "Link supply order" picker pulls from `orders` so supply receipts can be charged in one click.
-- **Overview** — lab-level dashboard: total active funding, spend by category, top grants by remaining balance, expiring-soon banner.
+- Admin-only table with `New / Edit / Archive` actions. Members see a read-only registry with availability status badges.
+- `ResourceForm` modal — covers all schema fields including buffers, min/max durations, required training, booking mode + policy, responsible person.
+- Archived toggle hides `is_active = false` resources by default (mirrors Supply Manager pattern).
 
-### Step 4 — Cross-app link from Supply
+### Step 5 — Daily-use bookings & cross-app surfacing
 
-When a supply order is marked received, surface a "Charge to grant" button in the order card that opens a Funding Manager modal pre-filled with the order's vendor / total / linked project. Saves an `expenses` row pointing back at the supply order. No schema change needed beyond the optional `supply_order_id` column on `expenses`.
+- Confirm `daily_use` booking_type works end-to-end on a soft-booking resource (no conflict block, overlap allowed). Already supported in the schema; just wire the form preset.
+- Surface upcoming bookings on the home dashboard's Upcoming Schedule card (currently a placeholder).
 
-### Step 5 — Deployment + docs
+### Step 6 — Docs
 
-- Funding Manager is already wired into `.github/workflows/deploy-protocol-manager-pages.yml`; just verify the build still passes.
-- Update `docs/features.md` with a "Funding Manager (Stage 4d)" section on ship.
+- Update `docs/features.md` Scheduler section as views ship.
+- Add a "Scheduler" subsection to `docs/module-development.md` if any new convention emerges (e.g. RRULE expansion helper) that future modules should reuse.
 
 ### Tradeoffs
 
-- **Allocation granularity.** v1 lets allocations target a project or stay lab-wide; further sub-budgeting (per-experiment, per-investigator) is out of scope. Add a parent allocation FK later if labs ask for nesting.
-- **Expense source.** Manual entry + supply-order link covers ~90% of charges for a small lab. Institutional ERP feeds, P-card imports, and effort reporting are deferred to a follow-up stage.
-- **Status machine.** Grants get a flat status field rather than a draft/review workflow — the data is administrative, not authorial, and a single lab admin enters it. If grant *applications* (pre-award) become a use case, revisit with a draft/submit/reject flow modeled on the Project review gating.
+- **Recurrence model.** v1 stores a free-form `recurrence_rule` text. We expand instances client-side for the rendered window — easier than persisting expanded rows, simple to extend later. Full RRULE editing (BYDAY, COUNT, UNTIL) is out of scope.
+- **Visibility enforcement.** The `visibility` column is stored but RLS treats every event as lab-visible for now (members read all). Tightening to `private` / `project` requires a join through `project_members`; deferred until a lab actually needs it.
+- **Conflict UX.** Server RPC raises `errcode 23P01` on hard conflict and the frontend re-runs `find_booking_conflicts` to render the offending rows. We don't have an admin "force override" button yet — admins can already book through the conflict because the RPC's check is gated by `is_lab_admin`.
 
 ---
 
-## After this stage
+## Deferred
 
-- **UI kit Phase E.** Write `packages/ui/README.md` + `docs/design-system.md` covering the primitives, the `--rl-*` token contract, and the "first use local, second use promote" rule. Phase D is already done (Account / Project / Protocol all run on `AppShell`).
-- **Stage 4e — Supply Manager v2.** Per-experiment consumption logging (links `experiments` to a new `stock_movements` ledger), supplier/catalog import, barcode scanning, lot/expiry alerts. The current single-row-per-item stock model upgrades to an append-only ledger when this lands.
-- **Stage 4f — Reporting / exports.** Cross-app digests: weekly lab-activity summary, grant-period spend report, protocol publication log. Probably edge-function generated, surfaced as a downloadable HTML/PDF.
-- **Rotatable share-link token.** Today the Account share link embeds a raw lab UUID. A signed HMAC with a server-stored secret + a "rotate" button in the share-link section would make leaked links revocable.
+- **Stage 4d — Funding Manager.** Grants / budgets / allocations / expenses, plus a "Charge to grant" button on received Supply orders. Spec is preserved in git history (was the previous next-stage); revive when the Scheduler MVP is in production.
+- **UI kit Phase F.** `packages/ui/README.md` + `docs/design-system.md` describing primitives, the `--rl-*` token contract, and the "first use local, second use promote" rule. Phase E (LabShell unification) shipped.
+- **Stage 4f — Supply Manager v2.** Per-experiment consumption logging (links `experiments` to a new `stock_movements` ledger), supplier/catalog import, barcode scanning, lot/expiry alerts.
+- **Stage 4g — Reporting / exports.** Cross-app digests (weekly lab activity, grant-period spend, protocol publication log).
+- **Rotatable share-link token.** Replace the raw lab UUID in the Account share link with a signed HMAC + revocation.
 - **Deferred housekeeping.** Fractional `sort_order`, layout polish (InfoTab responsive grid, roadmap card ellipsis, recycle-bin visual differentiation), dead-code simplify pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,22 @@
         "vite": "^5.4.11"
       }
     },
+    "apps/scheduler": {
+      "name": "@ilm/scheduler",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ilm/ui": "file:../../packages/ui",
+        "@ilm/utils": "file:../../packages/utils",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "typescript": "^5.7.2",
+        "vite": "^5.4.11"
+      }
+    },
     "apps/supply-manager": {
       "name": "@ilm/supply-manager",
       "version": "0.1.0",
@@ -623,6 +639,10 @@
     },
     "node_modules/@ilm/protocol-manager": {
       "resolved": "apps/protocol-manager",
+      "link": true
+    },
+    "node_modules/@ilm/scheduler": {
+      "resolved": "apps/scheduler",
       "link": true
     },
     "node_modules/@ilm/supply-manager": {

--- a/packages/ui/src/AppSwitcher.tsx
+++ b/packages/ui/src/AppSwitcher.tsx
@@ -4,6 +4,7 @@ export type AppId =
   | "project-manager"
   | "supply-manager"
   | "funding-manager"
+  | "scheduler"
   | "account";
 
 type AppLink = {
@@ -18,6 +19,7 @@ const APP_LINKS: AppLink[] = [
   { id: "project-manager", label: "Projects", href: "project-manager/" },
   { id: "supply-manager", label: "Supply", href: "supply-manager/" },
   { id: "funding-manager", label: "Funding", href: "funding-manager/" },
+  { id: "scheduler", label: "Scheduler", href: "scheduler/" },
 ];
 
 // Root segments recognized when walking back to the site root. The home app
@@ -28,6 +30,7 @@ const APP_ROOT_SEGMENTS = new Set<string>([
   "project-manager/",
   "supply-manager/",
   "funding-manager/",
+  "scheduler/",
 ]);
 
 const resolveSiteRoot = (baseUrl: string) => {

--- a/packages/ui/src/LabShell.tsx
+++ b/packages/ui/src/LabShell.tsx
@@ -65,8 +65,8 @@ const NAV_ITEMS: NavItem[] = [
     id: "calendar",
     label: "Calendar",
     glyph: "▣",
-    buildHref: (root) => `${root}#/calendar`,
-    tone: "soon",
+    buildHref: (_, base) => appUrl("scheduler/", base),
+    tone: "external",
   },
   {
     id: "team",

--- a/packages/ui/src/admin/LabShareLinkPanel.tsx
+++ b/packages/ui/src/admin/LabShareLinkPanel.tsx
@@ -7,7 +7,7 @@ const resolveSiteRoot = (baseUrl: string) => {
   const withLeadingSlash = base.startsWith("/") ? base : `/${base}`;
   const normalized = withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
   const url = new URL(normalized, window.location.origin);
-  const knownAppRoots = ["protocol-manager/", "project-manager/", "supply-manager/", "funding-manager/"];
+  const knownAppRoots = ["protocol-manager/", "project-manager/", "supply-manager/", "funding-manager/", "scheduler/"];
   const matchedAppRoot = knownAppRoots.find((segment) => url.pathname.endsWith(segment));
   const root = matchedAppRoot ? new URL("../", url) : url;
   return root.toString();

--- a/packages/ui/src/auth/LabPicker.tsx
+++ b/packages/ui/src/auth/LabPicker.tsx
@@ -66,6 +66,7 @@ export const LabPicker = () => {
       "project-manager",
       "supply-manager",
       "funding-manager",
+      "scheduler",
     ]);
     if (pathSegments.length > 0 && knownApps.has(pathSegments[pathSegments.length - 1])) {
       pathSegments.pop();

--- a/supabase/migrations/20260501000000_scheduler.sql
+++ b/supabase/migrations/20260501000000_scheduler.sql
@@ -1,0 +1,726 @@
+-- Stage 4e — Scheduler
+--
+-- Lab-scoped time/resource coordination: equipment registry, calendar events,
+-- equipment bookings (with conflict detection), and a queue of planned tasks
+-- that have not yet been scheduled.
+--
+-- All tables are lab-scoped. Reads are gated by lab membership; writes follow
+-- the standard pattern (member self-create, admin manage). Hard-booking
+-- conflict detection runs through a SECURITY DEFINER RPC so the overlap check
+-- happens server-side.
+
+-- ---------------------------------------------------------------------------
+-- 1) Tables
+-- ---------------------------------------------------------------------------
+
+-- 1.1) resources — equipment / bookable resources
+create table if not exists public.resources (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  name text not null,
+  description text,
+  category text not null default 'general'
+    check (category in ('sequencer', 'microscope', 'thermocycler', 'centrifuge',
+                        'incubator', 'qpcr', 'imaging', 'general', 'other')),
+  location text,
+  availability_status text not null default 'available'
+    check (availability_status in ('available', 'offline', 'maintenance', 'restricted')),
+  booking_mode text not null default 'hard_booking'
+    check (booking_mode in ('hard_booking', 'soft_booking')),
+  booking_policy text not null default 'open'
+    check (booking_policy in ('open', 'approval_required', 'admin_only')),
+  minimum_booking_duration_minutes integer,
+  maximum_booking_duration_minutes integer,
+  setup_buffer_minutes integer not null default 0,
+  cleanup_buffer_minutes integer not null default 0,
+  required_training boolean not null default false,
+  responsible_person_id uuid references auth.users(id) on delete set null,
+  linked_protocol_id uuid references public.protocols(id) on delete set null,
+  notes text,
+  is_active boolean not null default true,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists resources_lab_id_idx on public.resources (lab_id);
+create index if not exists resources_lab_active_idx on public.resources (lab_id, is_active);
+create index if not exists resources_category_idx on public.resources (lab_id, category);
+
+drop trigger if exists resources_set_updated_at on public.resources;
+create trigger resources_set_updated_at
+before update on public.resources
+for each row execute function public.set_updated_at();
+
+-- 1.2) calendar_events — scheduled events (meetings, experiments, deadlines, …)
+create table if not exists public.calendar_events (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  title text not null,
+  description text,
+  event_type text not null default 'general'
+    check (event_type in ('meeting', 'experiment', 'reminder', 'deadline',
+                          'maintenance', 'general')),
+  start_time timestamptz not null,
+  end_time timestamptz not null,
+  location text,
+  linked_project_id uuid references public.projects(id) on delete set null,
+  linked_protocol_id uuid references public.protocols(id) on delete set null,
+  linked_task_id uuid,
+  organizer_user_id uuid references auth.users(id) on delete set null,
+  participant_user_ids uuid[] not null default '{}',
+  visibility text not null default 'lab'
+    check (visibility in ('private', 'project', 'lab', 'equipment_visible')),
+  recurrence_rule text,
+  recurrence_exceptions timestamptz[] not null default '{}',
+  status text not null default 'scheduled'
+    check (status in ('scheduled', 'cancelled', 'completed')),
+  notes text,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint calendar_events_time_window check (end_time > start_time)
+);
+
+create index if not exists calendar_events_lab_idx on public.calendar_events (lab_id);
+create index if not exists calendar_events_window_idx
+  on public.calendar_events (lab_id, start_time, end_time);
+create index if not exists calendar_events_project_idx
+  on public.calendar_events (linked_project_id);
+
+drop trigger if exists calendar_events_set_updated_at on public.calendar_events;
+create trigger calendar_events_set_updated_at
+before update on public.calendar_events
+for each row execute function public.set_updated_at();
+
+-- 1.3) bookings — equipment reservations
+create table if not exists public.bookings (
+  id uuid primary key default gen_random_uuid(),
+  resource_id uuid not null references public.resources(id) on delete cascade,
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  calendar_event_id uuid references public.calendar_events(id) on delete set null,
+  user_id uuid references auth.users(id) on delete set null,
+  project_id uuid references public.projects(id) on delete set null,
+  protocol_id uuid references public.protocols(id) on delete set null,
+  planned_task_id uuid,
+  title text,
+  start_time timestamptz not null,
+  end_time timestamptz not null,
+  setup_buffer_minutes integer not null default 0,
+  cleanup_buffer_minutes integer not null default 0,
+  booking_type text not null default 'experiment'
+    check (booking_type in ('experiment', 'daily_use', 'maintenance',
+                            'calibration', 'training')),
+  status text not null default 'approved'
+    check (status in ('draft', 'requested', 'approved', 'denied', 'active',
+                      'completed', 'cancelled', 'no_show')),
+  approval_user_id uuid references auth.users(id) on delete set null,
+  purpose text,
+  sample_count integer,
+  notes text,
+  actual_start_time timestamptz,
+  actual_end_time timestamptz,
+  usage_record text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint bookings_time_window check (end_time > start_time)
+);
+
+create index if not exists bookings_resource_window_idx
+  on public.bookings (resource_id, start_time, end_time);
+create index if not exists bookings_lab_idx on public.bookings (lab_id);
+create index if not exists bookings_user_idx on public.bookings (user_id);
+create index if not exists bookings_project_idx on public.bookings (project_id);
+create index if not exists bookings_status_idx on public.bookings (lab_id, status);
+
+drop trigger if exists bookings_set_updated_at on public.bookings;
+create trigger bookings_set_updated_at
+before update on public.bookings
+for each row execute function public.set_updated_at();
+
+-- 1.4) planned_tasks — experiment work that has not yet been scheduled
+create table if not exists public.planned_tasks (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  title text not null,
+  description text,
+  project_id uuid references public.projects(id) on delete set null,
+  protocol_id uuid references public.protocols(id) on delete set null,
+  experiment_id uuid,
+  assigned_user_id uuid references auth.users(id) on delete set null,
+  estimated_duration_minutes integer,
+  required_resource_ids uuid[] not null default '{}',
+  preferred_start_date date,
+  preferred_end_date date,
+  priority text not null default 'normal'
+    check (priority in ('low', 'normal', 'high', 'urgent')),
+  status text not null default 'planned'
+    check (status in ('planned', 'ready_to_schedule', 'scheduled',
+                      'completed', 'cancelled')),
+  generated_from_protocol_step_id uuid,
+  scheduled_event_id uuid references public.calendar_events(id) on delete set null,
+  scheduled_booking_id uuid references public.bookings(id) on delete set null,
+  notes text,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists planned_tasks_lab_status_idx
+  on public.planned_tasks (lab_id, status);
+create index if not exists planned_tasks_project_idx
+  on public.planned_tasks (project_id);
+create index if not exists planned_tasks_assigned_idx
+  on public.planned_tasks (assigned_user_id);
+
+drop trigger if exists planned_tasks_set_updated_at on public.planned_tasks;
+create trigger planned_tasks_set_updated_at
+before update on public.planned_tasks
+for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- 2) RLS
+-- ---------------------------------------------------------------------------
+
+alter table public.resources       enable row level security;
+alter table public.calendar_events enable row level security;
+alter table public.bookings        enable row level security;
+alter table public.planned_tasks   enable row level security;
+
+-- 2.1) resources — lab members read; admins write.
+drop policy if exists resources_select on public.resources;
+create policy resources_select on public.resources
+  for select using (public.is_lab_member(lab_id));
+
+drop policy if exists resources_insert_admin on public.resources;
+create policy resources_insert_admin on public.resources
+  for insert with check (public.is_lab_admin(lab_id));
+
+drop policy if exists resources_update_admin on public.resources;
+create policy resources_update_admin on public.resources
+  for update using (public.is_lab_admin(lab_id))
+  with check (public.is_lab_admin(lab_id));
+
+drop policy if exists resources_delete_admin on public.resources;
+create policy resources_delete_admin on public.resources
+  for delete using (public.is_lab_admin(lab_id));
+
+-- 2.2) calendar_events — lab members read; members create/edit own; admins
+-- can edit/delete any.
+drop policy if exists calendar_events_select on public.calendar_events;
+create policy calendar_events_select on public.calendar_events
+  for select using (public.is_lab_member(lab_id));
+
+drop policy if exists calendar_events_insert on public.calendar_events;
+create policy calendar_events_insert on public.calendar_events
+  for insert with check (
+    public.is_lab_member(lab_id)
+    and (organizer_user_id is null or organizer_user_id = auth.uid())
+  );
+
+drop policy if exists calendar_events_update on public.calendar_events;
+create policy calendar_events_update on public.calendar_events
+  for update using (
+    public.is_lab_admin(lab_id)
+    or organizer_user_id = auth.uid()
+  )
+  with check (
+    public.is_lab_admin(lab_id)
+    or organizer_user_id = auth.uid()
+  );
+
+drop policy if exists calendar_events_delete on public.calendar_events;
+create policy calendar_events_delete on public.calendar_events
+  for delete using (
+    public.is_lab_admin(lab_id)
+    or organizer_user_id = auth.uid()
+  );
+
+-- 2.3) bookings — lab members read; members create own (subject to
+-- conflict-checking RPC for hard bookings); members edit/cancel own non-
+-- terminal bookings; admins can edit/delete any.
+drop policy if exists bookings_select on public.bookings;
+create policy bookings_select on public.bookings
+  for select using (public.is_lab_member(lab_id));
+
+drop policy if exists bookings_insert on public.bookings;
+create policy bookings_insert on public.bookings
+  for insert with check (
+    public.is_lab_member(lab_id)
+    and (user_id is null or user_id = auth.uid())
+  );
+
+drop policy if exists bookings_update on public.bookings;
+create policy bookings_update on public.bookings
+  for update using (
+    public.is_lab_admin(lab_id)
+    or (user_id = auth.uid() and status in ('draft', 'requested', 'approved', 'active'))
+  )
+  with check (
+    public.is_lab_admin(lab_id)
+    or (user_id = auth.uid() and status in ('draft', 'requested', 'approved',
+                                            'active', 'completed', 'cancelled'))
+  );
+
+drop policy if exists bookings_delete on public.bookings;
+create policy bookings_delete on public.bookings
+  for delete using (
+    public.is_lab_admin(lab_id)
+    or (user_id = auth.uid() and status in ('draft', 'requested'))
+  );
+
+-- 2.4) planned_tasks — lab members read; members create/edit own; admins
+-- manage all.
+drop policy if exists planned_tasks_select on public.planned_tasks;
+create policy planned_tasks_select on public.planned_tasks
+  for select using (public.is_lab_member(lab_id));
+
+drop policy if exists planned_tasks_insert on public.planned_tasks;
+create policy planned_tasks_insert on public.planned_tasks
+  for insert with check (
+    public.is_lab_member(lab_id)
+    and (created_by is null or created_by = auth.uid())
+  );
+
+drop policy if exists planned_tasks_update on public.planned_tasks;
+create policy planned_tasks_update on public.planned_tasks
+  for update using (
+    public.is_lab_admin(lab_id)
+    or created_by = auth.uid()
+    or assigned_user_id = auth.uid()
+  )
+  with check (
+    public.is_lab_admin(lab_id)
+    or created_by = auth.uid()
+    or assigned_user_id = auth.uid()
+  );
+
+drop policy if exists planned_tasks_delete on public.planned_tasks;
+create policy planned_tasks_delete on public.planned_tasks
+  for delete using (
+    public.is_lab_admin(lab_id)
+    or created_by = auth.uid()
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3) Conflict detection helper
+-- ---------------------------------------------------------------------------
+
+-- Returns the bookings that overlap a proposed window for a given resource,
+-- after applying the resource's setup/cleanup buffers. Soft-booking resources
+-- never produce conflicts (overlaps are visible but allowed).
+create or replace function public.find_booking_conflicts(
+  p_resource_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_exclude_booking_id uuid default null
+)
+returns setof public.bookings
+language plpgsql stable security definer set search_path = public as $$
+declare
+  v_resource public.resources%rowtype;
+  v_setup interval;
+  v_cleanup interval;
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+begin
+  select * into v_resource from public.resources where id = p_resource_id;
+  if not found then
+    raise exception 'resource not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_member(v_resource.lab_id) then
+    raise exception 'not permitted' using errcode = '42501';
+  end if;
+
+  -- Soft bookings tolerate overlap — return no conflicts.
+  if v_resource.booking_mode = 'soft_booking' then
+    return;
+  end if;
+
+  v_setup := make_interval(mins => coalesce(v_resource.setup_buffer_minutes, 0));
+  v_cleanup := make_interval(mins => coalesce(v_resource.cleanup_buffer_minutes, 0));
+  v_window_start := p_start_time - v_setup;
+  v_window_end := p_end_time + v_cleanup;
+
+  return query
+    select *
+      from public.bookings b
+     where b.resource_id = p_resource_id
+       and b.status in ('requested', 'approved', 'active')
+       and (p_exclude_booking_id is null or b.id <> p_exclude_booking_id)
+       and tstzrange(b.start_time - v_setup, b.end_time + v_cleanup, '[)')
+           && tstzrange(v_window_start, v_window_end, '[)');
+end;
+$$;
+
+grant execute on function public.find_booking_conflicts(uuid, timestamptz, timestamptz, uuid)
+  to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4) RPCs — booking lifecycle (server-side conflict-checked)
+-- ---------------------------------------------------------------------------
+
+-- 4.1) book_resource — creates a booking after conflict + policy checks.
+create or replace function public.book_resource(
+  p_resource_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_title text default null,
+  p_booking_type text default 'experiment',
+  p_project_id uuid default null,
+  p_protocol_id uuid default null,
+  p_planned_task_id uuid default null,
+  p_calendar_event_id uuid default null,
+  p_purpose text default null,
+  p_sample_count integer default null,
+  p_notes text default null
+)
+returns public.bookings
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_resource public.resources%rowtype;
+  v_status text;
+  v_duration_minutes integer;
+  v_conflict_count integer;
+  v_booking public.bookings%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if p_end_time <= p_start_time then
+    raise exception 'end_time must be after start_time' using errcode = '22023';
+  end if;
+
+  select * into v_resource from public.resources where id = p_resource_id;
+  if not found then
+    raise exception 'resource not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_member(v_resource.lab_id) then
+    raise exception 'not a member of this lab' using errcode = '42501';
+  end if;
+  if not v_resource.is_active then
+    raise exception 'resource is archived' using errcode = '22023';
+  end if;
+  if v_resource.availability_status in ('offline', 'maintenance')
+     and not public.is_lab_admin(v_resource.lab_id) then
+    raise exception 'resource is % and cannot be booked', v_resource.availability_status
+      using errcode = '22023';
+  end if;
+  if v_resource.booking_policy = 'admin_only'
+     and not public.is_lab_admin(v_resource.lab_id) then
+    raise exception 'this resource is admin-only' using errcode = '42501';
+  end if;
+
+  v_duration_minutes := ceil(extract(epoch from (p_end_time - p_start_time)) / 60.0);
+  if v_resource.minimum_booking_duration_minutes is not null
+     and v_duration_minutes < v_resource.minimum_booking_duration_minutes then
+    raise exception 'booking shorter than minimum % minutes',
+      v_resource.minimum_booking_duration_minutes using errcode = '22023';
+  end if;
+  if v_resource.maximum_booking_duration_minutes is not null
+     and v_duration_minutes > v_resource.maximum_booking_duration_minutes
+     and not public.is_lab_admin(v_resource.lab_id) then
+    raise exception 'booking longer than maximum % minutes',
+      v_resource.maximum_booking_duration_minutes using errcode = '22023';
+  end if;
+
+  -- Hard-conflict detection. Soft bookings short-circuit inside the helper.
+  if v_resource.booking_mode = 'hard_booking' then
+    select count(*) into v_conflict_count
+      from public.find_booking_conflicts(p_resource_id, p_start_time, p_end_time, null);
+    if v_conflict_count > 0 and not public.is_lab_admin(v_resource.lab_id) then
+      raise exception 'time conflicts with % existing booking(s)', v_conflict_count
+        using errcode = '23P01';
+    end if;
+  end if;
+
+  v_status := case
+    when v_resource.booking_policy = 'approval_required'
+         and not public.is_lab_admin(v_resource.lab_id) then 'requested'
+    else 'approved'
+  end;
+
+  insert into public.bookings (
+    resource_id, lab_id, calendar_event_id, user_id, project_id, protocol_id,
+    planned_task_id, title, start_time, end_time,
+    setup_buffer_minutes, cleanup_buffer_minutes,
+    booking_type, status, purpose, sample_count, notes
+  ) values (
+    p_resource_id, v_resource.lab_id, p_calendar_event_id, v_uid, p_project_id,
+    p_protocol_id, p_planned_task_id,
+    nullif(btrim(coalesce(p_title, '')), ''),
+    p_start_time, p_end_time,
+    coalesce(v_resource.setup_buffer_minutes, 0),
+    coalesce(v_resource.cleanup_buffer_minutes, 0),
+    coalesce(p_booking_type, 'experiment'),
+    v_status,
+    nullif(btrim(coalesce(p_purpose, '')), ''),
+    p_sample_count,
+    nullif(btrim(coalesce(p_notes, '')), '')
+  )
+  returning * into v_booking;
+
+  perform public._log_audit(v_resource.lab_id, 'booking', v_booking.id, 'book',
+    jsonb_build_object('resource_id', p_resource_id, 'status', v_status,
+                       'mode', v_resource.booking_mode));
+  return v_booking;
+end;
+$$;
+
+-- 4.2) cancel_booking — owner or admin
+create or replace function public.cancel_booking(p_booking_id uuid, p_note text default null)
+returns public.bookings
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.bookings%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select * into v_row from public.bookings where id = p_booking_id;
+  if not found then
+    raise exception 'booking not found' using errcode = '02000';
+  end if;
+  if v_row.user_id <> v_uid and not public.is_lab_admin(v_row.lab_id) then
+    raise exception 'not permitted to cancel this booking' using errcode = '42501';
+  end if;
+  if v_row.status in ('completed', 'cancelled', 'no_show') then
+    raise exception 'booking is already %', v_row.status using errcode = '22023';
+  end if;
+
+  update public.bookings
+     set status = 'cancelled',
+         notes = coalesce(nullif(btrim(coalesce(p_note, '')), ''), notes)
+   where id = p_booking_id
+   returning * into v_row;
+
+  perform public._log_audit(v_row.lab_id, 'booking', p_booking_id, 'cancel', '{}'::jsonb);
+  return v_row;
+end;
+$$;
+
+-- 4.3) complete_booking — owner or admin marks a booking complete with usage notes
+create or replace function public.complete_booking(
+  p_booking_id uuid,
+  p_usage_record text default null,
+  p_actual_start_time timestamptz default null,
+  p_actual_end_time timestamptz default null
+)
+returns public.bookings
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.bookings%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select * into v_row from public.bookings where id = p_booking_id;
+  if not found then
+    raise exception 'booking not found' using errcode = '02000';
+  end if;
+  if v_row.user_id <> v_uid and not public.is_lab_admin(v_row.lab_id) then
+    raise exception 'not permitted to complete this booking' using errcode = '42501';
+  end if;
+  if v_row.status not in ('approved', 'active', 'requested') then
+    raise exception 'cannot complete a booking with status %', v_row.status
+      using errcode = '22023';
+  end if;
+
+  update public.bookings
+     set status = 'completed',
+         usage_record = coalesce(nullif(btrim(coalesce(p_usage_record, '')), ''), usage_record),
+         actual_start_time = coalesce(p_actual_start_time, actual_start_time, v_row.start_time),
+         actual_end_time = coalesce(p_actual_end_time, actual_end_time, now())
+   where id = p_booking_id
+   returning * into v_row;
+
+  perform public._log_audit(v_row.lab_id, 'booking', p_booking_id, 'complete', '{}'::jsonb);
+  return v_row;
+end;
+$$;
+
+-- 4.4) approve_booking / deny_booking — for resources with approval_required
+create or replace function public.approve_booking(p_booking_id uuid, p_note text default null)
+returns public.bookings
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.bookings%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select * into v_row from public.bookings where id = p_booking_id;
+  if not found then
+    raise exception 'booking not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_admin(v_row.lab_id) then
+    raise exception 'only lab admins may approve bookings' using errcode = '42501';
+  end if;
+  if v_row.status <> 'requested' then
+    raise exception 'only requested bookings can be approved' using errcode = '22023';
+  end if;
+
+  update public.bookings
+     set status = 'approved',
+         approval_user_id = v_uid,
+         notes = coalesce(nullif(btrim(coalesce(p_note, '')), ''), notes)
+   where id = p_booking_id
+   returning * into v_row;
+
+  perform public._log_audit(v_row.lab_id, 'booking', p_booking_id, 'approve', '{}'::jsonb);
+  return v_row;
+end;
+$$;
+
+create or replace function public.deny_booking(p_booking_id uuid, p_note text)
+returns public.bookings
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.bookings%rowtype;
+  v_note text := nullif(btrim(coalesce(p_note, '')), '');
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if v_note is null then
+    raise exception 'a denial note is required' using errcode = '22023';
+  end if;
+
+  select * into v_row from public.bookings where id = p_booking_id;
+  if not found then
+    raise exception 'booking not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_admin(v_row.lab_id) then
+    raise exception 'only lab admins may deny bookings' using errcode = '42501';
+  end if;
+  if v_row.status <> 'requested' then
+    raise exception 'only requested bookings can be denied' using errcode = '22023';
+  end if;
+
+  update public.bookings
+     set status = 'denied',
+         approval_user_id = v_uid,
+         notes = v_note
+   where id = p_booking_id
+   returning * into v_row;
+
+  perform public._log_audit(v_row.lab_id, 'booking', p_booking_id, 'deny',
+    jsonb_build_object('note', v_note));
+  return v_row;
+end;
+$$;
+
+-- 4.5) schedule_planned_task — converts a planned task to a calendar event
+-- and/or booking. Either p_event_args or p_booking_args (or both) must be set.
+create or replace function public.schedule_planned_task(
+  p_task_id uuid,
+  p_event_args jsonb default null,
+  p_booking_args jsonb default null
+)
+returns public.planned_tasks
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_task public.planned_tasks%rowtype;
+  v_event public.calendar_events%rowtype;
+  v_booking public.bookings%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if p_event_args is null and p_booking_args is null then
+    raise exception 'must supply event or booking args' using errcode = '22023';
+  end if;
+
+  select * into v_task from public.planned_tasks where id = p_task_id;
+  if not found then
+    raise exception 'planned task not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_member(v_task.lab_id) then
+    raise exception 'not a member of this lab' using errcode = '42501';
+  end if;
+  if v_task.status in ('scheduled', 'completed', 'cancelled') then
+    raise exception 'task is already %', v_task.status using errcode = '22023';
+  end if;
+
+  if p_event_args is not null then
+    insert into public.calendar_events (
+      lab_id, title, description, event_type, start_time, end_time,
+      location, linked_project_id, linked_protocol_id, linked_task_id,
+      organizer_user_id, status, notes, created_by, updated_by
+    ) values (
+      v_task.lab_id,
+      coalesce(nullif(btrim(coalesce(p_event_args->>'title', '')), ''), v_task.title),
+      coalesce(p_event_args->>'description', v_task.description),
+      coalesce(p_event_args->>'event_type', 'experiment'),
+      (p_event_args->>'start_time')::timestamptz,
+      (p_event_args->>'end_time')::timestamptz,
+      nullif(btrim(coalesce(p_event_args->>'location', '')), ''),
+      coalesce(nullif(p_event_args->>'project_id', '')::uuid, v_task.project_id),
+      coalesce(nullif(p_event_args->>'protocol_id', '')::uuid, v_task.protocol_id),
+      v_task.id,
+      v_uid,
+      'scheduled',
+      nullif(btrim(coalesce(p_event_args->>'notes', '')), ''),
+      v_uid,
+      v_uid
+    )
+    returning * into v_event;
+  end if;
+
+  if p_booking_args is not null then
+    v_booking := public.book_resource(
+      (p_booking_args->>'resource_id')::uuid,
+      (p_booking_args->>'start_time')::timestamptz,
+      (p_booking_args->>'end_time')::timestamptz,
+      coalesce(nullif(btrim(coalesce(p_booking_args->>'title', '')), ''), v_task.title),
+      coalesce(p_booking_args->>'booking_type', 'experiment'),
+      coalesce(nullif(p_booking_args->>'project_id', '')::uuid, v_task.project_id),
+      coalesce(nullif(p_booking_args->>'protocol_id', '')::uuid, v_task.protocol_id),
+      v_task.id,
+      v_event.id,
+      nullif(btrim(coalesce(p_booking_args->>'purpose', '')), ''),
+      nullif(p_booking_args->>'sample_count', '')::integer,
+      nullif(btrim(coalesce(p_booking_args->>'notes', '')), '')
+    );
+  end if;
+
+  update public.planned_tasks
+     set status = 'scheduled',
+         scheduled_event_id = coalesce(v_event.id, scheduled_event_id),
+         scheduled_booking_id = coalesce(v_booking.id, scheduled_booking_id),
+         updated_by = v_uid
+   where id = p_task_id
+   returning * into v_task;
+
+  perform public._log_audit(v_task.lab_id, 'planned_task', p_task_id, 'schedule',
+    jsonb_build_object('event_id', v_event.id, 'booking_id', v_booking.id));
+  return v_task;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5) Grants
+-- ---------------------------------------------------------------------------
+
+grant execute on function public.book_resource(
+  uuid, timestamptz, timestamptz, text, text, uuid, uuid, uuid, uuid, text, integer, text
+) to authenticated;
+grant execute on function public.cancel_booking(uuid, text)            to authenticated;
+grant execute on function public.complete_booking(uuid, text, timestamptz, timestamptz)
+  to authenticated;
+grant execute on function public.approve_booking(uuid, text)           to authenticated;
+grant execute on function public.deny_booking(uuid, text)              to authenticated;
+grant execute on function public.schedule_planned_task(uuid, jsonb, jsonb)
+  to authenticated;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "apps/project-manager" },
     { "path": "apps/supply-manager" },
     { "path": "apps/funding-manager" },
+    { "path": "apps/scheduler" },
     { "path": "apps/account" }
   ]
 }


### PR DESCRIPTION
## Summary

Foundation PR for the **Scheduler** module per `docs/scheduler.txt`. Lands the lab-scoped schema with RLS, the lifecycle RPCs, and a Vite app shell wired to the existing `calendar` sidebar slot. The four views (Calendar / Bookings / Unscheduled / Resources) are placeholder cards in this PR — the view UIs and modals are the next session's work, against the typed adapter + workspace hook this PR adds.

Funding Manager (Stage 4d) is paused; `docs/next-stage.md` is rewritten so 4e is the active plan.

## What changed

### Schema — `supabase/migrations/20260501000000_scheduler.sql`
- Four lab-scoped tables behind RLS:
  - `resources` — equipment registry (category, location, availability_status, booking_mode `hard_booking | soft_booking`, booking_policy `open | approval_required | admin_only`, setup/cleanup buffers, min/max duration, required_training, responsible_person, optional `linked_protocol_id`).
  - `calendar_events` — events with `event_type`, start/end window check constraint, optional links to project / protocol / planned task, organizer + participant array, visibility, `recurrence_rule` text + `recurrence_exceptions` array, status.
  - `bookings` — resource reservations (FK to resource + optional calendar event / planned task / project / protocol, copied buffers, booking_type, status, actual start/end + usage_record).
  - `planned_tasks` — unscheduled work queue (priority, status, `required_resource_ids` array, back-links `scheduled_event_id` / `scheduled_booking_id`).
- `find_booking_conflicts(resource_id, start, end, exclude_booking_id)` helper — `tstzrange` overlap with the resource's setup/cleanup buffers extending the window on both sides; soft bookings short-circuit and return no conflicts.
- Lifecycle RPCs (SECURITY DEFINER + `_log_audit`): `book_resource` (server-side conflict + policy + duration + availability_status check; auto-routes to `requested` for `approval_required` resources), `cancel_booking`, `complete_booking`, `approve_booking`, `deny_booking` (note required), `schedule_planned_task` (converts a task into a calendar event and/or booking, links the IDs back, marks status `scheduled`).
- RLS: lab members read all four tables. `resources` admin-write only. `calendar_events` and `planned_tasks` allow members to create / edit / delete their own (organizer / created_by / assigned_user_id); admins manage all. Bookings allow members to create/edit non-terminal own; admins override.

### App — `apps/scheduler/`
- New Vite app on port 5177, `VITE_BASE_PATH=/ILM/scheduler/`.
- `App.tsx` renders inside the shared `<LabShell>` (active nav id `calendar`) with a four-tab subbar (Calendar / Bookings / Unscheduled / Resources) and Lab-context / Coming-up / Schema-status placeholder cards.
- `src/lib/cloudAdapter.ts` — typed records for every table, plus thin wrappers for the six RPCs and direct CRUD for the non-state-machine paths.
- `src/lib/useSchedulerWorkspace.ts` — `{ resources, events, bookings, plannedTasks, projects, protocols }` snapshot loader, identity-aware mutation wrappers, `await hydrate()` after each call. Drop-in for the views in the next session.

### Cross-app wiring
- `packages/ui/src/LabShell.tsx` — `calendar` slot was a `tone: "soon"` hash placeholder; now resolves to the new app via `appUrl("scheduler/", base)`.
- `packages/ui/src/AppSwitcher.tsx` — `scheduler` added to `AppId`, `APP_LINKS`, and `APP_ROOT_SEGMENTS`.
- `packages/ui/src/auth/LabPicker.tsx` and `packages/ui/src/admin/LabShareLinkPanel.tsx` — `scheduler` added to the known-app-roots sets so cross-app URL resolution stays correct from the new subpath.
- `.github/workflows/deploy-protocol-manager-pages.yml` — builds `@ilm/scheduler` and copies its dist to `.pages-dist/scheduler/`.
- `tsconfig.json` — references the new package.

### Docs
- `docs/features.md` — adds a **Scheduler (Stage 4e — foundation)** section describing the schema, RPCs, and shell scaffold; calls out that the four views are still placeholder cards.
- `docs/next-stage.md` — rewritten. Stage 4e is the active plan with view-by-view steps; Funding Manager moves to Deferred.

## Reviewer notes

- The conflict-detection RPC uses Postgres `tstzrange` overlap with `make_interval(mins => buffer)` — admins booking a hard-booking resource bypass the conflict block, matching the spec.
- Visibility column is stored on `calendar_events` but not enforced beyond lab membership in v1; that tightening is called out as a tradeoff in `docs/next-stage.md`.
- No frontend JSON migration — this is a brand-new module, no localStorage data to import.
- Existing apps are untouched apart from the shared UI package wiring (calendar nav slot now active, app-roots sets extended).

## Test plan

- [ ] `npm run typecheck` — clean across all 11 workspaces ✅ (verified locally).
- [ ] `npm run build -w @ilm/scheduler` — produces a working dist ✅ (verified locally; ~360 KB JS / 37 KB CSS).
- [ ] `npm run build` — full monorepo build still passes (only pre-existing `lucide-react` "use client" rollup warnings from other apps).
- [ ] After merge: deploy workflow publishes `/ILM/scheduler/`, the **Calendar** sidebar item now lights up and links to the new app instead of the `#/calendar` hash placeholder.
- [ ] Run the new migration against the dev Supabase project; verify RLS lets a lab member create a planned task and book a resource, and that an overlapping hard booking on the same resource is rejected with `errcode 23P01`.
- [ ] Verify `schedule_planned_task` with both `p_event_args` and `p_booking_args` populates `scheduled_event_id` + `scheduled_booking_id` on the task and links the booking to the new event via `calendar_event_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)