### PR TITLE
Lab picker: fix can't dismiss by clicking current lab

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -368,7 +368,7 @@ const SignedInShell = () => {
   }, [activeLabId, showPicker]);
 
   if (!activeLab || showPicker) {
-    return <LabPicker />;
+    return <LabPicker onClose={activeLab ? () => setShowPicker(false) : undefined} />;
   }
   return <HomeShell onOpenLabPicker={() => setShowPicker(true)} />;
 };

--- a/packages/ui/src/auth/LabPicker.tsx
+++ b/packages/ui/src/auth/LabPicker.tsx
@@ -12,8 +12,8 @@ const extractLabIdFromInput = (value: string): string | null => {
   return uuidMatch ? uuidMatch[0] : null;
 };
 
-export const LabPicker = () => {
-  const { labs, selectLab, createLab, signOut, profile, user } = useAuth();
+export const LabPicker = ({ onClose }: { onClose?: () => void } = {}) => {
+  const { labs, selectLab, createLab, signOut, profile, user, activeLab } = useAuth();
   const [mode, setMode] = useState<Mode>(labs.length === 0 ? "choose" : "choose");
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
@@ -86,9 +86,16 @@ export const LabPicker = () => {
             <h1 className="ilm-auth-title">Choose a lab workspace</h1>
             {displayName && <p className="ilm-auth-hint">Signed in as {displayName}</p>}
           </div>
-          <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
-            Sign out
-          </button>
+          <div style={{ display: "flex", gap: "0.5rem" }}>
+            {onClose && activeLab ? (
+              <button type="button" className="ilm-text-button" onClick={onClose}>
+                Cancel
+              </button>
+            ) : null}
+            <button type="button" className="ilm-text-button" onClick={() => void signOut()}>
+              Sign out
+            </button>
+          </div>
         </div>
 
         {!emptyState ? (
@@ -98,9 +105,16 @@ export const LabPicker = () => {
                 <button
                   type="button"
                   className="ilm-lab-list-item"
-                  onClick={() => selectLab(lab.id)}
+                  aria-current={activeLab?.id === lab.id ? "true" : undefined}
+                  onClick={() => {
+                    selectLab(lab.id);
+                    onClose?.();
+                  }}
                 >
-                  <span className="ilm-lab-list-name">{lab.name}</span>
+                  <span className="ilm-lab-list-name">
+                    {lab.name}
+                    {activeLab?.id === lab.id ? " (current)" : ""}
+                  </span>
                   <span className="ilm-lab-list-meta">{lab.role}</span>
                 </button>
               </li>


### PR DESCRIPTION
## Summary
- When the user opened the lab picker (Settings → "Join or create another lab…") and then tried to back out by clicking the already-active lab, nothing happened — the picker stayed open.
- Root cause: `SignedInShell` only closed the picker when `activeLabId` *changed*, but `selectLab(sameId)` is a no-op state update.

## Changes
- `LabPicker` accepts an optional `onClose`. List buttons call `onClose?.()` after `selectLab`, so clicking the current lab dismisses the picker.
- A **Cancel** button appears in the header when an active lab exists to return to.
- The active lab is now tagged "(current)" with `aria-current="true"`.
- `apps/account/src/App.tsx` passes `onClose={() => setShowPicker(false)}` when an active lab is set.

## Test plan
- [ ] Sign in to a lab, open Settings → "Join or create another lab…"
- [ ] Click the current lab → picker closes, you stay in that lab
- [ ] Click Cancel → picker closes
- [ ] Click a different lab → switches lab and closes picker
- [ ] On first sign-in (no active lab), no Cancel button is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)