### PR TITLE
docs: refresh README and add quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,83 @@
-# Integrated Lab Manager
+# Integrated Lab Manager (ILM)
 
-Integrated Lab Manager is a modular monorepo for structured lab operations software.
+Integrated Lab Manager is a static-first, Supabase-backed lab operations platform built as an npm workspaces monorepo. It provides modular apps for protocols, projects, inventory/supply, scheduling, funding-directory routing, and dataset registry workflows.
 
-## Current status
+## What is shipped today
 
-Three apps are production-ready on Supabase with RLS-enforced workflows:
+ILM is now a mature multi-app suite with production Supabase + RLS workflows:
 
-- **Protocol Manager** (Stage 3) — visual protocol designer with typed steps, draft → submit → review → publish flow, append-only revisions, and a 30-day recycle bin.
-- **Account / Home** (Stage 4a) — lab-wide overview dashboard at the site root, with profile, lab membership, invitations, join requests, and share links living under hash routes (`#/team`, `#/settings`). Strict tier hierarchy (owner > admin > member).
-- **Project Manager** (Stage 4b) — project lifecycle with milestones, experiments, roadmap drag-reorder, project leads, review-gated publish flow, and per-project GitHub repo activity.
+- **Account / Home** (`/`) — lab-wide operations dashboard, membership/roles, invitations, join requests, and cross-app review routing.
+- **Protocol Manager** (`/protocol-manager/`) — typed protocol editor with draft → submit → review → publish and append-only revisions.
+- **Project Manager** (`/project-manager/`) — projects, milestones, experiments, project leads, review gates, recycle bin, GitHub activity.
+- **Supply Manager** (`/supply-manager/`) — item catalog, stock checks, request/review/order/receipt lifecycle, lots, project visibility.
+- **Funding Manager (4d-lite)** (`/funding-manager/`) — grant alias directory used for supply approval routing (not financial accounting).
+- **Scheduler** (`/scheduler/`) — resources, events, bookings, and unscheduled task-to-booking/event conversion.
+- **Data Hub** (`/data-hub/`) — dataset registry with versions, storage references, project links, and access request/review.
 
-**Supply Manager** (Stage 4c) is the current in-flight stage — see [`docs/next-stage.md`](docs/next-stage.md). **Funding Manager** (Stage 4d) is deferred. Both are scaffolded auth shells today.
+For the currently planned follow-up scope, see [`docs/next-stage.md`](docs/next-stage.md).
+
+## Architecture at a glance
+
+- **Frontend only** (GitHub Pages deploy), no custom backend server.
+- **React + TypeScript + Vite** per app.
+- **Supabase Postgres + Auth** for persistence and identity.
+- **Row Level Security on every app table**; authorization is data-driven from `lab_memberships` and domain ownership/role policies.
+- **Shared UI & types** through internal packages (`@ilm/ui`, `@ilm/types`, `@ilm/utils`, `@ilm/validation`, `@ilm/ai-import`).
 
 ## Monorepo layout
 
 ```text
-integrated-lab-manager/
-├─ apps/
-│  ├─ protocol-manager/      # Stage 3  — production
-│  ├─ account/               # Stage 4a — production
-│  ├─ project-manager/       # Stage 4b — production
-│  ├─ supply-manager/        # Stage 4c — in flight (auth shell only)
-│  └─ funding-manager/       # Stage 4d — deferred (auth shell only)
-├─ packages/
-│  ├─ ai-import/             # AI import instructions + helpers
-│  ├─ types/                 # shared protocol TypeScript model
-│  ├─ validation/            # validation + normalization helpers
-│  ├─ utils/                 # ids + generic utility helpers
-│  └─ ui/                    # shared lightweight UI primitives
-├─ examples/
-│  └─ protocols/             # example protocol JSON files
-└─ docs/
+apps/
+  account/
+  data-hub/
+  funding-manager/
+  project-manager/
+  protocol-manager/
+  scheduler/
+  supply-manager/
+packages/
+  ai-import/
+  types/
+  ui/
+  utils/
+  validation/
+supabase/
+  migrations/
+docs/
 ```
 
-## Technical direction
+## Quickstart
 
-- TypeScript across the monorepo (npm workspaces)
-- React + Vite for every app
-- Static frontend — no custom backend server; deployable to GitHub Pages
-- Supabase (Postgres + Auth) for storage, with Row Level Security on every table
-- Canonical protocol JSON model (`document_json`) with schema versioning; other domains use normalized columns
-- Review-gated publishing: drafts are per-user sandboxes, submissions are frozen snapshots, revisions are written only on approval
-- Soft-delete with 30-day recycle bin across protocols and projects
+Use the dedicated quickstart guide:
 
-## Getting started
+- **[`docs/quickstart.md`](docs/quickstart.md)** — prerequisites, local setup, env vars, Supabase bootstrap, dev/build/test commands, and GitHub Pages notes.
 
-```bash
-npm install
-npm run dev
-```
+## Security model (non-negotiables)
 
-Then open the local URL shown by Vite.
+- Browser receives only:
+  - `VITE_SUPABASE_URL`
+  - `VITE_SUPABASE_ANON_KEY`
+- **Never** expose Supabase `service_role` key in frontend code, `.env*`, CI logs, or shipped artifacts.
+- Keep RLS enabled and tested on every table powering app data.
 
-## GitHub Pages
+## Product docs
 
-All five apps are bundled into a single GitHub Pages deploy from the `main` branch via GitHub Actions.
+- [`docs/features.md`](docs/features.md) — living “what’s shipped now” feature inventory.
+- [`docs/next-stage.md`](docs/next-stage.md) — active planned next stage.
+- [`docs/module-development.md`](docs/module-development.md) — module scaffolding conventions with shared `<LabShell>` chrome.
 
-- Production URL: `https://euchiz.github.io/ILM/` — the home overview dashboard (Account app)
-- Sibling apps live at `https://euchiz.github.io/ILM/protocol-manager/`, `/project-manager/`, `/supply-manager/`, `/funding-manager/`
-- Workflow file: `.github/workflows/deploy-protocol-manager-pages.yml`
+## Deployment
 
-For local development, every app runs at `/`. For the GitHub Pages build, the workflow sets `VITE_BASE_PATH=/ILM/` for the home shell and `VITE_BASE_PATH=/ILM/<app>/` for each sibling so static assets resolve correctly on the project site URL.
+ILM deploys to GitHub Pages via GitHub Actions from `main`.
 
-## Role-based workflows
+- Site root (Account/Home): `https://euchiz.github.io/ILM/`
+- App paths: `/protocol-manager/`, `/project-manager/`, `/supply-manager/`, `/funding-manager/`, `/scheduler/`, `/data-hub/`
 
-Each lab membership carries a role of `owner`, `admin`, or `member`. Roles are stored in `lab_memberships` and enforced by RLS.
+Set repository secrets for build-time env injection:
 
-- **Member** — can create personal drafts (protocols, projects), edit their own drafts, and submit them for review. Can view all published records in the lab.
-- **Project lead** — a member designated via `project_leads` on a specific project. Inherits edit rights on that project's roadmap, milestones, and experiments.
-- **Admin** — can approve or reject submissions, move items to the recycle bin, restore or permanently delete them, and manage project lead assignments.
-- **Owner** — admin privileges plus lab-level settings (future: invitations, role changes).
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
 
-Publishing flow (protocols and projects):
+## License
 
-1. Member creates a draft (private, owner-scoped).
-2. Member submits — a frozen snapshot is stored in `protocol_submissions` / project submission state.
-3. Admin (or designated lead) approves → a new revision is appended and the record is published. Reject returns the draft with reviewer comments.
-4. Projects marked `approval_required = false` (e.g. the auto-created "General" project) publish directly without the review step.
-
-Recycle bin:
-
-- Soft-delete sets `deleted_at`. Records are recoverable for 30 days, then eligible for permanent purge.
-- Only admins see the recycle bin and can restore or permanently delete.
-
-## Supabase backend
-
-ILM is moving from browser-only storage to Supabase (Postgres + Auth) while keeping the frontend static and deployable to GitHub Pages. No custom backend server is required.
-
-### Auth and workspace model
-
-- Each user has a personal account via Supabase Auth (email + password).
-- Users belong to one or more `labs` (shared workspaces) through `lab_memberships` with a role of `owner`, `admin`, or `member`.
-- All lab data (projects, protocols, revisions) is scoped to a `lab_id` and protected by Row Level Security. Authorization is driven by membership rows, not by the client.
-
-### Keys and secrets
-
-Only two values are needed in the browser. Both are safe to ship:
-
-- `VITE_SUPABASE_URL` — your project URL, e.g. `https://xxxx.supabase.co`
-- `VITE_SUPABASE_ANON_KEY` — the project's anon (public) API key
-
-**Never** place the Supabase service-role key in the frontend, in `.env*` files, or in GitHub Actions logs. It bypasses RLS and must live only in the Supabase dashboard or trusted server-side tooling.
-
-### One-time Supabase setup
-
-1. Create a project at https://supabase.com.
-2. In the SQL editor (or via `supabase db push` if you use the CLI), apply the migrations under [`supabase/migrations/`](supabase/migrations/). This creates `profiles`, `labs`, `lab_memberships`, `projects`, `protocols`, `protocol_revisions`, plus triggers and RLS policies.
-3. In **Authentication → Providers**, enable Email. Set the Site URL to your GitHub Pages URL (e.g. `https://euchiz.github.io/ILM/`) and add it under Redirect URLs.
-4. Copy the project URL and the anon public key from **Settings → API**.
-
-### Local development
-
-Copy `.env.example` to `.env.local` at the repo root (or inside `apps/protocol-manager/`) and fill in your values:
-
-```bash
-cp .env.example .env.local
-# then edit .env.local
-```
-
-Vite will pick these up automatically when you run `npm run dev`.
-
-### GitHub Pages deployment
-
-Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` as **Repository Secrets** (Settings → Secrets and variables → Actions). The deploy workflow injects them into the build step as environment variables so they land in the bundle. Changing a secret requires re-running the workflow.
-
-### Migrations
-
-SQL migrations live in [`supabase/migrations/`](supabase/migrations/). Apply them in order via the Supabase SQL editor or the Supabase CLI (`supabase db push`).
+See [`LICENSE`](LICENSE) if present; otherwise follow repository owner guidance.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,91 @@
+# ILM Quickstart
+
+This guide gets a local ILM environment running against your Supabase project.
+
+## 1) Prerequisites
+
+- Node.js 24+ (recommended)
+- npm 11+
+- A Supabase project you control
+
+> HPC note: if `npm` is unavailable on host, run npm commands via Singularity:
+>
+> ```bash
+> singularity exec --bind /mnt/isilon/wang_lab/zac/projects/ILM:/work docker://node:24-slim sh -c "cd /work && <npm command>"
+> ```
+
+## 2) Clone + install
+
+```bash
+git clone https://github.com/Euchiz/ILM.git
+cd ILM
+npm install
+```
+
+## 3) Configure environment
+
+Create `.env.local` at repo root:
+
+```bash
+cp .env.example .env.local
+```
+
+Set:
+
+```bash
+VITE_SUPABASE_URL=https://<your-project-ref>.supabase.co
+VITE_SUPABASE_ANON_KEY=<your-anon-public-key>
+```
+
+Only use the **anon** key in frontend env. Do **not** use the service-role key.
+
+## 4) Apply Supabase schema
+
+Run all SQL migrations in `supabase/migrations/` (via Supabase SQL editor or Supabase CLI):
+
+- Tables include labs/memberships, protocols, projects, supply, scheduler, funding directory, and data hub domains.
+- RLS policies are included in migrations and are required for correct app behavior.
+
+## 5) Run locally
+
+From repo root:
+
+```bash
+npm run dev
+```
+
+This starts workspace dev servers (per root scripts). Open the URL shown by Vite.
+
+## 6) Useful commands
+
+```bash
+npm run build
+npm run lint
+npm run typecheck
+```
+
+If your environment needs containerized npm, wrap each command with the Singularity command shown above.
+
+## 7) GitHub Pages deployment essentials
+
+In GitHub repository settings, add Actions secrets:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+Deploy pipeline builds static bundles for root + sibling app paths under `/ILM/`.
+
+## 8) First-run sanity checks
+
+After sign-up/sign-in:
+
+1. Create a lab in the lab picker.
+2. Verify Home (`/ILM/`) loads dashboard cards.
+3. Open Protocol / Project / Supply / Scheduler / Data Hub and confirm data reads/writes succeed.
+4. Confirm role-based behaviors (member vs admin/owner) are enforced.
+
+## 9) Where to look next
+
+- Current delivered capabilities: `docs/features.md`
+- Planned next stage: `docs/next-stage.md`
+- New module scaffolding: `docs/module-development.md`


### PR DESCRIPTION
### Motivation

- Bring the top-level README up to date with the current, mature ILM app surface and simplify onboarding language. 
- Provide a single, clear quickstart that captures prerequisites, environment setup, Supabase migration steps, and local dev commands so new developers can get running quickly. 
- Keep the repo documentation consistent with the shipped apps and the existing living docs (`docs/features.md`, `docs/next-stage.md`).

### Description

- Rewrote `README.md` to a concise, modern overview that highlights architecture, shipped apps, monorepo layout, security non-negotiables, deployment pointers, and links to product docs. 
- Added `docs/quickstart.md` with step-by-step instructions for cloning, installing, environment configuration, applying Supabase migrations, running the dev server, common commands, GitHub Pages deployment notes, and first-run sanity checks. 
- Updated README quickstart section to point to the new `docs/quickstart.md` and simplified several sections for clarity. 
- This is a documentation-only change and does not modify runtime code, schema, or app logic.

### Testing

- No automated tests were run for this PR because the changes are documentation-only; repository CI (if configured) will run on PR as usual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b3b186f8832490022649285eb805)