### PR TITLE
Settings: editable profile + headshot, owner-only lab rename

### DIFF
--- a/apps/account/src/lib/dashboardData.ts
+++ b/apps/account/src/lib/dashboardData.ts
@@ -40,7 +40,12 @@ export type TeamStats = {
   owners: number;
   admins: number;
   members: number;
-  recentAvatars: { id: string; label: string; email: string | null }[];
+  recentAvatars: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    headshotUrl: string | null;
+  }[];
 };
 
 export type ActivityEntry = {
@@ -211,7 +216,14 @@ export const useDashboardData = (labId: string | null): DashboardData => {
         inventory.criticalLow = seenLow.size;
 
         // Team
-        type MemberRow = { user_id: string; role: "owner" | "admin" | "member"; display_name: string | null; email: string | null; joined_at: string };
+        type MemberRow = {
+          user_id: string;
+          role: "owner" | "admin" | "member";
+          display_name: string | null;
+          email: string | null;
+          headshot_url: string | null;
+          joined_at: string;
+        };
         const memberRows = ((membersRes.data as MemberRow[] | null) ?? []).filter(Boolean);
         const team: TeamStats = {
           total: memberRows.length,
@@ -220,8 +232,9 @@ export const useDashboardData = (labId: string | null): DashboardData => {
           members: memberRows.filter((m) => m.role === "member").length,
           recentAvatars: memberRows.slice(0, 7).map((m) => ({
             id: m.user_id,
-            label: (m.display_name || m.email || "?").slice(0, 2).toUpperCase(),
+            name: m.display_name,
             email: m.email,
+            headshotUrl: m.headshot_url,
           })),
         };
 

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -928,6 +928,23 @@
 .acct-text-button:hover:not(:disabled) { background: var(--ilm-surface-soft); }
 .acct-text-button:disabled { opacity: 0.5; cursor: not-allowed; }
 
+.acct-profile-edit {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.acct-profile-edit-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+  flex: 1;
+}
+.acct-profile-edit-actions small {
+  font-size: 0.75rem;
+}
+
 .acct-side-profile {
   display: grid;
   gap: 0.2rem;

--- a/apps/account/src/views/OverviewView.tsx
+++ b/apps/account/src/views/OverviewView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useAuth } from "@ilm/ui";
+import { Avatar, useAuth } from "@ilm/ui";
 import { useDashboardData, type ProjectStateCounts, type ProtocolStats, type InventoryStats, type TeamStats } from "../lib/dashboardData";
 
 const formatNumber = (n: number) => new Intl.NumberFormat().format(n);
@@ -424,9 +424,7 @@ const TeamCard = ({ team }: { team: TeamStats }) => (
     </header>
     <div className="ovw-avatars">
       {team.recentAvatars.map((m) => (
-        <span className="ovw-avatar" key={m.id} title={m.email ?? ""}>
-          {m.label}
-        </span>
+        <Avatar key={m.id} size="md" name={m.name} email={m.email} url={m.headshotUrl} />
       ))}
       {team.total > team.recentAvatars.length ? (
         <span className="ovw-avatar ovw-avatar--more">+{team.total - team.recentAvatars.length}</span>

--- a/apps/account/src/views/SettingsView.tsx
+++ b/apps/account/src/views/SettingsView.tsx
@@ -1,4 +1,5 @@
-import { useAuth } from "@ilm/ui";
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
+import { Avatar, useAuth } from "@ilm/ui";
 
 type MembershipTier = "owner" | "admin" | "member";
 
@@ -14,11 +15,142 @@ const TIER_DESCRIPTION: Record<MembershipTier, string> = {
   member: "Read-only in the lab management surface.",
 };
 
+// Headshots are stored inline as data URLs. We downsample any uploaded
+// image to a small square so the encoded payload stays a few KB.
+const HEADSHOT_PX = 96;
+const MAX_HEADSHOT_BYTES = 64 * 1024;
+
+const errorMessage = (err: unknown) => (err instanceof Error ? err.message : "Unexpected error");
+
+const fileToDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read file"));
+    reader.readAsDataURL(file);
+  });
+
+const downscaleToDataUrl = (dataUrl: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = HEADSHOT_PX;
+      canvas.height = HEADSHOT_PX;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas not supported"));
+        return;
+      }
+      const side = Math.min(img.width, img.height);
+      const sx = (img.width - side) / 2;
+      const sy = (img.height - side) / 2;
+      ctx.drawImage(img, sx, sy, side, side, 0, 0, HEADSHOT_PX, HEADSHOT_PX);
+      // Try PNG first; fall back to JPEG if too large.
+      let out = canvas.toDataURL("image/png");
+      if (out.length > MAX_HEADSHOT_BYTES) {
+        out = canvas.toDataURL("image/jpeg", 0.85);
+      }
+      resolve(out);
+    };
+    img.onerror = () => reject(new Error("Could not decode image"));
+    img.src = dataUrl;
+  });
+
 export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
-  const { activeLab, profile, user, signOut } = useAuth();
+  const { activeLab, profile, user, signOut, updateProfile, renameLab, refreshLabs } = useAuth();
   const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
-  const displayName = profile?.display_name ?? user?.email ?? "Signed in";
+  const isOwner = tier === "owner";
   const email = profile?.email ?? user?.email ?? "";
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Profile editor state
+  const [displayName, setDisplayName] = useState(profile?.display_name ?? "");
+  const [headshotUrl, setHeadshotUrl] = useState<string | null>(profile?.headshot_url ?? null);
+  const [profileBusy, setProfileBusy] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [profileNotice, setProfileNotice] = useState<string | null>(null);
+
+  // Lab editor state
+  const [labName, setLabName] = useState(activeLab?.name ?? "");
+  const [labBusy, setLabBusy] = useState(false);
+  const [labError, setLabError] = useState<string | null>(null);
+  const [labNotice, setLabNotice] = useState<string | null>(null);
+
+  // Re-sync local state when the underlying profile/lab changes.
+  useEffect(() => {
+    setDisplayName(profile?.display_name ?? "");
+    setHeadshotUrl(profile?.headshot_url ?? null);
+  }, [profile?.display_name, profile?.headshot_url]);
+
+  useEffect(() => {
+    setLabName(activeLab?.name ?? "");
+    setLabError(null);
+    setLabNotice(null);
+  }, [activeLab?.id, activeLab?.name]);
+
+  const profileDirty =
+    (displayName.trim() || null) !== (profile?.display_name?.trim() || null) ||
+    (headshotUrl ?? null) !== (profile?.headshot_url ?? null);
+
+  const labDirty = labName.trim() !== (activeLab?.name ?? "").trim() && labName.trim().length > 0;
+
+  const handlePickHeadshot = () => fileInputRef.current?.click();
+
+  const handleHeadshotChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setProfileError(null);
+    setProfileNotice(null);
+    try {
+      const raw = await fileToDataUrl(file);
+      const small = await downscaleToDataUrl(raw);
+      setHeadshotUrl(small);
+    } catch (err) {
+      setProfileError(errorMessage(err));
+    }
+  };
+
+  const handleClearHeadshot = () => {
+    setProfileError(null);
+    setProfileNotice(null);
+    setHeadshotUrl(null);
+  };
+
+  const handleSaveProfile = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setProfileError(null);
+    setProfileNotice(null);
+    setProfileBusy(true);
+    try {
+      await updateProfile({ display_name: displayName, headshot_url: headshotUrl });
+      setProfileNotice("Profile saved.");
+    } catch (err) {
+      setProfileError(errorMessage(err));
+    } finally {
+      setProfileBusy(false);
+    }
+  };
+
+  const handleRenameLab = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!activeLab) return;
+    const next = labName.trim();
+    if (!next || next === activeLab.name) return;
+    setLabError(null);
+    setLabNotice(null);
+    setLabBusy(true);
+    try {
+      await renameLab(activeLab.id, next);
+      await refreshLabs();
+      setLabNotice("Lab renamed.");
+    } catch (err) {
+      setLabError(errorMessage(err));
+    } finally {
+      setLabBusy(false);
+    }
+  };
 
   return (
     <div className="acct-settings-page">
@@ -26,18 +158,89 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
         <div className="acct-card-header">
           <div>
             <h2>Profile</h2>
-            <p>Your personal account info as visible to lab co-workers.</p>
+            <p>Your name and headshot as visible to lab co-workers.</p>
           </div>
         </div>
-        <div className="acct-side-profile">
-          <strong>{displayName}</strong>
-          <span>{email}</span>
-        </div>
-        <div className="acct-row-actions">
-          <button type="button" className="acct-danger-button" onClick={() => void signOut()}>
-            Sign out
-          </button>
-        </div>
+
+        <form className="acct-form" onSubmit={handleSaveProfile}>
+          <div className="acct-profile-edit">
+            <Avatar
+              size="lg"
+              name={displayName || profile?.display_name}
+              email={email}
+              url={headshotUrl}
+            />
+            <div className="acct-profile-edit-actions">
+              <button
+                type="button"
+                className="acct-text-button"
+                onClick={handlePickHeadshot}
+                disabled={profileBusy}
+              >
+                {headshotUrl ? "Replace headshot…" : "Upload headshot…"}
+              </button>
+              {headshotUrl ? (
+                <button
+                  type="button"
+                  className="acct-text-button"
+                  onClick={handleClearHeadshot}
+                  disabled={profileBusy}
+                >
+                  Remove
+                </button>
+              ) : null}
+              <small style={{ color: "var(--ilm-muted)" }}>
+                Square images work best. We resize to {HEADSHOT_PX}×{HEADSHOT_PX}. Leave empty
+                to show initials only.
+              </small>
+            </div>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleHeadshotChange}
+            style={{ display: "none" }}
+          />
+
+          <label className="acct-field">
+            <span>Display name</span>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              placeholder={email || "Your name"}
+              maxLength={120}
+              disabled={profileBusy}
+            />
+          </label>
+
+          <label className="acct-field">
+            <span>Email</span>
+            <input type="email" value={email} disabled readOnly />
+          </label>
+
+          {profileError ? <p className="acct-error">{profileError}</p> : null}
+          {profileNotice ? <small style={{ color: "var(--ilm-viridian)" }}>{profileNotice}</small> : null}
+
+          <div className="acct-row-actions">
+            <button
+              type="submit"
+              className="acct-primary-button"
+              disabled={profileBusy || !profileDirty}
+            >
+              {profileBusy ? "Saving…" : "Save profile"}
+            </button>
+            <button
+              type="button"
+              className="acct-danger-button"
+              onClick={() => void signOut()}
+              disabled={profileBusy}
+            >
+              Sign out
+            </button>
+          </div>
+        </form>
       </section>
 
       <section className="acct-card">
@@ -67,10 +270,42 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
         <div className="acct-card-header">
           <div>
             <h2>Lab settings</h2>
-            <p>Lab name, slug, and ownership transfer arrive in a future stage.</p>
+            <p>
+              {isOwner
+                ? "Rename your lab. Only the owner can change this."
+                : "Only the lab owner can change the lab name."}
+            </p>
           </div>
         </div>
-        <p className="acct-empty">Nothing configurable here yet.</p>
+        {!activeLab ? (
+          <p className="acct-empty">No lab selected.</p>
+        ) : (
+          <form className="acct-form" onSubmit={handleRenameLab}>
+            <label className="acct-field">
+              <span>Lab name</span>
+              <input
+                type="text"
+                value={labName}
+                onChange={(event) => setLabName(event.target.value)}
+                maxLength={120}
+                disabled={!isOwner || labBusy}
+              />
+            </label>
+            {labError ? <p className="acct-error">{labError}</p> : null}
+            {labNotice ? <small style={{ color: "var(--ilm-viridian)" }}>{labNotice}</small> : null}
+            {isOwner ? (
+              <div className="acct-row-actions">
+                <button
+                  type="submit"
+                  className="acct-primary-button"
+                  disabled={labBusy || !labDirty}
+                >
+                  {labBusy ? "Saving…" : "Rename lab"}
+                </button>
+              </div>
+            ) : null}
+          </form>
+        )}
       </section>
     </div>
   );

--- a/packages/ui/src/admin/LabMembersPanel.tsx
+++ b/packages/ui/src/admin/LabMembersPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { Avatar } from "../primitives/Avatar";
 import {
   inviteMemberToLab,
   listLabInvitations,
@@ -134,10 +135,18 @@ export const LabMembersPanel = ({
               const isBusy = busyUserId === member.user_id;
               return (
                 <li className="ilm-admin-list-item" key={member.user_id}>
-                  <div className="ilm-admin-list-copy">
-                    <strong>{label}</strong>
-                    <span>{member.email || "No email available"}</span>
-                    <small>Joined {formatJoinedAt(member.joined_at)}{isSelf ? " • You" : ""}</small>
+                  <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", minWidth: 0 }}>
+                    <Avatar
+                      size="md"
+                      name={member.display_name}
+                      email={member.email}
+                      url={member.headshot_url}
+                    />
+                    <div className="ilm-admin-list-copy">
+                      <strong>{label}</strong>
+                      <span>{member.email || "No email available"}</span>
+                      <small>Joined {formatJoinedAt(member.joined_at)}{isSelf ? " • You" : ""}</small>
+                    </div>
                   </div>
                   <div className="ilm-admin-actions">
                     <span className={`ilm-admin-badge ilm-admin-badge-${member.role}`}>{member.role}</span>

--- a/packages/ui/src/admin/api.ts
+++ b/packages/ui/src/admin/api.ts
@@ -6,6 +6,7 @@ export type LabMemberRecord = {
   role: MembershipRole;
   display_name: string | null;
   email: string | null;
+  headshot_url: string | null;
   joined_at: string;
 };
 

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -30,9 +30,13 @@ type AuthContextValue = {
   signOut: () => Promise<void>;
   sendPasswordReset: (email: string, redirectTo?: string) => Promise<void>;
 
+  // Profile actions
+  updateProfile: (changes: { display_name?: string | null; headshot_url?: string | null }) => Promise<Profile>;
+
   // Lab actions
   selectLab: (labId: string | null) => void;
   createLab: (name: string, slug?: string) => Promise<LabWithRole>;
+  renameLab: (labId: string, name: string) => Promise<LabWithRole>;
   refreshLabs: () => Promise<void>;
 };
 
@@ -79,7 +83,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     async (userId: string): Promise<Profile | null> => {
       const { data, error: err } = await supabase
         .from("profiles")
-        .select("id, display_name, email")
+        .select("id, display_name, email, headshot_url")
         .eq("id", userId)
         .maybeSingle();
       if (err) throw err;
@@ -285,6 +289,61 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     setActiveLabId(labId);
   }, []);
 
+  const updateProfile = useCallback(
+    async (changes: { display_name?: string | null; headshot_url?: string | null }): Promise<Profile> => {
+      if (!user) throw new Error("Not signed in");
+      setError(null);
+      const patch: Record<string, unknown> = {};
+      if (Object.prototype.hasOwnProperty.call(changes, "display_name")) {
+        const next = changes.display_name;
+        patch.display_name = typeof next === "string" ? (next.trim() || null) : null;
+      }
+      if (Object.prototype.hasOwnProperty.call(changes, "headshot_url")) {
+        patch.headshot_url = changes.headshot_url ?? null;
+      }
+      if (Object.keys(patch).length === 0) {
+        if (!profile) throw new Error("Profile not loaded");
+        return profile;
+      }
+      const { data, error: err } = await supabase
+        .from("profiles")
+        .update(patch)
+        .eq("id", user.id)
+        .select("id, display_name, email, headshot_url")
+        .single();
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+      const next = data as Profile;
+      setProfile(next);
+      return next;
+    },
+    [profile, supabase, user]
+  );
+
+  const renameLab = useCallback(
+    async (labId: string, name: string): Promise<LabWithRole> => {
+      if (!user) throw new Error("Not signed in");
+      setError(null);
+      const { data, error: err } = await supabase
+        .rpc("rename_lab", { p_lab_id: labId, p_name: name })
+        .maybeSingle();
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+      if (!data) throw new Error("Rename failed");
+      const lab = data as Omit<LabWithRole, "role">;
+      setLabs((prev) =>
+        prev.map((entry) => (entry.id === lab.id ? { ...entry, ...lab } : entry))
+      );
+      const existing = labs.find((entry) => entry.id === lab.id);
+      return { ...lab, role: existing?.role ?? "owner" };
+    },
+    [labs, supabase, user]
+  );
+
   const value: AuthContextValue = {
     status,
     session,
@@ -297,8 +356,10 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     signUp,
     signOut,
     sendPasswordReset,
+    updateProfile,
     selectLab,
     createLab,
+    renameLab,
     refreshLabs,
   };
 

--- a/packages/ui/src/auth/types.ts
+++ b/packages/ui/src/auth/types.ts
@@ -4,6 +4,7 @@ export type Profile = {
   id: string;
   display_name: string | null;
   email: string | null;
+  headshot_url: string | null;
 };
 
 export type Lab = {

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -1,0 +1,46 @@
+import type { CSSProperties } from "react";
+
+export type AvatarSize = "sm" | "md" | "lg";
+
+export type AvatarProps = {
+  name?: string | null;
+  email?: string | null;
+  url?: string | null;
+  size?: AvatarSize;
+  title?: string;
+  className?: string;
+  style?: CSSProperties;
+};
+
+const initialsFor = (name?: string | null, email?: string | null): string => {
+  const source = (name && name.trim()) || (email && email.trim()) || "";
+  if (!source) return "?";
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+};
+
+export const Avatar = ({ name, email, url, size = "md", title, className, style }: AvatarProps) => {
+  const label = initialsFor(name, email);
+  const tooltip = title ?? name ?? email ?? "";
+  const classes = ["rl-avatar", `rl-avatar--${size}`, className].filter(Boolean).join(" ");
+  if (url) {
+    return (
+      <span className={classes} style={style} title={tooltip} aria-label={tooltip || undefined}>
+        <img src={url} alt="" className="rl-avatar-img" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`${classes} rl-avatar--initials`}
+      style={style}
+      title={tooltip}
+      aria-label={tooltip || undefined}
+    >
+      {label}
+    </span>
+  );
+};

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,3 +1,4 @@
+export { Avatar, type AvatarProps, type AvatarSize } from "./Avatar";
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
 export {
   FormField,

--- a/packages/ui/src/primitives/primitives.css
+++ b/packages/ui/src/primitives/primitives.css
@@ -751,3 +751,50 @@
     margin-left: 0;
   }
 }
+
+/* ------------------------------------------------------------
+   Avatar (.rl-avatar)
+   Sizes: sm / md / lg
+   Renders an image when `url` is set; otherwise letter initials.
+   ------------------------------------------------------------ */
+.rl-avatar {
+  --rl-avatar-size: 2rem;
+  --rl-avatar-font: 0.72rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--rl-avatar-size);
+  height: var(--rl-avatar-size);
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--rl-soft, #eef2ee);
+  color: var(--rl-ink, #2a2f2a);
+  border: 1px solid var(--rl-line, rgba(0, 0, 0, 0.08));
+  font-family: var(--rl-font-display);
+  font-size: var(--rl-avatar-font);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  user-select: none;
+}
+.rl-avatar--sm {
+  --rl-avatar-size: 1.5rem;
+  --rl-avatar-font: 0.62rem;
+}
+.rl-avatar--md {
+  --rl-avatar-size: 2rem;
+  --rl-avatar-font: 0.72rem;
+}
+.rl-avatar--lg {
+  --rl-avatar-size: 4rem;
+  --rl-avatar-font: 1.1rem;
+}
+.rl-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.rl-avatar--initials {
+  text-transform: uppercase;
+}

--- a/supabase/migrations/20260501000000_profile_headshot_and_lab_rename.sql
+++ b/supabase/migrations/20260501000000_profile_headshot_and_lab_rename.sql
@@ -1,0 +1,100 @@
+-- Settings improvements:
+--   * Add profiles.headshot_url so users can attach a small avatar image
+--     (stored as a data URL — no Supabase Storage bucket needed).
+--   * Refresh list_lab_members to surface headshot_url to the client.
+--   * Add rename_lab RPC enforcing owner-only lab renames, since the
+--     existing RLS update policy permits admins as well.
+
+-- ---------------------------------------------------------------------------
+-- profiles.headshot_url
+-- ---------------------------------------------------------------------------
+
+alter table public.profiles
+  add column if not exists headshot_url text;
+
+-- ---------------------------------------------------------------------------
+-- list_lab_members: include headshot_url
+-- ---------------------------------------------------------------------------
+
+drop function if exists public.list_lab_members(uuid);
+
+create or replace function public.list_lab_members(p_lab_id uuid)
+returns table (
+  user_id uuid,
+  role text,
+  display_name text,
+  email text,
+  headshot_url text,
+  joined_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    m.user_id,
+    m.role,
+    p.display_name,
+    p.email,
+    p.headshot_url,
+    m.created_at as joined_at
+  from public.lab_memberships m
+  left join public.profiles p on p.id = m.user_id
+  where m.lab_id = p_lab_id
+    and public.is_lab_member(p_lab_id)
+  order by
+    case m.role
+      when 'owner' then 0
+      when 'admin' then 1
+      else 2
+    end,
+    coalesce(p.display_name, p.email, m.user_id::text);
+$$;
+
+grant execute on function public.list_lab_members(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- rename_lab: owner-only
+-- ---------------------------------------------------------------------------
+
+create or replace function public.rename_lab(p_lab_id uuid, p_name text)
+returns public.labs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_role text;
+  v_name text;
+  v_lab public.labs;
+begin
+  if v_uid is null then
+    raise exception 'Not authenticated' using errcode = '42501';
+  end if;
+
+  v_name := nullif(btrim(p_name), '');
+  if v_name is null then
+    raise exception 'Lab name cannot be empty' using errcode = '22023';
+  end if;
+
+  select role into v_role
+  from public.lab_memberships
+  where lab_id = p_lab_id and user_id = v_uid
+  limit 1;
+
+  if v_role is null or v_role <> 'owner' then
+    raise exception 'Only the lab owner can rename the lab' using errcode = '42501';
+  end if;
+
+  update public.labs
+  set name = v_name
+  where id = p_lab_id
+  returning * into v_lab;
+
+  return v_lab;
+end;
+$$;
+
+grant execute on function public.rename_lab(uuid, text) to authenticated;


### PR DESCRIPTION
## Summary
- Settings page rewrite: users can edit their **display name** and upload/remove a **headshot**; owners can **rename the active lab**.
- New Supabase migration adds `profiles.headshot_url`, expands the `list_lab_members` RPC, and adds a `rename_lab` RPC that enforces owner-only renames (existing RLS update policy permits admins too).
- New `<Avatar>` primitive in `@ilm/ui` (image when URL set, otherwise initials), wired into the Lab Members panel and the dashboard Team card.
- Headshots stored as small data URLs (resized client-side to 96×96 PNG ≤ 64 KB / JPEG fallback) to keep the static-frontend constraint — no Supabase Storage bucket required.

## Test plan
- [ ] Apply migration `20260501000000_profile_headshot_and_lab_rename.sql`
- [ ] Open `#/settings`, change display name → save → reload → name persists
- [ ] Upload a headshot → save → appears on dashboard Team card and Lab Members list
- [ ] Remove headshot → falls back to initials
- [ ] As lab owner: rename lab → activeLab name updates everywhere
- [ ] As admin/member: lab name field is disabled, no Save button
- [ ] Hard-refresh after deploy (Ctrl+Shift+R) before retesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)