### PR TITLE
Inventory radar shows stocked %; clean up dashboard row alignment

### DIFF
--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -388,6 +388,18 @@
   letter-spacing: 0.04em;
   fill: var(--ilm-muted);
 }
+.ovw-inv-radar-pct {
+  font-family: var(--rl-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  fill: var(--ilm-ink);
+}
+.ovw-inv-radar-pct-label {
+  font-family: var(--rl-font-display);
+  font-size: 6.5px;
+  letter-spacing: 0.18em;
+  fill: var(--ilm-muted);
+}
 .ovw-inv-stats {
   list-style: none;
   margin: 0;
@@ -416,9 +428,14 @@
   color: var(--ilm-ink);
 }
 
-/* Activity */
+/* Activity — full-width row at the bottom of the dashboard */
 .ovw-activity {
-  grid-column: span 1;
+  grid-column: span 3;
+}
+.ovw-activity-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: grid;
+  gap: 0.55rem 1.5rem;
 }
 .ovw-activity-dot--protocol { background: var(--ilm-viridian); }
 .ovw-activity-dot--project  { background: var(--ilm-viridian-2); }
@@ -521,50 +538,46 @@
    Responsive — collapse to one column on narrow screens
    ============================================================ */
 
+/* Tighter 3-col grid for medium widths — 2/1 hero+schedule, full-width
+   reviews, 2/1 inventory+team, full-width activity. No orphan rows. */
 @media (max-width: 1280px) {
   .ovw-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
   }
-  .ovw-hero {
-    grid-column: span 3;
-  }
-  .ovw-reviews {
-    grid-column: span 3;
-  }
-  .ovw-inventory {
-    grid-column: span 2;
-  }
+  .ovw-hero       { grid-column: span 2; }
+  .ovw-schedule   { grid-column: span 1; }
+  .ovw-reviews    { grid-column: span 3; }
+  .ovw-inventory  { grid-column: span 2; }
+  .ovw-team       { grid-column: span 1; }
+  .ovw-activity   { grid-column: span 3; }
 }
 
+/* On tablets, drop to 2 columns. Each card spans the full row to keep
+   alignment crisp; the review tiles re-flow inside their card. */
 @media (max-width: 960px) {
   .ovw-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   }
-  .ovw-hero,
-  .ovw-reviews {
-    grid-column: span 2;
-  }
-  .ovw-inventory {
-    grid-column: span 2;
-  }
-  .ovw-inv-body {
-    grid-template-columns: 140px 1fr;
-  }
-  .ovw-inv-radar { width: 140px; height: 140px; }
+  .ovw-hero       { grid-column: span 2; }
+  .ovw-schedule   { grid-column: span 2; }
+  .ovw-reviews    { grid-column: span 2; }
+  .ovw-inventory  { grid-column: span 2; }
+  .ovw-team       { grid-column: span 2; }
+  .ovw-activity   { grid-column: span 2; }
+  .ovw-inv-body { grid-template-columns: 150px 1fr; }
+  .ovw-inv-radar { width: 150px; height: 150px; }
+  .ovw-activity-list { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 640px) {
-  .ovw-grid {
-    grid-template-columns: 1fr;
-  }
+  .ovw-grid { grid-template-columns: 1fr; }
   .ovw-hero,
+  .ovw-schedule,
   .ovw-reviews,
-  .ovw-inventory {
-    grid-column: span 1;
-  }
-  .ovw-hero {
-    grid-template-columns: 1fr;
-  }
+  .ovw-inventory,
+  .ovw-team,
+  .ovw-activity { grid-column: span 1; }
+  .ovw-hero { grid-template-columns: 1fr; }
   .ovw-hero-art { display: none; }
   .ovw-metric-row {
     grid-template-columns: repeat(2, 1fr);
@@ -574,7 +587,8 @@
     border-right: none;
     padding: 0;
   }
-  .ovw-inv-stats { grid-template-columns: 1fr; }
+  .ovw-inv-body { grid-template-columns: 1fr; justify-items: center; }
+  .ovw-inv-stats { grid-template-columns: 1fr 1fr; width: 100%; }
 }
 
 /* ============================================================

--- a/apps/account/src/views/OverviewView.tsx
+++ b/apps/account/src/views/OverviewView.tsx
@@ -253,7 +253,7 @@ const ReviewQueueCard = ({
 // Inventory status — replaces resource utilization
 // ---------------------------------------------------------------------------
 
-const InventoryRadar = ({ stats }: { stats: InventoryStats }) => {
+const InventoryRadar = ({ stats, stockedPct }: { stats: InventoryStats; stockedPct: number | null }) => {
   // Six axes: 4 known classifications + 2 placeholder slots so the polygon
   // still reads as a hexagon while we wait for additional taxonomy.
   const axes: { label: string; value: number }[] = [
@@ -327,12 +327,24 @@ const InventoryRadar = ({ stats }: { stats: InventoryStats }) => {
           {p.label}
         </text>
       ))}
+      {stockedPct !== null ? (
+        <>
+          <text x={cx} y={cy - 2} textAnchor="middle" className="ovw-inv-radar-pct">
+            {stockedPct}%
+          </text>
+          <text x={cx} y={cy + 11} textAnchor="middle" className="ovw-inv-radar-pct-label">
+            STOCKED
+          </text>
+        </>
+      ) : null}
     </svg>
   );
 };
 
 const InventoryCard = ({ stats }: { stats: InventoryStats }) => {
   const inventoryHref = appUrl("supply-manager/", APP_BASE_URL);
+  const stockedPct =
+    stats.total > 0 ? Math.round(((stats.total - stats.criticalLow) / stats.total) * 100) : null;
   return (
     <section className="ovw-card ovw-inventory">
       <header>
@@ -340,7 +352,7 @@ const InventoryCard = ({ stats }: { stats: InventoryStats }) => {
         <a className="ovw-card-link" href={inventoryHref}>View inventory</a>
       </header>
       <div className="ovw-inv-body">
-        <InventoryRadar stats={stats} />
+        <InventoryRadar stats={stats} stockedPct={stockedPct} />
         <ul className="ovw-inv-stats">
           <li>
             <i style={{ background: "var(--ilm-viridian)" }} />
@@ -488,8 +500,8 @@ export const OverviewView = () => {
       <ScheduleCard schedule={data.schedule} />
       <ReviewQueueCard mode={reviewMode} pending={data.pending} />
       <InventoryCard stats={data.inventory} />
-      <ActivityCard entries={data.activity} />
       <TeamCard team={data.team} />
+      <ActivityCard entries={data.activity} />
     </div>
   );
 };


### PR DESCRIPTION
Inventory radar now centers a STOCKED % readout (enough / total) so the card communicates fitness at a glance, not just raw counts.

Reorder + grid rules so every breakpoint produces clean, full rows:
  Row 1: Hero (2) + Schedule (1)
  Row 2: Reviews (3, full-width)
  Row 3: Inventory (2) + Team (1)
  Row 4: Activity (3, full-width, two-column list)
No more orphan single-column row at the bottom.