### PR TITLE
Fix invited-user profile save and add password change in Account Settings

### DIFF
--- a/apps/account/src/views/SettingsView.tsx
+++ b/apps/account/src/views/SettingsView.tsx
@@ -58,7 +58,16 @@ const downscaleToDataUrl = (dataUrl: string): Promise<string> =>
   });
 
 export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
-  const { activeLab, profile, user, signOut, updateProfile, renameLab, refreshLabs } = useAuth();
+  const {
+    activeLab,
+    profile,
+    user,
+    signOut,
+    updateProfile,
+    updatePassword,
+    renameLab,
+    refreshLabs,
+  } = useAuth();
   const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
   const isOwner = tier === "owner";
   const email = profile?.email ?? user?.email ?? "";
@@ -76,6 +85,14 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
   const [labBusy, setLabBusy] = useState(false);
   const [labError, setLabError] = useState<string | null>(null);
   const [labNotice, setLabNotice] = useState<string | null>(null);
+
+  // Password editor state
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordBusy, setPasswordBusy] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordNotice, setPasswordNotice] = useState<string | null>(null);
 
   // Re-sync local state when the underlying profile/lab changes.
   useEffect(() => {
@@ -130,6 +147,37 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
       setProfileError(errorMessage(err));
     } finally {
       setProfileBusy(false);
+    }
+  };
+
+
+  const handleChangePassword = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordError(null);
+    setPasswordNotice(null);
+    if (!currentPassword.trim()) {
+      setPasswordError("Enter your current password for confirmation.");
+      return;
+    }
+    if (newPassword.trim().length < 8) {
+      setPasswordError("New password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError("New password and confirmation do not match.");
+      return;
+    }
+    setPasswordBusy(true);
+    try {
+      await updatePassword(newPassword);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setPasswordNotice("Password updated.");
+    } catch (err) {
+      setPasswordError(errorMessage(err));
+    } finally {
+      setPasswordBusy(false);
     }
   };
 
@@ -238,6 +286,60 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
               disabled={profileBusy}
             >
               Sign out
+            </button>
+          </div>
+        </form>
+      </section>
+
+
+      <section className="acct-card">
+        <div className="acct-card-header">
+          <div>
+            <h2>Password</h2>
+            <p>Change the password used to sign in to your account.</p>
+          </div>
+        </div>
+
+        <form className="acct-form" onSubmit={handleChangePassword}>
+          <label className="acct-field">
+            <span>Current password</span>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(event) => setCurrentPassword(event.target.value)}
+              autoComplete="current-password"
+              disabled={passwordBusy}
+            />
+          </label>
+          <label className="acct-field">
+            <span>New password</span>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              autoComplete="new-password"
+              minLength={8}
+              disabled={passwordBusy}
+            />
+          </label>
+          <label className="acct-field">
+            <span>Confirm new password</span>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              autoComplete="new-password"
+              minLength={8}
+              disabled={passwordBusy}
+            />
+          </label>
+
+          {passwordError ? <p className="acct-error">{passwordError}</p> : null}
+          {passwordNotice ? <small style={{ color: "var(--ilm-viridian)" }}>{passwordNotice}</small> : null}
+
+          <div className="acct-row-actions">
+            <button type="submit" className="acct-primary-button" disabled={passwordBusy}>
+              {passwordBusy ? "Updating…" : "Change password"}
             </button>
           </div>
         </form>

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -28,6 +28,7 @@ type AuthContextValue = {
   signUp: (email: string, password: string, displayName?: string) => Promise<{ needsEmailConfirmation: boolean }>;
   signOut: () => Promise<void>;
   sendPasswordReset: (email: string, redirectTo?: string) => Promise<void>;
+  updatePassword: (nextPassword: string) => Promise<void>;
 
   // Profile actions
   updateProfile: (changes: { display_name?: string | null; headshot_url?: string | null }) => Promise<Profile>;
@@ -290,6 +291,23 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     setActiveLabId(labId);
   }, []);
 
+  const updatePassword = useCallback(
+    async (nextPassword: string): Promise<void> => {
+      if (!user) throw new Error("Not signed in");
+      const normalized = nextPassword.trim();
+      if (normalized.length < 8) {
+        throw new Error("Password must be at least 8 characters.");
+      }
+      setError(null);
+      const { error: err } = await supabase.auth.updateUser({ password: normalized });
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [supabase, user]
+  );
+
   const updateProfile = useCallback(
     async (changes: { display_name?: string | null; headshot_url?: string | null }): Promise<Profile> => {
       if (!user) throw new Error("Not signed in");
@@ -306,10 +324,10 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         if (!profile) throw new Error("Profile not loaded");
         return profile;
       }
+      const payload = { ...patch, id: user.id, email: user.email ?? null };
       const { data, error: err } = await supabase
         .from("profiles")
-        .update(patch)
-        .eq("id", user.id)
+        .upsert(payload, { onConflict: "id" })
         .select("id, display_name, email, headshot_url")
         .single();
       if (err) {
@@ -357,6 +375,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     signUp,
     signOut,
     sendPasswordReset,
+    updatePassword,
     updateProfile,
     selectLab,
     createLab,


### PR DESCRIPTION
### Motivation
- Invited users who had no existing `profiles` row could not save a display name or headshot, and there was no in-app UI to change the signed-in user's password from Account Settings.

### Description
- Change profile persistence to `upsert(..., { onConflict: "id" })` and include `id`/`email` in the payload so invited users without a prior `profiles` row can save `display_name` and `headshot_url` (file: `packages/ui/src/auth/AuthProvider.tsx`).
- Add a new `updatePassword` action to the auth context which calls `supabase.auth.updateUser` with a minimum-length guard and error propagation (file: `packages/ui/src/auth/AuthProvider.tsx`).
- Extend the Account Settings view with a new Password section (current/new/confirm fields), client-side validation, submit handling, and success/error notices, and wire it to the new `updatePassword` action (file: `apps/account/src/views/SettingsView.tsx`).
- Expose the new `updatePassword` in the `AuthContext` type and provider value so UI consumers can call it (file: `packages/ui/src/auth/AuthProvider.tsx`).

### Testing
- Ran `npm run typecheck` across workspaces and the TypeScript checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b49cf948832497b0f8eece063ae9)