### PR TITLE
Remove duplicate panel headers from Project Manager

### DIFF
--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -1314,12 +1314,6 @@ export const App = () => {
 
   const overviewPanel = (
     <div className="pm-panel-body">
-      <header className="pm-panel-header">
-        <div>
-          <h2>Overview</h2>
-          <p>Lab projects at a glance.</p>
-        </div>
-      </header>
       <section className="pm-summary-grid">
         <article className="pm-summary-card">
           <span className="pm-summary-kicker">Active lab</span>
@@ -1367,12 +1361,6 @@ export const App = () => {
 
   const libraryPanel = (
     <div className="pm-panel-body">
-      <header className="pm-panel-header">
-        <div>
-          <h2>Library</h2>
-          <p>Browse drafts and published projects. Open one to edit in the View tab.</p>
-        </div>
-      </header>
       {actionError ? <p className="pm-page-error">{actionError}</p> : null}
 
       {isOwner ? (
@@ -1453,12 +1441,6 @@ export const App = () => {
 
   const reviewPanel = (
     <div className="pm-panel-body">
-      <header className="pm-panel-header">
-        <div>
-          <h2>Review</h2>
-          <p>Only drafts that have been explicitly submitted for first publication appear here.</p>
-        </div>
-      </header>
       {actionError ? <p className="pm-page-error">{actionError}</p> : null}
       {pendingForMyReview.length > 0 ? (
         <section className="pm-panel-section">

--- a/apps/project-manager/src/styles.css
+++ b/apps/project-manager/src/styles.css
@@ -133,19 +133,6 @@
 ========================================================= */
 .pm-panel-body { display: flex; flex-direction: column; gap: 1.4rem; }
 
-.pm-panel-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
-}
-.pm-panel-header h2 {
-  margin: 0;
-  font-family: var(--rl-font-display);
-  font-size: 1.35rem;
-}
-.pm-panel-header p { margin: 0.15rem 0 0; color: var(--rl-muted); }
-
 .pm-panel-section {
   background: var(--rl-surface);
   border: 1px solid var(--rl-line);


### PR DESCRIPTION
## Summary
- Drop redundant `<header className="pm-panel-header">` blocks from the Overview, Library, and Review panels — they re-rendered the page name already shown by `LabTopbar` (`statusLabel(sidebarTab)`).
- Remove the orphan `.pm-panel-header` CSS rules.

## Test plan
- [ ] Open Project Manager → Overview, Library, Review tabs and confirm only the topbar title shows (no duplicate `<h2>` underneath).
- [ ] Confirm View tab is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)