### PR TITLE
Scheduler: ship a favicon to silence the root /favicon.ico fallback

### DIFF
--- a/apps/scheduler/index.html
+++ b/apps/scheduler/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <title>Scheduler</title>
   </head>
   <body>

--- a/apps/scheduler/public/favicon.svg
+++ b/apps/scheduler/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="3" y="6" width="26" height="22" rx="3" fill="#0f6f8a"/>
+  <rect x="3" y="6" width="26" height="6" fill="#0a4d62"/>
+  <rect x="9" y="3" width="2" height="6" rx="1" fill="#0a4d62"/>
+  <rect x="21" y="3" width="2" height="6" rx="1" fill="#0a4d62"/>
+  <rect x="7"  y="15" width="5" height="3" rx="0.5" fill="#ffffff" opacity="0.92"/>
+  <rect x="14" y="15" width="5" height="3" rx="0.5" fill="#ffffff" opacity="0.55"/>
+  <rect x="21" y="15" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.55"/>
+  <rect x="7"  y="20" width="5" height="3" rx="0.5" fill="#ffffff" opacity="0.55"/>
+  <rect x="14" y="20" width="11" height="3" rx="0.5" fill="#ffd166"/>
+</svg>


### PR DESCRIPTION
## Summary

Reported in DevTools after PR #60 shipped:

```
{"message":"No API key found in request","hint":"No \`apikey\` request header or url param was found."}
```

## Root cause

The Scheduler `index.html` had no `<link rel="icon">`, so the browser auto-requests `/favicon.ico` from the document root. Under the deploy at `/ILM/scheduler/`, that resolves outside the app's base path and hits whatever happens to be at the site root favicon URL — in the reporter's environment it landed on a Supabase REST endpoint, which returns the JSON error above.

## Fix

- Add a small SVG favicon at `apps/scheduler/public/favicon.svg`. Vite copies the `public/` directory verbatim to the dist root, so the file lands at `/ILM/scheduler/favicon.svg` in production.
- Add `<link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />` to `apps/scheduler/index.html`. Vite expands `%BASE_URL%` at build time — `/favicon.svg` in dev, `/ILM/scheduler/favicon.svg` in production.

## Verification

```
npm run build -w @ilm/scheduler
# emits:
# <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
# (or /ILM/scheduler/favicon.svg under VITE_BASE_PATH=/ILM/scheduler/)
# dist/favicon.svg is present
```

## Note for the other apps

Funding / Project / Protocol / Supply / Account have the same gap — none of them ship a favicon either. They likely silently fall through to the GitHub Pages 404 SPA fallback (the Account `index.html`) which the browser ignores as an icon. The Supabase JSON only surfaces in environments where the site root resolves to Supabase. Worth a follow-up to add favicons across the board, but out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)