### PR TITLE
Add equipment and kit inventory categories

### DIFF
--- a/apps/account/src/lib/dashboardData.ts
+++ b/apps/account/src/lib/dashboardData.ts
@@ -21,6 +21,8 @@ export type InventoryStats = {
   consumables: number;
   supplies: number;
   samples: number;
+  equipment: number;
+  kits: number;
   other: number;
   criticalLow: number;
   inOrder: number;
@@ -84,7 +86,19 @@ export type DashboardData = {
 const emptyState: Omit<DashboardData, "refresh"> = {
   projects: { draft: 0, published: 0, deleted: 0, total: 0 },
   protocols: { total: 0, active: 0, inReview: 0, archived: 0 },
-  inventory: { total: 0, reagents: 0, consumables: 0, supplies: 0, samples: 0, other: 0, criticalLow: 0, inOrder: 0, unchecked: 0 },
+  inventory: {
+    total: 0,
+    reagents: 0,
+    consumables: 0,
+    supplies: 0,
+    samples: 0,
+    equipment: 0,
+    kits: 0,
+    other: 0,
+    criticalLow: 0,
+    inOrder: 0,
+    unchecked: 0,
+  },
   team: { total: 0, owners: 0, admins: 0, members: 0, recentAvatars: [] },
   pending: { protocols: 0, projects: 0, orders: 0, members: 0, bookings: 0, datasets: 0 },
   schedule: [],
@@ -302,6 +316,8 @@ export const useDashboardData = (
           consumables: byClass("consumable"),
           supplies: byClass("supply"),
           samples: byClass("sample"),
+          equipment: byClass("equipment"),
+          kits: byClass("kit"),
           other: byClass("other"),
           criticalLow: 0,
           inOrder: 0,

--- a/apps/account/src/views/OverviewView.tsx
+++ b/apps/account/src/views/OverviewView.tsx
@@ -263,15 +263,13 @@ const ReviewQueueCard = ({
 // ---------------------------------------------------------------------------
 
 const InventoryRadar = ({ stats, stockedPct }: { stats: InventoryStats; stockedPct: number | null }) => {
-  // Six axes: 4 known classifications + 2 placeholder slots so the polygon
-  // still reads as a hexagon while we wait for additional taxonomy.
   const axes: { label: string; value: number }[] = [
     { label: "Reagents", value: stats.reagents },
     { label: "Supplies", value: stats.supplies },
     { label: "Samples", value: stats.samples },
     { label: "Consumables", value: stats.consumables },
-    { label: "Other 1", value: stats.other },
-    { label: "Other 2", value: 0 },
+    { label: "Equipment", value: stats.equipment },
+    { label: "Kits", value: stats.kits },
   ];
   const max = Math.max(1, ...axes.map((a) => a.value));
   const cx = 75;

--- a/apps/supply-manager/src/App.tsx
+++ b/apps/supply-manager/src/App.tsx
@@ -51,7 +51,15 @@ import type {
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
-const CLASSIFICATIONS: ItemClassification[] = ["reagent", "consumable", "supply", "sample", "other"];
+const CLASSIFICATIONS: ItemClassification[] = [
+  "reagent",
+  "consumable",
+  "supply",
+  "sample",
+  "equipment",
+  "kit",
+  "other",
+];
 const STOCK_STATUSES: StockStatus[] = ["plenty", "medium", "low", "out", "unknown"];
 const REQUEST_PRIORITIES: RequestPriority[] = ["low", "normal", "high", "urgent"];
 const ASSOCIATION_TYPES: ItemAssociationType[] = ["primary", "shared", "temporary", "general"];

--- a/apps/supply-manager/src/lib/cloudAdapter.ts
+++ b/apps/supply-manager/src/lib/cloudAdapter.ts
@@ -11,7 +11,14 @@ export type { FundingAssignmentStatus, FundingDefaultRecord, FundingSourceRecord
 // Domain types
 // ---------------------------------------------------------------------------
 
-export type ItemClassification = "reagent" | "consumable" | "supply" | "sample" | "other";
+export type ItemClassification =
+  | "reagent"
+  | "consumable"
+  | "supply"
+  | "sample"
+  | "equipment"
+  | "kit"
+  | "other";
 
 export type StockStatus = "plenty" | "medium" | "low" | "out" | "unknown";
 

--- a/supabase/migrations/20260504060000_supply_add_equipment_kit.sql
+++ b/supabase/migrations/20260504060000_supply_add_equipment_kit.sql
@@ -1,0 +1,21 @@
+-- Add `equipment` and `kit` to the items.classification check constraint.
+--
+-- The original supply_manager migration restricted classification to
+-- ('reagent', 'consumable', 'supply', 'sample', 'other'). Labs need to track
+-- equipment (durable instruments / hardware) and kits (bundled assay kits)
+-- as first-class categories alongside the existing taxonomy.
+
+alter table public.items
+  drop constraint if exists items_classification_check;
+
+alter table public.items
+  add constraint items_classification_check
+  check (classification in (
+    'reagent',
+    'consumable',
+    'supply',
+    'sample',
+    'equipment',
+    'kit',
+    'other'
+  ));


### PR DESCRIPTION
Extends ItemClassification with `equipment` and `kit` so labs can track durable instruments and assay kits as first-class categories. Surfaces both on the home-page inventory radar, replacing the Other 1 / Other 2 placeholder slots.