### PR TITLE
Data Hub: explicit access grants, hard delete, stricter private tier

### DIFF
--- a/apps/data-hub/src/App.tsx
+++ b/apps/data-hub/src/App.tsx
@@ -34,6 +34,7 @@ import {
   SOURCE_TYPES,
   VERSION_TYPES,
   type AccessLevel,
+  type DatasetAccessGrantRecord,
   type DatasetAccessRequestRecord,
   type DatasetInput,
   type DatasetRecord,
@@ -123,6 +124,19 @@ const accessTone = (level: AccessLevel): BadgeTone => {
   return "danger";
 };
 
+const ACCESS_LEVEL_DESCRIPTIONS: Record<AccessLevel, string> = {
+  "open-lab":
+    "Open lab — every member sees metadata and storage. No request; uses are recorded directly.",
+  "request-required":
+    "Request required — every member sees metadata. Storage location is revealed only after the owner approves a request.",
+  "restricted":
+    "Restricted — owner, contact, and lab admins see it. Owner can also grant access to additional members one by one.",
+  "private":
+    "Private — only the creator/owner and lab admins/owners see it. Cannot be shared; switch to Restricted to add members.",
+};
+
+const accessLevelDescription = (level: AccessLevel) => ACCESS_LEVEL_DESCRIPTIONS[level];
+
 const requestTone = (status: DatasetAccessRequestRecord["status"]): BadgeTone => {
   if (status === "approved") return "success";
   if (status === "denied") return "danger";
@@ -144,6 +158,9 @@ const getRequestAction = (
       label: hasRecordedUse ? "Record another use" : "Record use",
       disabled: false,
     };
+  }
+  if (dataset.access_level === "restricted" || dataset.access_level === "private") {
+    return { label: "Owner-managed access", disabled: true };
   }
   if (mine.some((request) => request.status === "pending")) {
     return { label: "Pending", disabled: true };
@@ -198,6 +215,7 @@ export const App = () => {
   const versionsByDatasetId = useMemo(() => groupBy(workspace.versions, "dataset_id"), [workspace.versions]);
   const requestsByDatasetId = useMemo(() => groupBy(workspace.requests, "dataset_id"), [workspace.requests]);
   const storageByDatasetId = useMemo(() => groupBy(workspace.storageLinks, "dataset_id"), [workspace.storageLinks]);
+  const grantsByDatasetId = useMemo(() => groupBy(workspace.accessGrants, "dataset_id"), [workspace.accessGrants]);
 
   const allTags = useMemo(
     () => Array.from(new Set(workspace.tags.map((tag) => tag.tag))).sort((a, b) => a.localeCompare(b)),
@@ -288,10 +306,40 @@ export const App = () => {
           versions={versionsByDatasetId.get(selectedDataset.id) ?? []}
           requests={requestsByDatasetId.get(selectedDataset.id) ?? []}
           storageLinks={storageByDatasetId.get(selectedDataset.id) ?? []}
+          accessGrants={grantsByDatasetId.get(selectedDataset.id) ?? []}
+          labMembers={workspace.labMembers}
+          onGrantAccess={(userId) =>
+            wrap(() => workspace.grantDatasetAccess({ datasetId: selectedDataset.id, userId }))
+          }
+          onRevokeAccess={(grantId) => wrap(() => workspace.revokeDatasetAccess(grantId))}
           onBack={() => setSelectedDatasetId(null)}
           onEdit={() => setModal({ kind: "dataset", dataset: selectedDataset })}
           onArchive={() => wrap(() => workspace.archiveDataset(selectedDataset.id))}
           onRestore={() => wrap(() => workspace.restoreDataset(selectedDataset.id))}
+          onDelete={async () => {
+            if (
+              typeof window !== "undefined" &&
+              !window.confirm(
+                `Permanently delete "${selectedDataset.name}"? This removes all versions, tags, project links, requests, and storage references and cannot be undone.`
+              )
+            ) {
+              return;
+            }
+            const ok = await wrap(async () => {
+              await workspace.deleteDataset(selectedDataset.id);
+              return true;
+            });
+            if (ok) setSelectedDatasetId(null);
+          }}
+          onDeleteVersion={async (versionId, versionName) => {
+            if (
+              typeof window !== "undefined" &&
+              !window.confirm(`Delete version "${versionName}"? This cannot be undone.`)
+            ) {
+              return;
+            }
+            await wrap(() => workspace.deleteDatasetVersion(versionId));
+          }}
           onAddVersion={() => setModal({ kind: "version", datasetId: selectedDataset.id })}
           onRequestAccess={() => setModal({ kind: "request", datasetId: selectedDataset.id })}
           onReview={(request, decision) => setModal({ kind: "review", request, decision })}
@@ -885,10 +933,16 @@ function DatasetDetailView({
   versions,
   requests,
   storageLinks,
+  accessGrants,
+  labMembers,
+  onGrantAccess,
+  onRevokeAccess,
   onBack,
   onEdit,
   onArchive,
   onRestore,
+  onDelete,
+  onDeleteVersion,
   onAddVersion,
   onRequestAccess,
   onReview,
@@ -905,10 +959,16 @@ function DatasetDetailView({
   versions: DatasetVersionRecord[];
   requests: DatasetAccessRequestRecord[];
   storageLinks: DatasetStorageLinkRecord[];
+  accessGrants: DatasetAccessGrantRecord[];
+  labMembers: LabMemberRecord[];
+  onGrantAccess: (userId: string) => void;
+  onRevokeAccess: (grantId: string) => void;
   onBack: () => void;
   onEdit: () => void;
   onArchive: () => void;
   onRestore: () => void;
+  onDelete: () => void;
+  onDeleteVersion: (versionId: string, versionName: string) => void;
   onAddVersion: () => void;
   onRequestAccess: () => void;
   onReview: (request: DatasetAccessRequestRecord, decision: "approved" | "denied") => void;
@@ -949,9 +1009,16 @@ function DatasetDetailView({
             ) : canEdit ? (
               <Button variant="ghost" onClick={onArchive}>Archive</Button>
             ) : null}
+            {isAdmin ? (
+              <Button variant="danger" onClick={onDelete}>Delete</Button>
+            ) : null}
           </div>
         </div>
         <p className="dh-detail-description">{dataset.description ?? "No description yet."}</p>
+        <InlineNote>
+          <strong>{labelize(dataset.access_level)}.</strong>{" "}
+          {accessLevelDescription(dataset.access_level)}
+        </InlineNote>
       </Panel>
 
       <div className="dh-detail-grid">
@@ -1028,20 +1095,38 @@ function DatasetDetailView({
           meta={`${versions.length}`}
           actions={canEdit ? <Button size="sm" variant="secondary" onClick={onAddVersion}>+ Add version</Button> : null}
         />
-        <VersionList versions={versions} storageLinks={storageLinks} />
+        <VersionList
+          versions={versions}
+          storageLinks={storageLinks}
+          canEdit={canEdit}
+          onDeleteVersion={onDeleteVersion}
+        />
       </Panel>
 
-      <RequestsDashboard
-        requests={requests}
-        datasets={[dataset]}
-        projectsById={projectsById}
-        membersById={membersById}
-        currentUserId={currentUserId}
-        isAdmin={isAdmin}
-        onOpenDataset={() => undefined}
-        onReview={onReview}
-        onWithdraw={onWithdraw}
-      />
+      {dataset.access_level === "restricted" && canEdit ? (
+        <PermittedUsersPanel
+          dataset={dataset}
+          accessGrants={accessGrants}
+          labMembers={labMembers}
+          membersById={membersById}
+          onGrantAccess={onGrantAccess}
+          onRevokeAccess={onRevokeAccess}
+        />
+      ) : null}
+
+      {dataset.access_level === "request-required" || dataset.access_level === "open-lab" ? (
+        <RequestsDashboard
+          requests={requests}
+          datasets={[dataset]}
+          projectsById={projectsById}
+          membersById={membersById}
+          currentUserId={currentUserId}
+          isAdmin={isAdmin}
+          onOpenDataset={() => undefined}
+          onReview={onReview}
+          onWithdraw={onWithdraw}
+        />
+      ) : null}
 
       {dataset.notes ? (
         <Panel>
@@ -1053,12 +1138,91 @@ function DatasetDetailView({
   );
 }
 
+function PermittedUsersPanel({
+  dataset,
+  accessGrants,
+  labMembers,
+  membersById,
+  onGrantAccess,
+  onRevokeAccess,
+}: {
+  dataset: DatasetRecord;
+  accessGrants: DatasetAccessGrantRecord[];
+  labMembers: LabMemberRecord[];
+  membersById: Map<string, LabMemberRecord>;
+  onGrantAccess: (userId: string) => void;
+  onRevokeAccess: (grantId: string) => void;
+}) {
+  const [pendingUserId, setPendingUserId] = useState("");
+  const grantedUserIds = new Set(accessGrants.map((grant) => grant.user_id));
+  const reservedUserIds = new Set(
+    [dataset.owner_user_id, dataset.contact_user_id].filter((id): id is string => Boolean(id))
+  );
+  const candidates = labMembers.filter(
+    (member) => !grantedUserIds.has(member.user_id) && !reservedUserIds.has(member.user_id)
+  );
+
+  const handleAdd = () => {
+    if (!pendingUserId) return;
+    onGrantAccess(pendingUserId);
+    setPendingUserId("");
+  };
+
+  return (
+    <Panel>
+      <SectionHeader title="Permitted users" meta={`${accessGrants.length}`} />
+      <InlineNote>
+        Owner, contact, and lab admins always have access. Add anyone else who should see this {labelize(dataset.access_level).toLowerCase()} dataset in their library.
+      </InlineNote>
+      <div className="dh-grant-add">
+        <Select value={pendingUserId} onChange={(event) => setPendingUserId(event.target.value)}>
+          <option value="">Select a lab member…</option>
+          {candidates.map((member) => (
+            <option key={member.user_id} value={member.user_id}>{memberLabel(member)}</option>
+          ))}
+        </Select>
+        <Button variant="secondary" onClick={handleAdd} disabled={!pendingUserId}>
+          Grant access
+        </Button>
+      </div>
+      {accessGrants.length === 0 ? (
+        <EmptyState description="No additional users granted yet. Owner, contact, and admins still see this dataset." />
+      ) : (
+        <div className="dh-grant-list">
+          {accessGrants.map((grant) => {
+            const member = membersById.get(grant.user_id);
+            const grantedBy = membersById.get(grant.granted_by ?? "");
+            return (
+              <div key={grant.id} className="dh-grant-row">
+                <div>
+                  <strong>{memberLabel(member, grant.user_id)}</strong>
+                  <div className="dh-cell-meta">
+                    Granted {formatDate(grant.granted_at)}
+                    {grantedBy ? ` by ${memberLabel(grantedBy)}` : ""}
+                  </div>
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => onRevokeAccess(grant.id)}>
+                  Revoke
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
 function VersionList({
   versions,
   storageLinks,
+  canEdit,
+  onDeleteVersion,
 }: {
   versions: DatasetVersionRecord[];
   storageLinks: DatasetStorageLinkRecord[];
+  canEdit: boolean;
+  onDeleteVersion: (versionId: string, versionName: string) => void;
 }) {
   if (versions.length === 0) {
     return <EmptyState description="No versions recorded yet." />;
@@ -1076,6 +1240,7 @@ function VersionList({
             <th>QC</th>
             <th>Location</th>
             <th>Created</th>
+            {canEdit ? <th aria-label="Actions" /> : null}
           </tr>
         </thead>
         <tbody>
@@ -1093,6 +1258,17 @@ function VersionList({
                 <td className="dh-note-cell">{version.qc_summary ?? "-"}</td>
                 <td>{location ? <code>{location.storage_uri}</code> : "-"}</td>
                 <td>{formatDate(version.created_at)}</td>
+                {canEdit ? (
+                  <td className="dh-actions-cell">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onDeleteVersion(version.id, version.version_name)}
+                    >
+                      Delete
+                    </Button>
+                  </td>
+                ) : null}
               </tr>
             );
           })}
@@ -1219,9 +1395,6 @@ function DatasetFormModal({
     <Modal open onClose={onClose} title={dataset ? "Edit dataset" : "Register dataset"} width="wide">
       <form className="dh-form" onSubmit={handleSubmit}>
         {error ? <InlineError>{error}</InlineError> : null}
-        {accessLevel === "restricted" || accessLevel === "private" ? (
-          <InlineNote>Restricted and private datasets reduce discoverability. Use them only when metadata visibility itself is sensitive.</InlineNote>
-        ) : null}
         <FormField label="Dataset name *">
           <Input value={name} onChange={(event) => setName(event.target.value)} required />
         </FormField>
@@ -1246,7 +1419,7 @@ function DatasetFormModal({
           </FormField>
         </FormRow>
         <FormRow>
-          <FormField label="Access level">
+          <FormField label="Access level" hint={accessLevelDescription(accessLevel)}>
             <Select value={accessLevel} onChange={(event) => setAccessLevel(event.target.value as AccessLevel)}>
               {ACCESS_LEVELS.map((level) => <option key={level} value={level}>{labelize(level)}</option>)}
             </Select>
@@ -1258,6 +1431,17 @@ function DatasetFormModal({
             <MemberSelect value={contactUserId} onChange={setContactUserId} members={labMembers} />
           </FormField>
         </FormRow>
+        <fieldset className="dh-fieldset">
+          <legend>Access tier reference</legend>
+          <ul className="dh-tier-legend">
+            {ACCESS_LEVELS.map((level) => (
+              <li key={level} className={level === accessLevel ? "is-active" : undefined}>
+                <Badge tone={accessTone(level)}>{labelize(level)}</Badge>
+                <span>{accessLevelDescription(level)}</span>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
         <FormRow>
           <FormField label="Organism">
             <Input value={organism} onChange={(event) => setOrganism(event.target.value)} />

--- a/apps/data-hub/src/lib/cloudAdapter.ts
+++ b/apps/data-hub/src/lib/cloudAdapter.ts
@@ -182,6 +182,16 @@ export interface DatasetStorageLinkRecord {
   created_at: string;
 }
 
+export interface DatasetAccessGrantRecord {
+  id: string;
+  lab_id: string;
+  dataset_id: string;
+  user_id: string;
+  granted_by: string | null;
+  granted_at: string;
+  note: string | null;
+}
+
 export interface ProjectOptionRecord {
   id: string;
   name: string;
@@ -194,6 +204,7 @@ export interface DataHubWorkspaceSnapshot {
   requests: DatasetAccessRequestRecord[];
   tags: DatasetTagRecord[];
   storageLinks: DatasetStorageLinkRecord[];
+  accessGrants: DatasetAccessGrantRecord[];
   projects: ProjectOptionRecord[];
   labMembers: LabMemberRecord[];
 }
@@ -251,6 +262,8 @@ const REQUEST_FIELDS =
 const TAG_FIELDS = "id, lab_id, dataset_id, tag, created_at";
 const STORAGE_FIELDS =
   "id, lab_id, dataset_id, dataset_version_id, label, storage_uri, storage_type, notes, created_by, created_at";
+const GRANT_FIELDS =
+  "id, lab_id, dataset_id, user_id, granted_by, granted_at, note";
 
 const normalizeTags = (tags: string[]) =>
   Array.from(new Set(tags.map((tag) => tag.trim()).filter(Boolean))).slice(0, 24);
@@ -263,6 +276,7 @@ export async function listDataHubWorkspace(labId: string): Promise<DataHubWorksp
     requestsResult,
     tagsResult,
     storageLinksResult,
+    accessGrantsResult,
     projectsResult,
     members,
   ] = await Promise.all([
@@ -272,6 +286,7 @@ export async function listDataHubWorkspace(labId: string): Promise<DataHubWorksp
     client().from("dataset_access_requests").select(REQUEST_FIELDS).eq("lab_id", labId).order("created_at", { ascending: false }),
     client().from("dataset_tags").select(TAG_FIELDS).eq("lab_id", labId).order("tag", { ascending: true }),
     client().from("dataset_storage_links").select(STORAGE_FIELDS).eq("lab_id", labId).order("created_at", { ascending: true }),
+    client().from("dataset_access_grants").select(GRANT_FIELDS).eq("lab_id", labId).order("granted_at", { ascending: true }),
     client().from("projects").select("id, name").eq("lab_id", labId).order("name", { ascending: true }),
     listLabMembers(labId).catch(() => [] as LabMemberRecord[]),
   ]);
@@ -282,6 +297,7 @@ export async function listDataHubWorkspace(labId: string): Promise<DataHubWorksp
   if (requestsResult.error) throw requestsResult.error;
   if (tagsResult.error) throw tagsResult.error;
   if (storageLinksResult.error) throw storageLinksResult.error;
+  if (accessGrantsResult.error) throw accessGrantsResult.error;
   if (projectsResult.error) throw projectsResult.error;
 
   return {
@@ -291,6 +307,7 @@ export async function listDataHubWorkspace(labId: string): Promise<DataHubWorksp
     requests: (requestsResult.data as DatasetAccessRequestRecord[]) ?? [],
     tags: (tagsResult.data as DatasetTagRecord[]) ?? [],
     storageLinks: (storageLinksResult.data as DatasetStorageLinkRecord[]) ?? [],
+    accessGrants: (accessGrantsResult.data as DatasetAccessGrantRecord[]) ?? [],
     projects: (projectsResult.data as ProjectOptionRecord[]) ?? [],
     labMembers: members,
   };
@@ -389,6 +406,37 @@ export async function restoreDataset(datasetId: string): Promise<DatasetRecord> 
     .single();
   if (error) throw error;
   return data as DatasetRecord;
+}
+
+export async function deleteDataset(datasetId: string): Promise<void> {
+  const { error } = await client().rpc("delete_dataset", { p_dataset_id: datasetId });
+  if (error) throw error;
+}
+
+export async function deleteDatasetVersion(versionId: string): Promise<void> {
+  const { error } = await client().rpc("delete_dataset_version", { p_version_id: versionId });
+  if (error) throw error;
+}
+
+export async function grantDatasetAccess(args: {
+  datasetId: string;
+  userId: string;
+  note?: string | null;
+}): Promise<DatasetAccessGrantRecord> {
+  const { data, error } = await client()
+    .rpc("grant_dataset_access", {
+      p_dataset_id: args.datasetId,
+      p_user_id: args.userId,
+      p_note: args.note ?? null,
+    })
+    .single();
+  if (error) throw error;
+  return data as DatasetAccessGrantRecord;
+}
+
+export async function revokeDatasetAccess(grantId: string): Promise<void> {
+  const { error } = await client().rpc("revoke_dataset_access", { p_grant_id: grantId });
+  if (error) throw error;
 }
 
 export async function createDatasetVersion(args: {

--- a/apps/data-hub/src/lib/useDataHubWorkspace.ts
+++ b/apps/data-hub/src/lib/useDataHubWorkspace.ts
@@ -4,13 +4,18 @@ import {
   createDataset as rpcCreateDataset,
   createDatasetAccessRequest as rpcCreateDatasetAccessRequest,
   createDatasetVersion as rpcCreateDatasetVersion,
+  deleteDataset as rpcDeleteDataset,
+  deleteDatasetVersion as rpcDeleteDatasetVersion,
+  grantDatasetAccess as rpcGrantDatasetAccess,
   listDataHubWorkspace,
   recordDatasetUse as rpcRecordDatasetUse,
   restoreDataset as rpcRestoreDataset,
   reviewDatasetAccessRequest as rpcReviewDatasetAccessRequest,
+  revokeDatasetAccess as rpcRevokeDatasetAccess,
   updateDataset as rpcUpdateDataset,
   withdrawDatasetAccessRequest as rpcWithdrawDatasetAccessRequest,
   type DataHubWorkspaceSnapshot,
+  type DatasetAccessGrantRecord,
   type DatasetAccessRequestRecord,
   type DatasetInput,
   type DatasetRecord,
@@ -41,6 +46,14 @@ export interface UseDataHubWorkspaceValue extends DataHubWorkspaceSnapshot {
   }) => Promise<DatasetRecord>;
   archiveDataset: (datasetId: string) => Promise<DatasetRecord>;
   restoreDataset: (datasetId: string) => Promise<DatasetRecord>;
+  deleteDataset: (datasetId: string) => Promise<void>;
+  deleteDatasetVersion: (versionId: string) => Promise<void>;
+  grantDatasetAccess: (args: {
+    datasetId: string;
+    userId: string;
+    note?: string | null;
+  }) => Promise<DatasetAccessGrantRecord>;
+  revokeDatasetAccess: (grantId: string) => Promise<void>;
   createDatasetVersion: (args: {
     datasetId: string;
     data: VersionInput;
@@ -77,6 +90,7 @@ const EMPTY_SNAPSHOT: DataHubWorkspaceSnapshot = {
   requests: [],
   tags: [],
   storageLinks: [],
+  accessGrants: [],
   projects: [],
   labMembers: [],
 };
@@ -159,6 +173,43 @@ export function useDataHubWorkspace(args: {
     [hydrate, requireIdentity]
   );
 
+  const deleteDataset = useCallback<UseDataHubWorkspaceValue["deleteDataset"]>(
+    async (datasetId) => {
+      requireIdentity();
+      await rpcDeleteDataset(datasetId);
+      await hydrate();
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const deleteDatasetVersion = useCallback<UseDataHubWorkspaceValue["deleteDatasetVersion"]>(
+    async (versionId) => {
+      requireIdentity();
+      await rpcDeleteDatasetVersion(versionId);
+      await hydrate();
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const grantDatasetAccess = useCallback<UseDataHubWorkspaceValue["grantDatasetAccess"]>(
+    async (input) => {
+      requireIdentity();
+      const created = await rpcGrantDatasetAccess(input);
+      await hydrate();
+      return created;
+    },
+    [hydrate, requireIdentity]
+  );
+
+  const revokeDatasetAccess = useCallback<UseDataHubWorkspaceValue["revokeDatasetAccess"]>(
+    async (grantId) => {
+      requireIdentity();
+      await rpcRevokeDatasetAccess(grantId);
+      await hydrate();
+    },
+    [hydrate, requireIdentity]
+  );
+
   const createDatasetVersion = useCallback<UseDataHubWorkspaceValue["createDatasetVersion"]>(
     async (input) => {
       const identity = requireIdentity();
@@ -218,6 +269,10 @@ export function useDataHubWorkspace(args: {
     updateDataset,
     archiveDataset,
     restoreDataset,
+    deleteDataset,
+    deleteDatasetVersion,
+    grantDatasetAccess,
+    revokeDatasetAccess,
     createDatasetVersion,
     createDatasetAccessRequest,
     recordDatasetUse,

--- a/apps/data-hub/src/styles.css
+++ b/apps/data-hub/src/styles.css
@@ -323,6 +323,59 @@
   accent-color: var(--rl-green);
 }
 
+.dh-tier-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dh-tier-legend li {
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+  color: var(--rl-fg-2);
+  font-size: 0.84rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--rl-radius-sm);
+  border: 1px solid transparent;
+}
+
+.dh-tier-legend li.is-active {
+  border-color: var(--rl-line);
+  background: var(--rl-soft);
+  color: var(--rl-ink);
+}
+
+.dh-grant-add {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.dh-grant-add > :first-child {
+  flex: 1 1 auto;
+}
+
+.dh-grant-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dh-grant-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--rl-line);
+  border-radius: var(--rl-radius-sm);
+  background: var(--rl-bg);
+}
+
 @media (max-width: 1100px) {
   .dh-filter-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/supabase/migrations/20260504030000_data_hub_delete_and_private.sql
+++ b/supabase/migrations/20260504030000_data_hub_delete_and_private.sql
@@ -1,0 +1,167 @@
+-- Data Hub: hard-delete RPCs + distinct private vs restricted semantics
+--
+-- Until now `archive_dataset` was the only removal path, leaving no way to
+-- get rid of a mistakenly-created dataset. Add admin-only `delete_dataset`
+-- and editor-scoped `delete_dataset_version` so the UI's delete button has a
+-- backend to call.
+--
+-- Also disambiguate `restricted` and `private`. Previously both fell through
+-- the same `can_view_dataset` branch (admin/owner/contact OR approved
+-- request), so picking between them in the form had no behavioural effect.
+-- New semantics:
+--   open-lab          metadata + storage visible to every lab member
+--   request-required  metadata visible to every lab member; storage gated
+--   restricted        only owner/contact/admin discover by default; other
+--                     members may submit access requests
+--   private           only owner/contact/admin can see anything; new access
+--                     requests are rejected
+
+create or replace function public.can_view_dataset(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.datasets d
+    where d.id = p_dataset_id
+      and public.is_lab_member(d.lab_id)
+      and (
+        d.access_level in ('open-lab', 'request-required')
+        or public.is_lab_admin(d.lab_id)
+        or d.owner_user_id = auth.uid()
+        or d.contact_user_id = auth.uid()
+        or (
+          d.access_level = 'restricted'
+          and exists (
+            select 1
+            from public.dataset_access_requests r
+            where r.dataset_id = d.id
+              and r.requester_user_id = auth.uid()
+              and r.status = 'approved'
+          )
+        )
+      )
+  );
+$$;
+
+grant execute on function public.can_view_dataset(uuid) to authenticated;
+
+create or replace function public.delete_dataset(p_dataset_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.datasets%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select * into v_row from public.datasets where id = p_dataset_id;
+  if not found then
+    raise exception 'dataset not found' using errcode = '02000';
+  end if;
+  if not public.is_lab_admin(v_row.lab_id) then
+    raise exception 'only lab admins can delete a dataset' using errcode = '42501';
+  end if;
+
+  delete from public.datasets where id = p_dataset_id;
+  perform public._log_audit(v_row.lab_id, 'dataset', p_dataset_id, 'delete',
+    jsonb_build_object('name', v_row.name));
+end;
+$$;
+
+create or replace function public.delete_dataset_version(p_version_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.dataset_versions%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+
+  select * into v_row from public.dataset_versions where id = p_version_id;
+  if not found then
+    raise exception 'dataset version not found' using errcode = '02000';
+  end if;
+  if not public.can_edit_dataset(v_row.dataset_id) then
+    raise exception 'not permitted to delete this dataset version' using errcode = '42501';
+  end if;
+
+  delete from public.dataset_versions where id = p_version_id;
+  perform public._log_audit(v_row.lab_id, 'dataset_version', p_version_id, 'delete',
+    jsonb_build_object('dataset_id', v_row.dataset_id, 'version_name', v_row.version_name));
+end;
+$$;
+
+-- Reject access requests for private datasets at the RPC layer so the UI can
+-- relay a clear error rather than letting them stack up on a tier that does
+-- not allow approvals.
+create or replace function public.submit_dataset_access_request(
+  p_dataset_id uuid,
+  p_dataset_version_id uuid default null,
+  p_project_id uuid default null,
+  p_intended_use text default null,
+  p_requested_access_type text default 'reuse-in-project'
+) returns public.dataset_access_requests
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_intended_use text := nullif(btrim(coalesce(p_intended_use, '')), '');
+  v_dataset public.datasets%rowtype;
+  v_row public.dataset_access_requests%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  select * into v_dataset from public.datasets where id = p_dataset_id;
+  if not found then
+    raise exception 'dataset not found' using errcode = '02000';
+  end if;
+  if v_dataset.access_level = 'private' then
+    raise exception 'private datasets do not accept access requests; contact the owner directly'
+      using errcode = '42501';
+  end if;
+  if not public.can_view_dataset(p_dataset_id) then
+    raise exception 'dataset is not visible to this user' using errcode = '42501';
+  end if;
+  if v_intended_use is null then
+    raise exception 'intended use is required' using errcode = '22023';
+  end if;
+  if p_dataset_version_id is not null and not exists (
+    select 1 from public.dataset_versions v
+    where v.id = p_dataset_version_id and v.dataset_id = p_dataset_id
+  ) then
+    raise exception 'version must belong to this dataset' using errcode = '22023';
+  end if;
+  if p_project_id is not null and not exists (
+    select 1 from public.projects p
+    where p.id = p_project_id and p.lab_id = v_dataset.lab_id
+  ) then
+    raise exception 'project is not in this lab' using errcode = '22023';
+  end if;
+
+  insert into public.dataset_access_requests (
+    lab_id, dataset_id, dataset_version_id, requester_user_id, project_id,
+    intended_use, requested_access_type, status
+  ) values (
+    v_dataset.lab_id,
+    p_dataset_id,
+    p_dataset_version_id,
+    v_uid,
+    p_project_id,
+    v_intended_use,
+    coalesce(p_requested_access_type, 'reuse-in-project'),
+    'pending'
+  )
+  returning * into v_row;
+
+  perform public._log_audit(v_dataset.lab_id, 'dataset_access_request', v_row.id, 'submit',
+    jsonb_build_object('dataset_id', p_dataset_id, 'project_id', p_project_id));
+  return v_row;
+end;
+$$;
+
+grant execute on function public.delete_dataset(uuid) to authenticated;
+grant execute on function public.delete_dataset_version(uuid) to authenticated;

--- a/supabase/migrations/20260504040000_data_hub_access_grants.sql
+++ b/supabase/migrations/20260504040000_data_hub_access_grants.sql
@@ -1,0 +1,290 @@
+-- Data Hub: explicit allow-list for restricted/private datasets
+--
+-- Reworks the four access tiers around a clearer mental model:
+--
+--   open-lab          everyone in the lab discovers + sees storage; uses are
+--                     recorded directly (no review)
+--   request-required  everyone in the lab discovers metadata; storage URL is
+--                     hidden until the owner approves a request
+--   restricted        only owner-assigned users discover the dataset at all;
+--                     no public request flow, the owner curates the list
+--   private           same allow-list mechanism as restricted; signals stricter
+--                     intent (default = owner only)
+--
+-- For any tier where a viewer is not yet permitted, metadata is visible (when
+-- the tier exposes metadata) but storage URLs are not.
+
+create table if not exists public.dataset_access_grants (
+  id uuid primary key default gen_random_uuid(),
+  lab_id uuid not null references public.labs(id) on delete cascade,
+  dataset_id uuid not null references public.datasets(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  granted_by uuid references auth.users(id) on delete set null,
+  granted_at timestamptz not null default now(),
+  note text,
+  unique(dataset_id, user_id)
+);
+
+create index if not exists dataset_access_grants_dataset_idx
+  on public.dataset_access_grants (dataset_id);
+create index if not exists dataset_access_grants_user_idx
+  on public.dataset_access_grants (user_id);
+create index if not exists dataset_access_grants_lab_idx
+  on public.dataset_access_grants (lab_id);
+
+alter table public.dataset_access_grants enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- View helpers
+-- ---------------------------------------------------------------------------
+
+create or replace function public.has_dataset_access_grant(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.dataset_access_grants g
+    where g.dataset_id = p_dataset_id
+      and g.user_id = auth.uid()
+  );
+$$;
+
+grant execute on function public.has_dataset_access_grant(uuid) to authenticated;
+
+create or replace function public.can_view_dataset(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.datasets d
+    where d.id = p_dataset_id
+      and public.is_lab_member(d.lab_id)
+      and (
+        d.access_level in ('open-lab', 'request-required')
+        or public.is_lab_admin(d.lab_id)
+        or d.owner_user_id = auth.uid()
+        or d.contact_user_id = auth.uid()
+        or public.has_dataset_access_grant(d.id)
+      )
+  );
+$$;
+
+create or replace function public.can_view_dataset_storage(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.datasets d
+    where d.id = p_dataset_id
+      and public.is_lab_member(d.lab_id)
+      and (
+        d.access_level = 'open-lab'
+        or public.is_lab_admin(d.lab_id)
+        or d.owner_user_id = auth.uid()
+        or d.contact_user_id = auth.uid()
+        or (
+          d.access_level = 'request-required'
+          and exists (
+            select 1
+            from public.dataset_access_requests r
+            where r.dataset_id = d.id
+              and r.requester_user_id = auth.uid()
+              and r.status = 'approved'
+          )
+        )
+        or (
+          d.access_level in ('restricted', 'private')
+          and public.has_dataset_access_grant(d.id)
+        )
+      )
+  );
+$$;
+
+grant execute on function public.can_view_dataset(uuid) to authenticated;
+grant execute on function public.can_view_dataset_storage(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- RLS for grants
+-- ---------------------------------------------------------------------------
+
+-- A granted user only needs to know their own grant exists (so the dataset
+-- shows up in their library). The full grant list — i.e. who else has access —
+-- is curator-only (owner / contact / admin / created_by).
+drop policy if exists dataset_access_grants_select on public.dataset_access_grants;
+create policy dataset_access_grants_select on public.dataset_access_grants
+  for select using (
+    user_id = auth.uid()
+    or public.can_edit_dataset(dataset_id)
+  );
+
+drop policy if exists dataset_access_grants_insert on public.dataset_access_grants;
+create policy dataset_access_grants_insert on public.dataset_access_grants
+  for insert with check (
+    public.can_edit_dataset(dataset_id)
+    and exists (
+      select 1 from public.datasets d
+      where d.id = dataset_access_grants.dataset_id
+        and d.lab_id = dataset_access_grants.lab_id
+    )
+    and exists (
+      select 1 from public.lab_memberships m
+      where m.lab_id = dataset_access_grants.lab_id
+        and m.user_id = dataset_access_grants.user_id
+    )
+  );
+
+drop policy if exists dataset_access_grants_delete on public.dataset_access_grants;
+create policy dataset_access_grants_delete on public.dataset_access_grants
+  for delete using (public.can_edit_dataset(dataset_id));
+
+-- ---------------------------------------------------------------------------
+-- Grant/revoke RPCs
+-- ---------------------------------------------------------------------------
+
+create or replace function public.grant_dataset_access(
+  p_dataset_id uuid,
+  p_user_id uuid,
+  p_note text default null
+) returns public.dataset_access_grants
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_dataset public.datasets%rowtype;
+  v_row public.dataset_access_grants%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  select * into v_dataset from public.datasets where id = p_dataset_id;
+  if not found then
+    raise exception 'dataset not found' using errcode = '02000';
+  end if;
+  if not public.can_edit_dataset(p_dataset_id) then
+    raise exception 'not permitted to manage access for this dataset' using errcode = '42501';
+  end if;
+  if not exists (
+    select 1 from public.lab_memberships m
+    where m.lab_id = v_dataset.lab_id and m.user_id = p_user_id
+  ) then
+    raise exception 'user is not a member of this lab' using errcode = '22023';
+  end if;
+
+  insert into public.dataset_access_grants (
+    lab_id, dataset_id, user_id, granted_by, note
+  ) values (
+    v_dataset.lab_id,
+    p_dataset_id,
+    p_user_id,
+    v_uid,
+    nullif(btrim(coalesce(p_note, '')), '')
+  )
+  on conflict (dataset_id, user_id)
+    do update set granted_by = excluded.granted_by, note = excluded.note
+  returning * into v_row;
+
+  perform public._log_audit(v_dataset.lab_id, 'dataset_access_grant', v_row.id, 'grant',
+    jsonb_build_object('dataset_id', p_dataset_id, 'user_id', p_user_id));
+  return v_row;
+end;
+$$;
+
+create or replace function public.revoke_dataset_access(p_grant_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_row public.dataset_access_grants%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  select * into v_row from public.dataset_access_grants where id = p_grant_id;
+  if not found then
+    raise exception 'access grant not found' using errcode = '02000';
+  end if;
+  if not public.can_edit_dataset(v_row.dataset_id) then
+    raise exception 'not permitted to manage access for this dataset' using errcode = '42501';
+  end if;
+
+  delete from public.dataset_access_grants where id = p_grant_id;
+  perform public._log_audit(v_row.lab_id, 'dataset_access_grant', p_grant_id, 'revoke',
+    jsonb_build_object('dataset_id', v_row.dataset_id, 'user_id', v_row.user_id));
+end;
+$$;
+
+grant execute on function public.grant_dataset_access(uuid, uuid, text) to authenticated;
+grant execute on function public.revoke_dataset_access(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Requests are now only valid for `request-required`. Restricted and private
+-- are owner-curated and reject submissions outright.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.submit_dataset_access_request(
+  p_dataset_id uuid,
+  p_dataset_version_id uuid default null,
+  p_project_id uuid default null,
+  p_intended_use text default null,
+  p_requested_access_type text default 'reuse-in-project'
+) returns public.dataset_access_requests
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_intended_use text := nullif(btrim(coalesce(p_intended_use, '')), '');
+  v_dataset public.datasets%rowtype;
+  v_row public.dataset_access_requests%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  select * into v_dataset from public.datasets where id = p_dataset_id;
+  if not found then
+    raise exception 'dataset not found' using errcode = '02000';
+  end if;
+  if v_dataset.access_level in ('restricted', 'private') then
+    raise exception 'this dataset does not accept requests; ask the owner to grant access directly'
+      using errcode = '42501';
+  end if;
+  if v_dataset.access_level = 'open-lab' then
+    raise exception 'open-lab datasets do not need a request; record use directly'
+      using errcode = '22023';
+  end if;
+  if not public.can_view_dataset(p_dataset_id) then
+    raise exception 'dataset is not visible to this user' using errcode = '42501';
+  end if;
+  if v_intended_use is null then
+    raise exception 'intended use is required' using errcode = '22023';
+  end if;
+  if p_dataset_version_id is not null and not exists (
+    select 1 from public.dataset_versions v
+    where v.id = p_dataset_version_id and v.dataset_id = p_dataset_id
+  ) then
+    raise exception 'version must belong to this dataset' using errcode = '22023';
+  end if;
+  if p_project_id is not null and not exists (
+    select 1 from public.projects p
+    where p.id = p_project_id and p.lab_id = v_dataset.lab_id
+  ) then
+    raise exception 'project is not in this lab' using errcode = '22023';
+  end if;
+
+  insert into public.dataset_access_requests (
+    lab_id, dataset_id, dataset_version_id, requester_user_id, project_id,
+    intended_use, requested_access_type, status
+  ) values (
+    v_dataset.lab_id,
+    p_dataset_id,
+    p_dataset_version_id,
+    v_uid,
+    p_project_id,
+    v_intended_use,
+    coalesce(p_requested_access_type, 'reuse-in-project'),
+    'pending'
+  )
+  returning * into v_row;
+
+  perform public._log_audit(v_dataset.lab_id, 'dataset_access_request', v_row.id, 'submit',
+    jsonb_build_object('dataset_id', p_dataset_id, 'project_id', p_project_id));
+  return v_row;
+end;
+$$;

--- a/supabase/migrations/20260504050000_data_hub_private_strict.sql
+++ b/supabase/migrations/20260504050000_data_hub_private_strict.sql
@@ -1,0 +1,161 @@
+-- Data Hub: tighten `private` to creator + admins only
+--
+-- Earlier passes treated private and restricted as the same allow-list
+-- mechanism. Per the product model the two should diverge:
+--
+--   private     visible only to the dataset's creator/owner and lab
+--               admins/owner. The contact field does not grant view, and
+--               grants are refused — there is no way to share with other
+--               members short of changing the access level.
+--   restricted  visible to owner, contact, lab admins, AND any user the
+--               owner explicitly grants access. Requests still rejected.
+--
+-- This keeps `private` meaningful as the "do not share" tier and `restricted`
+-- as "share with a curated subset".
+
+create or replace function public.can_view_dataset(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.datasets d
+    where d.id = p_dataset_id
+      and public.is_lab_member(d.lab_id)
+      and (
+        case d.access_level
+          when 'open-lab' then true
+          when 'request-required' then true
+          when 'restricted' then
+            public.is_lab_admin(d.lab_id)
+            or d.owner_user_id = auth.uid()
+            or d.created_by = auth.uid()
+            or d.contact_user_id = auth.uid()
+            or public.has_dataset_access_grant(d.id)
+          when 'private' then
+            public.is_lab_admin(d.lab_id)
+            or d.owner_user_id = auth.uid()
+            or d.created_by = auth.uid()
+          else false
+        end
+      )
+  );
+$$;
+
+create or replace function public.can_view_dataset_storage(p_dataset_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.datasets d
+    where d.id = p_dataset_id
+      and public.is_lab_member(d.lab_id)
+      and (
+        case d.access_level
+          when 'open-lab' then true
+          when 'request-required' then
+            public.is_lab_admin(d.lab_id)
+            or d.owner_user_id = auth.uid()
+            or d.contact_user_id = auth.uid()
+            or exists (
+              select 1
+              from public.dataset_access_requests r
+              where r.dataset_id = d.id
+                and r.requester_user_id = auth.uid()
+                and r.status = 'approved'
+            )
+          when 'restricted' then
+            public.is_lab_admin(d.lab_id)
+            or d.owner_user_id = auth.uid()
+            or d.created_by = auth.uid()
+            or d.contact_user_id = auth.uid()
+            or public.has_dataset_access_grant(d.id)
+          when 'private' then
+            public.is_lab_admin(d.lab_id)
+            or d.owner_user_id = auth.uid()
+            or d.created_by = auth.uid()
+          else false
+        end
+      )
+  );
+$$;
+
+grant execute on function public.can_view_dataset(uuid) to authenticated;
+grant execute on function public.can_view_dataset_storage(uuid) to authenticated;
+
+-- Refuse grants on private datasets so the UI's lack of grant management for
+-- private cannot be circumvented via direct RPC.
+create or replace function public.grant_dataset_access(
+  p_dataset_id uuid,
+  p_user_id uuid,
+  p_note text default null
+) returns public.dataset_access_grants
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_dataset public.datasets%rowtype;
+  v_row public.dataset_access_grants%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  select * into v_dataset from public.datasets where id = p_dataset_id;
+  if not found then
+    raise exception 'dataset not found' using errcode = '02000';
+  end if;
+  if not public.can_edit_dataset(p_dataset_id) then
+    raise exception 'not permitted to manage access for this dataset' using errcode = '42501';
+  end if;
+  if v_dataset.access_level = 'private' then
+    raise exception 'private datasets cannot be shared; switch to restricted to grant access'
+      using errcode = '42501';
+  end if;
+  if v_dataset.access_level not in ('restricted') then
+    raise exception 'only restricted datasets use the grant list (open-lab/request-required do not need grants)'
+      using errcode = '22023';
+  end if;
+  if not exists (
+    select 1 from public.lab_memberships m
+    where m.lab_id = v_dataset.lab_id and m.user_id = p_user_id
+  ) then
+    raise exception 'user is not a member of this lab' using errcode = '22023';
+  end if;
+
+  insert into public.dataset_access_grants (
+    lab_id, dataset_id, user_id, granted_by, note
+  ) values (
+    v_dataset.lab_id,
+    p_dataset_id,
+    p_user_id,
+    v_uid,
+    nullif(btrim(coalesce(p_note, '')), '')
+  )
+  on conflict (dataset_id, user_id)
+    do update set granted_by = excluded.granted_by, note = excluded.note
+  returning * into v_row;
+
+  perform public._log_audit(v_dataset.lab_id, 'dataset_access_grant', v_row.id, 'grant',
+    jsonb_build_object('dataset_id', p_dataset_id, 'user_id', p_user_id));
+  return v_row;
+end;
+$$;
+
+grant execute on function public.grant_dataset_access(uuid, uuid, text) to authenticated;
+
+-- Drop any stale grants attached to a dataset that has since been switched to
+-- private, so the access list does not silently re-activate if the dataset is
+-- ever flipped back to restricted.
+create or replace function public._purge_grants_on_private()
+returns trigger
+language plpgsql as $$
+begin
+  if new.access_level = 'private' and (old.access_level is null or old.access_level <> 'private') then
+    delete from public.dataset_access_grants where dataset_id = new.id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists datasets_purge_grants_on_private on public.datasets;
+create trigger datasets_purge_grants_on_private
+after update of access_level on public.datasets
+for each row execute function public._purge_grants_on_private();


### PR DESCRIPTION
## Summary
- Add `delete_dataset` (admin-only) and `delete_dataset_version` (editor) RPCs and surface Delete buttons in the UI; archive remains the soft-state path.
- Introduce `dataset_access_grants` for an owner-curated allow-list. Restricted datasets now appear only in the libraries of users the owner explicitly grants. Private datasets are tighter still — visible only to the creator/owner and lab admins; the grant RPC + a trigger refuse / clear any grants on private.
- Reject access requests for restricted/private/open-lab; requests are only meaningful for `request-required`. Open-lab uses `record_dataset_use`.
- Per-tier descriptions in the dataset form, an inline tier-reference legend, and a Permitted-users panel (restricted only) for managing the grant list.

### Final tier model

| Tier | Sees metadata | Sees storage URL | Sharing |
|---|---|---|---|
| open-lab | every member | every member | record use directly |
| request-required | every member | owner/contact/admin + approved request | submit access request |
| restricted | owner + contact + admins + grants | same as discovery | owner curates grant list |
| private | owner/creator + admins | same as discovery | not shareable — switch to Restricted |

## Migrations (apply in order)
1. `20260504030000_data_hub_delete_and_private.sql`
2. `20260504040000_data_hub_access_grants.sql`
3. `20260504050000_data_hub_private_strict.sql`

## Test plan
- [ ] Apply migrations against the Supabase project.
- [ ] As an admin, create a dataset, hit Delete, verify it disappears (and child rows go too).
- [ ] Create a `restricted` dataset; confirm a non-granted member doesn't see it; grant them; confirm it appears in their library and storage URL is visible.
- [ ] Switch the same dataset to `private`; confirm grants are purged and the previously-granted member loses access.
- [ ] On a `request-required` dataset, confirm metadata is visible to everyone but storage URL stays hidden until the owner approves a request.
- [ ] On an `open-lab` dataset, confirm Record use still creates an approved request and a `used-by` project link.
- [ ] Try to call `submit_dataset_access_request` against a restricted/private/open-lab dataset; confirm a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)