### PR TITLE
Inventory status: total/low/in-order/unchecked + 6-axis radar

### DIFF
--- a/apps/account/src/lib/dashboardData.ts
+++ b/apps/account/src/lib/dashboardData.ts
@@ -23,6 +23,8 @@ export type InventoryStats = {
   samples: number;
   other: number;
   criticalLow: number;
+  inOrder: number;
+  unchecked: number;
 };
 
 export type TeamStats = {
@@ -81,7 +83,7 @@ export type DashboardData = {
 const emptyState: Omit<DashboardData, "refresh"> = {
   projects: { draft: 0, published: 0, deleted: 0, total: 0 },
   protocols: { total: 0, active: 0, inReview: 0, archived: 0 },
-  inventory: { total: 0, reagents: 0, consumables: 0, supplies: 0, samples: 0, other: 0, criticalLow: 0 },
+  inventory: { total: 0, reagents: 0, consumables: 0, supplies: 0, samples: 0, other: 0, criticalLow: 0, inOrder: 0, unchecked: 0 },
   team: { total: 0, owners: 0, admins: 0, members: 0, recentAvatars: [] },
   pending: { protocols: 0, projects: 0, orders: 0, members: 0, bookings: 0 },
   schedule: [],
@@ -160,6 +162,7 @@ export const useDashboardData = (labId: string | null, userId: string | null): D
           bookingsRes,
           recentOrdersRes,
           projectLeadRes,
+          inOrderItemsRes,
         ] = await Promise.all([
           supabase.from("projects").select("id, state, updated_at, name, review_requested_at").eq("lab_id", labId),
           supabase
@@ -176,9 +179,8 @@ export const useDashboardData = (labId: string | null, userId: string | null): D
             .from("inventory_checks")
             .select("item_id, stock_status, checked_at, items!inner(lab_id)")
             .eq("items.lab_id", labId)
-            .in("stock_status", ["low", "out"])
             .order("checked_at", { ascending: false })
-            .limit(200),
+            .limit(2000),
           supabase.rpc("list_lab_members", { p_lab_id: labId }),
           supabase
             .from("protocol_submissions")
@@ -230,6 +232,14 @@ export const useDashboardData = (labId: string | null, userId: string | null): D
                 .eq("projects.lab_id", labId)
                 .limit(1)
             : Promise.resolve({ data: [], error: null } as unknown as { data: unknown[]; error: null }),
+          // Items currently "in order": distinct item_ids appearing in
+          // order_request_items whose parent order_request is open
+          // (submitted / approved / ordered) within this lab.
+          supabase
+            .from("order_request_items")
+            .select("item_id, order_requests!inner(lab_id, status)")
+            .eq("order_requests.lab_id", labId)
+            .in("order_requests.status", ["submitted", "approved", "ordered"]),
         ]);
 
         // Projects
@@ -278,12 +288,40 @@ export const useDashboardData = (labId: string | null, userId: string | null): D
           samples: byClass("sample"),
           other: byClass("other"),
           criticalLow: 0,
+          inOrder: 0,
+          unchecked: 0,
         };
-        type LowRow = { item_id: string };
-        const lowRows = (lowChecksRes.data as LowRow[] | null) ?? [];
-        const seenLow = new Set<string>();
-        for (const r of lowRows) seenLow.add(r.item_id);
-        inventory.criticalLow = seenLow.size;
+
+        // Walk the latest check per item to find the active stock_status, and
+        // record which items have ever been checked (for the "unchecked" count).
+        type CheckRow = { item_id: string; stock_status: string; checked_at: string };
+        const checkRows = (lowChecksRes.data as CheckRow[] | null) ?? [];
+        const latestStatus = new Map<string, string>();
+        for (const r of checkRows) {
+          // Rows arrive sorted by checked_at desc, so the first time we see an
+          // item_id is the latest check.
+          if (!latestStatus.has(r.item_id)) latestStatus.set(r.item_id, r.stock_status);
+        }
+        let lowCount = 0;
+        for (const status of latestStatus.values()) {
+          if (status === "low" || status === "out") lowCount += 1;
+        }
+        inventory.criticalLow = lowCount;
+        const activeItemIds = new Set(itemRows.map((r) => r.id));
+        let uncheckedCount = 0;
+        for (const id of activeItemIds) {
+          if (!latestStatus.has(id)) uncheckedCount += 1;
+        }
+        inventory.unchecked = uncheckedCount;
+
+        // Items currently in an open order
+        type OrderItemRow = { item_id: string };
+        const orderItemRows = (inOrderItemsRes.data as OrderItemRow[] | null) ?? [];
+        const inOrderSet = new Set<string>();
+        for (const r of orderItemRows) {
+          if (activeItemIds.has(r.item_id)) inOrderSet.add(r.item_id);
+        }
+        inventory.inOrder = inOrderSet.size;
 
         // Team
         type MemberRow = {

--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -371,17 +371,22 @@
 }
 .ovw-inv-body {
   display: grid;
-  grid-template-columns: 150px 1fr;
-  gap: 1rem;
+  grid-template-columns: 170px 1fr;
+  gap: 1.2rem;
   align-items: center;
 }
 .ovw-inv-radar {
-  width: 150px;
-  height: 150px;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  opacity: 0.85;
+  width: 170px;
+  height: 170px;
+  display: block;
+  overflow: visible;
+}
+.ovw-inv-radar-label {
+  font-family: var(--rl-font-display);
+  font-size: 7.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  fill: var(--ilm-muted);
 }
 .ovw-inv-stats {
   list-style: none;
@@ -409,28 +414,6 @@
   font-family: var(--rl-font-display);
   font-size: 1.05rem;
   color: var(--ilm-ink);
-}
-.ovw-inv-bar {
-  display: grid;
-  gap: 0.3rem;
-  margin-top: 0.4rem;
-}
-.ovw-inv-bar-track {
-  display: block;
-  height: 6px;
-  background: var(--ilm-surface-soft);
-  border-radius: 999px;
-  overflow: hidden;
-}
-.ovw-inv-bar-fill {
-  display: block;
-  height: 100%;
-  background: linear-gradient(90deg, var(--ilm-viridian-2) 0%, var(--ilm-viridian) 100%);
-  transition: width 0.4s ease;
-}
-.ovw-inv-bar small {
-  font-size: 0.7rem;
-  color: var(--ilm-muted);
 }
 
 /* Activity */
@@ -565,9 +548,9 @@
     grid-column: span 2;
   }
   .ovw-inv-body {
-    grid-template-columns: 110px 1fr;
+    grid-template-columns: 140px 1fr;
   }
-  .ovw-inv-radar { width: 110px; height: 110px; }
+  .ovw-inv-radar { width: 140px; height: 140px; }
 }
 
 @media (max-width: 640px) {

--- a/apps/account/src/views/OverviewView.tsx
+++ b/apps/account/src/views/OverviewView.tsx
@@ -253,10 +253,86 @@ const ReviewQueueCard = ({
 // Inventory status — replaces resource utilization
 // ---------------------------------------------------------------------------
 
+const InventoryRadar = ({ stats }: { stats: InventoryStats }) => {
+  // Six axes: 4 known classifications + 2 placeholder slots so the polygon
+  // still reads as a hexagon while we wait for additional taxonomy.
+  const axes: { label: string; value: number }[] = [
+    { label: "Reagents", value: stats.reagents },
+    { label: "Supplies", value: stats.supplies },
+    { label: "Samples", value: stats.samples },
+    { label: "Consumables", value: stats.consumables },
+    { label: "Other 1", value: stats.other },
+    { label: "Other 2", value: 0 },
+  ];
+  const max = Math.max(1, ...axes.map((a) => a.value));
+  const cx = 75;
+  const cy = 75;
+  const radius = 52;
+  // 6 evenly-spaced angles, starting at top (-90°)
+  const points = axes.map((axis, i) => {
+    const angle = (-Math.PI / 2) + (i * 2 * Math.PI) / axes.length;
+    const r = (axis.value / max) * radius;
+    return {
+      x: cx + Math.cos(angle) * r,
+      y: cy + Math.sin(angle) * r,
+      ringX: cx + Math.cos(angle) * radius,
+      ringY: cy + Math.sin(angle) * radius,
+      labelX: cx + Math.cos(angle) * (radius + 13),
+      labelY: cy + Math.sin(angle) * (radius + 13),
+      label: axis.label,
+      value: axis.value,
+    };
+  });
+  const polygonPoints = points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" ");
+  const ringPoints = points.map((p) => `${p.ringX.toFixed(1)},${p.ringY.toFixed(1)}`).join(" ");
+  const innerRadii = [0.33, 0.66];
+  return (
+    <svg viewBox="0 0 150 150" className="ovw-inv-radar" role="img" aria-label="Inventory class distribution">
+      <g fill="none" stroke="var(--ilm-line)">
+        {innerRadii.map((scale) => (
+          <polygon
+            key={scale}
+            points={points
+              .map((p) => {
+                const ix = cx + (p.ringX - cx) * scale;
+                const iy = cy + (p.ringY - cy) * scale;
+                return `${ix.toFixed(1)},${iy.toFixed(1)}`;
+              })
+              .join(" ")}
+          />
+        ))}
+        <polygon points={ringPoints} />
+        {points.map((p, i) => (
+          <line key={i} x1={cx} y1={cy} x2={p.ringX} y2={p.ringY} />
+        ))}
+      </g>
+      <polygon
+        points={polygonPoints}
+        fill="rgba(78,159,146,0.32)"
+        stroke="var(--ilm-viridian)"
+        strokeWidth="1.3"
+      />
+      {points.map((p, i) => (
+        <circle key={i} cx={p.x} cy={p.y} r="2" fill="var(--ilm-viridian)" />
+      ))}
+      {points.map((p, i) => (
+        <text
+          key={`l-${i}`}
+          x={p.labelX}
+          y={p.labelY}
+          className="ovw-inv-radar-label"
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          {p.label}
+        </text>
+      ))}
+    </svg>
+  );
+};
+
 const InventoryCard = ({ stats }: { stats: InventoryStats }) => {
   const inventoryHref = appUrl("supply-manager/", APP_BASE_URL);
-  const totalKnown = stats.total || 1;
-  const lowPct = Math.min(100, Math.round((stats.criticalLow / totalKnown) * 100));
   return (
     <section className="ovw-card ovw-inventory">
       <header>
@@ -264,43 +340,29 @@ const InventoryCard = ({ stats }: { stats: InventoryStats }) => {
         <a className="ovw-card-link" href={inventoryHref}>View inventory</a>
       </header>
       <div className="ovw-inv-body">
-        <div
-          className="ovw-inv-radar"
-          aria-hidden="true"
-          style={{ backgroundImage: `url(${APP_BASE_URL}assets/radar.png)` }}
-        />
+        <InventoryRadar stats={stats} />
         <ul className="ovw-inv-stats">
           <li>
             <i style={{ background: "var(--ilm-viridian)" }} />
-            <strong>{stats.reagents}</strong>
-            <span>Reagents</span>
-          </li>
-          <li>
-            <i style={{ background: "var(--ilm-viridian-2)" }} />
-            <strong>{stats.consumables}</strong>
-            <span>Consumables</span>
-          </li>
-          <li>
-            <i style={{ background: "var(--ilm-blue)" }} />
-            <strong>{stats.supplies + stats.samples + stats.other}</strong>
-            <span>Supplies · samples · other</span>
+            <strong>{stats.total}</strong>
+            <span>Total items</span>
           </li>
           <li>
             <i style={{ background: "var(--ilm-amber)" }} />
             <strong>{stats.criticalLow}</strong>
-            <span>Critical low · reorder</span>
+            <span>Low · needs reorder</span>
+          </li>
+          <li>
+            <i style={{ background: "var(--ilm-viridian-2)" }} />
+            <strong>{stats.inOrder}</strong>
+            <span>In order</span>
+          </li>
+          <li>
+            <i style={{ background: "var(--ilm-fg-4, #9aa3a0)" }} />
+            <strong>{stats.unchecked}</strong>
+            <span>Unchecked</span>
           </li>
         </ul>
-      </div>
-      <div className="ovw-inv-bar" aria-hidden="true">
-        <span className="ovw-inv-bar-track">
-          <span className="ovw-inv-bar-fill" style={{ width: `${100 - lowPct}%` }} />
-        </span>
-        <small>
-          {stats.total > 0
-            ? `${stats.total - stats.criticalLow} / ${stats.total} items above reorder threshold`
-            : "No active inventory items yet"}
-        </small>
       </div>
     </section>
   );


### PR DESCRIPTION
The card now reports four counts (total / low / in order / unchecked) instead of classification breakdowns, and the radar visualizes the six classification axes (reagents, supplies, samples, consumables, plus two placeholder slots) so the viz still reads as a hexagon while we wait for additional taxonomy.

useDashboardData broadens the inventory_checks pull (no stock_status filter) so it can compute the latest status per item — feeding both criticalLow and the new "unchecked" count — and adds an order_request_items query joined to open order_requests (submitted/approved/ordered) for the "in order" count.