### PR TITLE
Add print scaling with zoom plus transform fallback to print styles

### DIFF
--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -2371,9 +2371,22 @@ const PRINT_WINDOW_STYLES = `
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   }
 
+  body.print-window-body {
+    --print-recommended-scale: 0.8;
+  }
+
   .print-document {
     max-width: 900px;
     margin: 0 auto;
+    zoom: var(--print-recommended-scale);
+    transform-origin: top center;
+  }
+
+  @supports not (zoom: 1) {
+    .print-document {
+      transform: scale(var(--print-recommended-scale));
+      width: calc(100% / var(--print-recommended-scale));
+    }
   }
 
   .preview-section,


### PR DESCRIPTION
### Motivation

- Ensure printed protocol documents render at a consistent, recommended scale across browsers by providing a configurable scale and a cross-browser fallback.

### Description

- Introduce a CSS variable `--print-recommended-scale: 0.8` on `body.print-window-body` to allow adjusting default print scale.
- Apply `zoom: var(--print-recommended-scale)` and `transform-origin: top center` to `.print-document` to scale content in browsers that support `zoom`.
- Add an `@supports not (zoom: 1)` rule that uses `transform: scale(var(--print-recommended-scale))` with `width: calc(100% / var(--print-recommended-scale))` to preserve layout in browsers without `zoom` support.

### Testing

- Ran a project build with `yarn build` and ran the existing test suite with `yarn test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d26fd2a883249948e052c25e112d)