### PR TITLE
Fix Scheduler EventFormModal: id collision blocked submit

### DIFF
--- a/apps/scheduler/src/components/EventFormModal.tsx
+++ b/apps/scheduler/src/components/EventFormModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import {
   Button,
   ConfirmDialog,
@@ -143,10 +143,6 @@ export const EventFormModal = ({
   }, [open, initial, initialStartIso, initialEndIso]);
 
   const isEdit = initial !== null;
-  const titleId = useMemo(
-    () => `event-form-${initial?.id ?? "new"}`,
-    [initial?.id]
-  );
 
   const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setState((prev) => ({ ...prev, [key]: value }));
@@ -221,7 +217,6 @@ export const EventFormModal = ({
       onClose={busy ? () => {} : onClose}
       title={isEdit ? "Edit event" : "New event"}
       width="wide"
-      labelledBy={titleId}
       actions={
         <>
           {isEdit && onDelete ? (
@@ -239,7 +234,7 @@ export const EventFormModal = ({
           <Button
             variant="primary"
             type="submit"
-            form={titleId}
+            form="event-form"
             disabled={busy}
           >
             {isEdit ? "Save changes" : "Create event"}
@@ -247,7 +242,7 @@ export const EventFormModal = ({
         </>
       }
     >
-      <form id={titleId} className="sch-form" onSubmit={handleSubmit}>
+      <form id="event-form" className="sch-form" onSubmit={handleSubmit}>
         {error ? <InlineError>{error}</InlineError> : null}
         <FormField label="Title">
           <Input


### PR DESCRIPTION
## Summary

Reported: clicking **Create event** in the Calendar view's new-event modal had no effect — info filled in, button click silent, modal stayed open.

## Root cause

`EventFormModal` was passing the same id (`event-form-<initialId|new>`) to three places:

1. `<Modal labelledBy={titleId}>` — Modal renders that as `<h2 id={labelledBy}>`.
2. `<form id={titleId}>` — the actual form element.
3. `<Button type="submit" form={titleId}>` — the submit-button-to-form association.

Two DOM nodes (the `<h2>` title and the `<form>`) ended up sharing the same `id`. The browser resolves `button[form="…"]` via `document.getElementById`, which returns the **first** match in DOM order — the `<h2>` — so the submit button found no form and clicking it did nothing.

The other four modals in this app (`BookingFormModal`, `PlannedTaskFormModal`, `ResourceFormModal`, `ScheduleTaskModal`) don't pass `labelledBy` and use static form ids, which is why only Calendar event creation broke.

## Fix

Drop `labelledBy` (the Modal already exposes the title via `aria-modal` + the rendered `<h2>` text), drop the unused `useMemo` for the dynamic id, and switch to a fixed `event-form` id — matching the other modals' pattern.

## Verification

- `npm run build -w @ilm/scheduler` — passes.
- After deploy: the Calendar tab's **+ New event** flow saves and the modal closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)