### PR TITLE
Scheduler: fix protocols hydration query (column is title, not name)

### DIFF
--- a/apps/scheduler/src/lib/cloudAdapter.ts
+++ b/apps/scheduler/src/lib/cloudAdapter.ts
@@ -234,7 +234,9 @@ export async function listSchedulerWorkspace(
       .eq("lab_id", labId)
       .order("created_at", { ascending: false }),
     client().from("projects").select("id, name").eq("lab_id", labId).order("name"),
-    client().from("protocols").select("id, name").eq("lab_id", labId).order("name"),
+    // PostgREST alias `name:title` returns the protocols.title column under
+    // the key `name` so ProtocolOption keeps a single shape across modules.
+    client().from("protocols").select("id, name:title").eq("lab_id", labId).order("title"),
   ]);
 
   if (resourcesResult.error) throw resourcesResult.error;


### PR DESCRIPTION
## Summary

The Scheduler workspace hydration was selecting `protocols.name`, but the table has no `name` column — it's `title` (per the Stage 3 init migration). Every load of the Scheduler app fired a 400 from PostgREST with `error=42703` (undefined_column).

The earlier "No API key found in request" body that was reported turned out to be unrelated — the actual Network response that surfaces in the deployed app is a column-not-found error, with `apikey` and `Authorization` headers both correctly attached.

## Fix

One-line change in `apps/scheduler/src/lib/cloudAdapter.ts`:

```ts
// before
client().from("protocols").select("id, name").eq("lab_id", labId).order("name"),

// after
client().from("protocols").select("id, name:title").eq("lab_id", labId).order("title"),
```

PostgREST's `name:title` alias returns the `title` column under the key `name` in the response, so the shared `ProtocolOption` shape `{ id, name }` is preserved and no form modal needs to change.

## Verification

- `npm run build -w @ilm/scheduler` — passes.
- After deploy: hitting `/ILM/scheduler/` should no longer fire a 400 against `/rest/v1/protocols`. The "Linked protocol" dropdowns in EventForm / BookingForm / PlannedTaskForm / ResourceForm will populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)