### PR TITLE
Restrict project publish approval to admins/owners only

### DIFF
--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -695,10 +695,7 @@ export const App = () => {
     return set;
   }, [projectMembers, user?.id]);
 
-  const canReviewProject = useCallback(
-    (project: ProjectRecord) => isAdmin || myLeadProjectIds.has(project.id),
-    [isAdmin, myLeadProjectIds]
-  );
+  const canReviewProject = useCallback((_: ProjectRecord) => isAdmin, [isAdmin]);
 
   const pendingForMyReview = useMemo(
     () => pendingForReview.filter((project) => isAdmin || myLeadProjectIds.has(project.id)),


### PR DESCRIPTION
### Motivation
- Fix a bug where non-admin users (including project leads) could use the direct "Publish now" path from the draft edit view instead of being forced to submit for review, so only lab admins/owners may approve and publish projects directly.

### Description
- Update `apps/project-manager/src/App.tsx` by changing `canReviewProject` to return only `isAdmin` (owners/admins) rather than allowing project leads via `myLeadProjectIds`, which ensures the UI shows "Publish now" only to admins and keeps others on "Publish for review".

### Testing
- Ran TypeScript checks with `npm run -w apps/project-manager typecheck` and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bfe889808324ace65c734ef5806b)