### PR TITLE
Use subtab label for Scheduler topbar title and rename sidebar Calendar → Schedule

### DIFF
--- a/apps/data-hub/src/App.tsx
+++ b/apps/data-hub/src/App.tsx
@@ -51,6 +51,12 @@ import {
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
 type DataHubTab = "library" | "my-datasets" | "requests";
+
+const TAB_LABELS: Record<DataHubTab, string> = {
+  library: "Library",
+  "my-datasets": "My Datasets",
+  requests: "Requests",
+};
 type ModalState =
   | { kind: "none" }
   | { kind: "dataset"; dataset: DatasetRecord | null }
@@ -411,17 +417,13 @@ export const App = () => {
       topbar={
         <LabTopbar
           kicker="DATA HUB"
-          title="Data Hub"
+          title={TAB_LABELS[tab]}
           subtitle="Find, register, request, and reuse lab datasets without storing raw files in ILM."
         />
       }
       subbar={
         <nav className="dh-subbar" aria-label="Data Hub sections">
-          {[
-            ["library", "Library"],
-            ["my-datasets", "My Datasets"],
-            ["requests", "Requests"],
-          ].map(([id, label]) => (
+          {(Object.entries(TAB_LABELS) as [DataHubTab, string][]).map(([id, label]) => (
             <button
               key={id}
               type="button"

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -97,6 +97,20 @@ type ProjectGroup = {
   proposed: number;
 };
 
+const SIDEBAR_TAB_LABELS: Record<Exclude<SidebarTab, "view">, string> = {
+  overview: "Overview",
+  library: "Library",
+  reviews: "Reviews",
+  recycle: "Recycle bin",
+};
+
+const VIEW_MODE_LABELS: Record<ViewMode, string> = {
+  summary: "Summary",
+  step: "Editor",
+  preview: "Preview",
+  transfer: "Transfer",
+};
+
 const STATUS_TONE_MAP: Record<string, string> = {
   active: "active",
   archived: "archived",
@@ -2273,6 +2287,8 @@ export const App = () => {
       </nav>
     );
 
+  const topbarTitle = sidebarTab === "view" ? VIEW_MODE_LABELS[viewMode] : SIDEBAR_TAB_LABELS[sidebarTab];
+
   return (
     <LabShell
       activeNavId="protocols"
@@ -2281,7 +2297,7 @@ export const App = () => {
       topbar={
         <LabTopbar
           kicker="PROTOCOLS"
-          title="Protocol Manager"
+          title={topbarTitle}
           subtitle="Authoring, review, and rendering for the active lab's protocols."
         />
       }

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -2230,62 +2230,31 @@ export const App = () => {
     </section>
   );
 
-  // Sub-section nav: in the workspace view, swap the section tabs for the
-  // view-mode tabs (Summary / Step / Preview / Transfer). Library/Overview/
-  // Reviews/Recycle live behind the section tabs.
-  const subbar =
-    sidebarTab === "view" ? (
-      <nav className="protocol-subbar-tabs" aria-label="Protocol view modes">
-        <button className={`protocol-subtab${viewMode === "summary" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("summary")}>
-          Summary
+  const subbar = (
+    <nav className="protocol-subbar-tabs" aria-label="Protocol manager sections">
+      <button className={`protocol-subtab${sidebarTab === "overview" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("overview")}>
+        Overview
+      </button>
+      <button className={`protocol-subtab${sidebarTab === "library" || sidebarTab === "view" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("library")}>
+        Library
+      </button>
+      {visibleReviewsTab ? (
+        <button className={`protocol-subtab${sidebarTab === "reviews" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("reviews")}>
+          Reviews
+          {pendingSubmissions.length > 0 ? (
+            <span className="protocol-subtab-badge">{pendingSubmissions.length}</span>
+          ) : null}
         </button>
-        <button className={`protocol-subtab${viewMode === "step" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("step")}>
-          Step
-        </button>
-        <button className={`protocol-subtab${viewMode === "preview" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("preview")}>
-          Preview
-        </button>
-        <button className={`protocol-subtab${viewMode === "transfer" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("transfer")}>
-          Transfer
-        </button>
-        <span className="protocol-subbar-spacer" />
-        {editor?.draftId ? (
-          <SubmissionHistoryLink
-            visible
-            history={workspace?.drafts.find((d) => d.id === editor.draftId)?.submissionHistory ?? []}
-            linkLabel="Submission history"
-          />
-        ) : null}
-        <button type="button" className="protocol-subbar-back" onClick={() => setSidebarTab("library")}>
-          ← Back to library
-        </button>
-        <span className="protocol-subbar-divider" aria-hidden="true" />
-      </nav>
-    ) : (
-      <nav className="protocol-subbar-tabs" aria-label="Protocol manager sections">
-        <button className={`protocol-subtab${sidebarTab === "overview" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("overview")}>
-          Overview
-        </button>
-        <button className={`protocol-subtab${sidebarTab === "library" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("library")}>
-          Library
-        </button>
-        {visibleReviewsTab ? (
-          <button className={`protocol-subtab${sidebarTab === "reviews" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("reviews")}>
-            Reviews
-            {pendingSubmissions.length > 0 ? (
-              <span className="protocol-subtab-badge">{pendingSubmissions.length}</span>
-            ) : null}
-          </button>
-        ) : null}
-        <button className={`protocol-subtab${sidebarTab === "recycle" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("recycle")}>
-          Recycle bin
-        </button>
-        <span className="protocol-subbar-spacer" />
-        <button type="button" className="protocol-subbar-strong" onClick={() => setNewProtocolModalOpen(true)}>
-          + New protocol
-        </button>
-      </nav>
-    );
+      ) : null}
+      <button className={`protocol-subtab${sidebarTab === "recycle" ? " is-active" : ""}`} type="button" onClick={() => setSidebarTab("recycle")}>
+        Recycle bin
+      </button>
+      <span className="protocol-subbar-spacer" />
+      <button type="button" className="protocol-subbar-strong" onClick={() => setNewProtocolModalOpen(true)}>
+        + New protocol
+      </button>
+    </nav>
+  );
 
   const topbarTitle = sidebarTab === "view" ? VIEW_MODE_LABELS[viewMode] : SIDEBAR_TAB_LABELS[sidebarTab];
 
@@ -2304,7 +2273,36 @@ export const App = () => {
       subbar={subbar}
       bodyClassName={sidebarTab === "view" ? "protocol-body--workspace" : ""}
     >
-      {sidebarTab === "view" ? viewWorkspace : libraryAndOverview}
+      {sidebarTab === "view" ? (
+        <>
+          <nav className="protocol-subsubbar-tabs" aria-label="Protocol editor modes">
+            <button className={`protocol-subsubtab${viewMode === "summary" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("summary")}>
+              Summary
+            </button>
+            <button className={`protocol-subsubtab${viewMode === "step" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("step")}>
+              Editor
+            </button>
+            <button className={`protocol-subsubtab${viewMode === "preview" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("preview")}>
+              Preview
+            </button>
+            <button className={`protocol-subsubtab${viewMode === "transfer" ? " is-active" : ""}`} type="button" onClick={() => openViewMode("transfer")}>
+              Transfer
+            </button>
+            <span className="protocol-subsubbar-spacer" />
+            {editor?.draftId ? (
+              <SubmissionHistoryLink
+                visible
+                history={workspace?.drafts.find((d) => d.id === editor.draftId)?.submissionHistory ?? []}
+                linkLabel="Submission history"
+              />
+            ) : null}
+            <button type="button" className="protocol-subbar-back" onClick={() => setSidebarTab("library")}>
+              ← Back to library
+            </button>
+          </nav>
+          {viewWorkspace}
+        </>
+      ) : libraryAndOverview}
 
           {newProtocolModalOpen ? (
             <div className="step-modal-overlay" onClick={() => setNewProtocolModalOpen(false)}>

--- a/apps/protocol-manager/src/styles.css
+++ b/apps/protocol-manager/src/styles.css
@@ -90,6 +90,38 @@
   letter-spacing: 0.04em;
 }
 
+.protocol-subsubbar-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 1rem;
+  border-bottom: 1px solid var(--rl-line);
+  background: color-mix(in oklab, var(--rl-soft) 75%, white);
+}
+.protocol-subsubbar-spacer { flex: 1; }
+.protocol-subsubtab {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--rl-muted);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.protocol-subsubtab:hover:not(:disabled) {
+  color: var(--rl-ink);
+  border-color: var(--rl-line);
+  background: #fff;
+}
+.protocol-subsubtab.is-active {
+  color: var(--rl-green);
+  border-color: color-mix(in oklab, var(--rl-green) 35%, var(--rl-line));
+  background: color-mix(in oklab, var(--rl-green) 14%, white);
+}
+
 /* When viewing a protocol the body becomes the editor 3-pane and needs to
    stretch full-bleed under the subbar without the default LabShell gutter. */
 .ils-body.protocol-body--workspace {

--- a/apps/scheduler/src/App.tsx
+++ b/apps/scheduler/src/App.tsx
@@ -145,7 +145,7 @@ export const App = () => {
       topbar={
         <LabTopbar
           kicker="SCHEDULER"
-          title="Scheduler"
+          title={TAB_LABELS[tab]}
           subtitle="Plan lab work, meetings, and equipment usage."
         />
       }

--- a/packages/ui/src/LabShell.tsx
+++ b/packages/ui/src/LabShell.tsx
@@ -82,7 +82,7 @@ const NAV_ITEMS: NavItem[] = [
   },
   {
     id: "calendar",
-    label: "Calendar",
+    label: "Schedule",
     glyph: "▣",
     buildHref: (_, base) => appUrl("scheduler/", base),
     tone: "external",


### PR DESCRIPTION
### Motivation
- The Scheduler topbar was showing a fixed title identical to the kicker instead of reflecting the active subtab like other apps, which reduces contextual clarity.
- The sidebar entry labeled `Calendar` should read `Schedule` to better describe the app's purpose while still routing to the same scheduler app.

### Description
- Changed the Scheduler topbar title in `apps/scheduler/src/App.tsx` to use `title={TAB_LABELS[tab]}` so the title follows the active subtab label (`Calendar`, `Bookings`, `Unscheduled`, `Resources`).
- Renamed the sidebar navigation label from `Calendar` to `Schedule` by updating the `NAV_ITEMS` entry in `packages/ui/src/LabShell.tsx` while keeping the `id` as `calendar` and the `buildHref` pointing to the same `scheduler/` route.
- No changes were made to routing or subtab identifiers, only the displayed label and topbar title binding were modified.

### Testing
- Ran `npm run typecheck` across the monorepo and the typecheck completed successfully.
- Running `npm run typecheck --workspace scheduler` failed due to the workspace selector not being recognized in this repository configuration, which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f423a255a083248ce7cfec950e1c42)