### PR TITLE
Bookings: resource calendar + 30-min completed grace

### DIFF
--- a/apps/scheduler/src/components/BookingCalendarPanel.tsx
+++ b/apps/scheduler/src/components/BookingCalendarPanel.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  EmptyState,
+  FormField,
+  FormRow,
+  Panel,
+  SectionHeader,
+  Select,
+} from "@ilm/ui";
+import type { BookingRecord, ResourceRecord } from "../lib/cloudAdapter";
+import {
+  HOUR_MS,
+  addDays,
+  formatTime,
+  formatWeekLabel,
+  isToday,
+  startOfDay,
+  startOfWeek,
+} from "../lib/datetime";
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const VISIBLE_HOURS = Array.from({ length: 13 }, (_, i) => i + 7); // 07:00 – 19:00
+
+const minutesSinceMidnight = (d: Date) => d.getHours() * 60 + d.getMinutes();
+
+const INACTIVE_STATUSES = new Set<BookingRecord["status"]>([
+  "completed",
+  "cancelled",
+  "no_show",
+  "denied",
+]);
+
+const HIDDEN_STATUSES = new Set<BookingRecord["status"]>(["draft"]);
+
+interface PositionedBooking {
+  booking: BookingRecord;
+  start: Date;
+  end: Date;
+  day: number;
+  top: number;
+  height: number;
+}
+
+export interface BookingCalendarPanelProps {
+  bookings: BookingRecord[];
+  resources: ResourceRecord[];
+}
+
+export const BookingCalendarPanel = ({ bookings, resources }: BookingCalendarPanelProps) => {
+  const activeResources = useMemo(
+    () => resources.filter((r) => r.is_active),
+    [resources]
+  );
+
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
+
+  // Default to the first active resource once data arrives.
+  useEffect(() => {
+    if (!selectedId && activeResources.length > 0) {
+      setSelectedId(activeResources[0].id);
+    }
+  }, [activeResources, selectedId]);
+
+  const weekStartDay = useMemo(() => startOfDay(weekStart), [weekStart]);
+  const weekEndDay = useMemo(() => addDays(weekStartDay, 7), [weekStartDay]);
+
+  const selectedResource = useMemo(
+    () => activeResources.find((r) => r.id === selectedId) ?? null,
+    [activeResources, selectedId]
+  );
+
+  const positioned = useMemo<PositionedBooking[]>(() => {
+    if (!selectedId) return [];
+    const out: PositionedBooking[] = [];
+    for (const booking of bookings) {
+      if (booking.resource_id !== selectedId) continue;
+      if (HIDDEN_STATUSES.has(booking.status)) continue;
+      const start = new Date(booking.start_time);
+      const end = new Date(booking.end_time);
+      if (
+        end.getTime() <= weekStartDay.getTime() ||
+        start.getTime() >= weekEndDay.getTime()
+      ) {
+        continue;
+      }
+      const day = Math.floor(
+        (startOfDay(start).getTime() - weekStartDay.getTime()) / (HOUR_MS * 24)
+      );
+      if (day < 0 || day > 6) continue;
+      const startMin = Math.max(VISIBLE_HOURS[0] * 60, minutesSinceMidnight(start));
+      const endMin = Math.min(
+        (VISIBLE_HOURS[VISIBLE_HOURS.length - 1] + 1) * 60,
+        minutesSinceMidnight(end)
+      );
+      if (endMin <= startMin) continue;
+      const top = (startMin - VISIBLE_HOURS[0] * 60) / 60;
+      const height = Math.max(0.75, (endMin - startMin) / 60);
+      out.push({ booking, start, end, day, top, height });
+    }
+    return out.sort((a, b) => a.start.getTime() - b.start.getTime());
+  }, [bookings, selectedId, weekStartDay, weekEndDay]);
+
+  const bookingsByDay = useMemo(() => {
+    const buckets: PositionedBooking[][] = Array.from({ length: 7 }, () => []);
+    for (const item of positioned) buckets[item.day].push(item);
+    return buckets;
+  }, [positioned]);
+
+  return (
+    <Panel className="sch-calendar-panel">
+      <SectionHeader
+        title={selectedResource ? `${selectedResource.name} schedule` : "Resource schedule"}
+        meta={`${formatWeekLabel(weekStartDay)} • ${positioned.length} booking${positioned.length === 1 ? "" : "s"}`}
+        actions={
+          <div className="sch-cal-toolbar">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setWeekStart(addDays(weekStartDay, -7))}
+            >
+              ◀ Prev
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setWeekStart(startOfWeek(new Date()))}
+            >
+              Today
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setWeekStart(addDays(weekStartDay, 7))}
+            >
+              Next ▶
+            </Button>
+          </div>
+        }
+      />
+      <FormRow className="sch-filter-row">
+        <FormField label="Resource">
+          <Select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            disabled={activeResources.length === 0}
+          >
+            {activeResources.length === 0 ? (
+              <option value="">No active resources</option>
+            ) : (
+              activeResources.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name} {r.booking_mode === "soft_booking" ? "(soft)" : ""}
+                </option>
+              ))
+            )}
+          </Select>
+        </FormField>
+      </FormRow>
+      {!selectedResource ? (
+        <EmptyState
+          title="No active resources"
+          description="Add a resource to start visualizing its schedule."
+        />
+      ) : (
+        <div
+          className="sch-cal-grid"
+          style={{ ["--sch-cal-rows" as string]: VISIBLE_HOURS.length }}
+        >
+          <div className="sch-cal-grid-corner" />
+          {DAY_LABELS.map((label, idx) => {
+            const day = addDays(weekStartDay, idx);
+            return (
+              <div
+                key={label}
+                className={[
+                  "sch-cal-day-head",
+                  isToday(day) ? "is-today" : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+              >
+                <span className="sch-cal-day-label">{label}</span>
+                <span className="sch-cal-day-num">{day.getDate()}</span>
+              </div>
+            );
+          })}
+          <div className="sch-cal-hour-col">
+            {VISIBLE_HOURS.map((hour) => (
+              <div key={hour} className="sch-cal-hour-cell">
+                <span>{hour.toString().padStart(2, "0")}:00</span>
+              </div>
+            ))}
+          </div>
+          {Array.from({ length: 7 }, (_, dayIdx) => (
+            <div key={dayIdx} className="sch-cal-day-col">
+              {VISIBLE_HOURS.map((hour) => (
+                <div key={hour} className="sch-cal-slot" />
+              ))}
+              {bookingsByDay[dayIdx].map((entry, entryIdx) => {
+                const isInactive = INACTIVE_STATUSES.has(entry.booking.status);
+                const labelTitle =
+                  entry.booking.title ??
+                  entry.booking.booking_type.replace(/_/g, " ");
+                return (
+                  <div
+                    key={`${entry.booking.id}-${entryIdx}`}
+                    className={[
+                      "sch-cal-event",
+                      `sch-cal-booking--${entry.booking.status}`,
+                      isInactive ? "is-inactive" : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    style={{
+                      top: `calc(${entry.top} * var(--sch-cal-row))`,
+                      height: `calc(${entry.height} * var(--sch-cal-row))`,
+                    }}
+                    title={`${labelTitle} • ${entry.booking.status} • ${formatTime(entry.start)} – ${formatTime(entry.end)}`}
+                  >
+                    <span className="sch-cal-event-title">{labelTitle}</span>
+                    <span className="sch-cal-event-meta">
+                      {formatTime(entry.start)} – {formatTime(entry.end)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </Panel>
+  );
+};

--- a/apps/scheduler/src/components/BookingsView.tsx
+++ b/apps/scheduler/src/components/BookingsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Badge,
   Button,
@@ -7,6 +7,7 @@ import {
   FormRow,
   Input,
   InlineError,
+  InlineNote,
   Panel,
   SectionHeader,
   Select,
@@ -22,6 +23,13 @@ import type {
   ResourceRecord,
 } from "../lib/cloudAdapter";
 import { formatDateTime, formatDuration } from "../lib/datetime";
+import { BookingCalendarPanel } from "./BookingCalendarPanel";
+
+/** A completed booking lingers in the table for this long after its
+ *  actual end (or last update if no actual_end_time was recorded), then
+ *  drops off unless the user explicitly filters by status = completed.
+ *  It still shows up — grayed out — on the resource calendar above. */
+const COMPLETED_GRACE_MS = 30 * 60 * 1000;
 
 const STATUS_TONES: Record<BookingStatus, StatusTone> = {
   draft: "draft",
@@ -84,6 +92,14 @@ export const BookingsView = ({
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingBookingId, setPendingBookingId] = useState<string | null>(null);
 
+  // Tick once a minute so completed bookings drop off the table after
+  // their 30-min grace window without requiring a manual refresh.
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = window.setInterval(() => setNowTick(Date.now()), 60_000);
+    return () => window.clearInterval(interval);
+  }, []);
+
   const resourcesById = useMemo(
     () => new Map(resources.map((r) => [r.id, r])),
     [resources]
@@ -93,6 +109,12 @@ export const BookingsView = ({
     [projects]
   );
 
+  const isStaleCompleted = (b: BookingRecord, now: number): boolean => {
+    if (b.status !== "completed") return false;
+    const reference = b.actual_end_time ?? b.updated_at;
+    return now - new Date(reference).getTime() > COMPLETED_GRACE_MS;
+  };
+
   const filteredBookings = useMemo(() => {
     const fromMs = fromDate ? new Date(fromDate).getTime() : null;
     const toMs = toDate ? new Date(toDate).getTime() + 86_400_000 : null;
@@ -101,6 +123,10 @@ export const BookingsView = ({
       if (projectFilter !== "all" && b.project_id !== projectFilter) return false;
       if (statusFilter !== "all" && b.status !== statusFilter) return false;
       if (mineOnly && b.user_id !== currentUserId) return false;
+      // Completed bookings older than 30 min drop out of the "any
+      // status" view — the user can still surface them by switching
+      // the Status filter to Completed.
+      if (statusFilter === "all" && isStaleCompleted(b, nowTick)) return false;
       const startMs = new Date(b.start_time).getTime();
       if (fromMs !== null && startMs < fromMs) return false;
       if (toMs !== null && startMs >= toMs) return false;
@@ -115,7 +141,16 @@ export const BookingsView = ({
     fromDate,
     toDate,
     currentUserId,
+    nowTick,
   ]);
+
+  const hiddenCompletedCount = useMemo(() => {
+    if (statusFilter !== "all") return 0;
+    return bookings.reduce(
+      (acc, b) => (isStaleCompleted(b, nowTick) ? acc + 1 : acc),
+      0
+    );
+  }, [bookings, statusFilter, nowTick]);
 
   const wrap = async (id: string, op: () => Promise<unknown>) => {
     setActionError(null);
@@ -212,7 +247,9 @@ export const BookingsView = ({
   };
 
   return (
-    <Panel>
+    <div className="sch-bookings-stack">
+      <BookingCalendarPanel bookings={bookings} resources={resources} />
+      <Panel>
       <SectionHeader
         title="Bookings"
         meta={`${filteredBookings.length} of ${bookings.length}`}
@@ -287,6 +324,14 @@ export const BookingsView = ({
         </FormField>
       </FormRow>
       {actionError ? <InlineError>{actionError}</InlineError> : null}
+      {hiddenCompletedCount > 0 ? (
+        <InlineNote>
+          {hiddenCompletedCount} completed booking
+          {hiddenCompletedCount === 1 ? "" : "s"} hidden after the 30-min grace
+          window — switch the Status filter to <strong>Completed</strong> to
+          see them.
+        </InlineNote>
+      ) : null}
       {bookings.length === 0 ? (
         <EmptyState
           title="No bookings yet"
@@ -347,6 +392,7 @@ export const BookingsView = ({
           </tbody>
         </Table>
       )}
-    </Panel>
+      </Panel>
+    </div>
   );
 };

--- a/apps/scheduler/src/styles.css
+++ b/apps/scheduler/src/styles.css
@@ -278,6 +278,42 @@
 .sch-cal-event--maintenance { border-left: 3px solid #d39e00; }
 .sch-cal-event--general     { border-left: 3px solid #555;   }
 
+/* Booking blocks reuse the .sch-cal-event grid positioning but key off
+   booking status instead of event type. Inactive (completed / cancelled
+   / no_show / denied) renders gray so the historical context stays
+   visible without competing with active reservations. */
+.sch-cal-booking--requested { border-left: 3px solid #d39e00; background: #fff8e6; }
+.sch-cal-booking--approved  { border-left: 3px solid #1f9d6c; background: #e9f6f0; }
+.sch-cal-booking--active    { border-left: 3px solid #1a7048; background: #d6efdf; }
+.sch-cal-booking--completed,
+.sch-cal-booking--cancelled,
+.sch-cal-booking--no_show,
+.sch-cal-booking--denied {
+  border-left: 3px solid #c0c4ca;
+  background: #f1f3f6;
+}
+
+.sch-cal-event.is-inactive {
+  color: var(--rl-muted);
+}
+
+.sch-cal-event.is-inactive .sch-cal-event-title {
+  text-decoration: line-through;
+  text-decoration-color: var(--rl-muted);
+  text-decoration-thickness: 1px;
+}
+
+.sch-cal-event.is-inactive .sch-cal-event-meta {
+  color: var(--rl-muted);
+}
+
+/* The Bookings tab now stacks the resource calendar and the table. */
+.sch-bookings-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 /* ----- Conflict panel ----- */
 
 .sch-conflict-panel {


### PR DESCRIPTION
## Summary

Two requested improvements to the Bookings tab.

### 1. Resource calendar (`BookingCalendarPanel`)

New panel above the bookings table renders a week grid scoped to a single selected resource. Reuses the same Mon-anchored 07:00–19:00 grid as `CalendarView` for visual consistency. Booking blocks are colored by status:

| Status | Visual |
| --- | --- |
| `requested` | Amber border, light yellow fill |
| `approved` | Green border, soft mint fill |
| `active` | Stronger green |
| `completed` / `cancelled` / `no_show` / `denied` | Gray + strikethrough text |

The user picks any active resource from the dropdown and steps through weeks with prev / today / next. Drafts are excluded (they're per-user scratch state).

### 2. 30-min grace for completed bookings

When the Status filter is set to "any status", completed bookings are kept in the table for 30 minutes past their `actual_end_time` (falling back to `updated_at` if null) and then drop off. They still appear on the resource calendar above as gray blocks so the schedule history stays visible.

- A 60-second tick (`setInterval`) refreshes the cutoff so bookings expire from the table without requiring a manual refresh.
- An `InlineNote` tells the user how many bookings are currently hidden and how to surface them again ("switch the Status filter to Completed").
- When the user explicitly filters by Status = Completed, the grace rule is bypassed.

## Files

- `apps/scheduler/src/components/BookingCalendarPanel.tsx` — new component.
- `apps/scheduler/src/components/BookingsView.tsx` — mount the calendar above the table; add `nowTick`, `isStaleCompleted`, the InlineNote, and the filter rule.
- `apps/scheduler/src/styles.css` — `.sch-cal-booking--*` per-status colors, `.is-inactive` strikethrough/muted state, `.sch-bookings-stack` layout.

## Verification

- `npm run build -w @ilm/scheduler` — passes.
- After deploy: Bookings tab now renders the resource calendar above the filter row + table. Mark any approved booking complete → it stays in the table for ~30 min (depending on its `actual_end_time`) then drops off; the gray block remains on the calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)