### PR TITLE
Fix small bugs (#87) and add global page search (#88)

### DIFF
--- a/apps/account/src/App.tsx
+++ b/apps/account/src/App.tsx
@@ -175,6 +175,7 @@ const HomeShell = ({ onOpenLabPicker }: { onOpenLabPicker: () => void }) => {
           kicker={ROUTE_KICKER[route.kind]}
           title={ROUTE_TITLE[route.kind]}
           subtitle={ROUTE_SUBTITLE[route.kind]}
+          baseUrl={APP_BASE_URL}
         />
       }
     >

--- a/apps/data-hub/src/App.tsx
+++ b/apps/data-hub/src/App.tsx
@@ -419,6 +419,7 @@ export const App = () => {
           kicker="DATA HUB"
           title={TAB_LABELS[tab]}
           subtitle="Find, register, request, and reuse lab datasets without storing raw files in ILM."
+          baseUrl={APP_BASE_URL}
         />
       }
       subbar={

--- a/apps/data-hub/src/lib/cloudAdapter.ts
+++ b/apps/data-hub/src/lib/cloudAdapter.ts
@@ -330,8 +330,14 @@ export async function createDataset(args: {
       p_source_type: args.data.source_type ?? "internal-generated",
       p_status: args.data.status ?? "planned",
       p_access_level: args.data.access_level ?? "request-required",
-      p_owner_user_id: args.data.owner_user_id ?? args.userId,
-      p_contact_user_id: args.data.contact_user_id ?? args.data.owner_user_id ?? args.userId,
+      p_owner_user_id:
+        args.data.owner_user_id === undefined ? args.userId : args.data.owner_user_id,
+      p_contact_user_id:
+        args.data.contact_user_id === undefined
+          ? args.data.owner_user_id === undefined
+            ? args.userId
+            : args.data.owner_user_id
+          : args.data.contact_user_id,
       p_organism: args.data.organism ?? null,
       p_sample_type: args.data.sample_type ?? null,
       p_assay_platform: args.data.assay_platform ?? null,

--- a/apps/funding-manager/src/App.tsx
+++ b/apps/funding-manager/src/App.tsx
@@ -162,6 +162,7 @@ export const App = () => {
           kicker="FUNDING DIRECTORY"
           title="Funding Directory"
           subtitle="Manage PI-approved funding aliases and grant identifiers for order routing. No budget or cost tracking is stored."
+          baseUrl={APP_BASE_URL}
         />
       }
     >

--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -1770,6 +1770,7 @@ export const App = () => {
           kicker="PROJECTS"
           title={sidebarTab === "view" && activeProject ? activeProject.name : statusLabel(sidebarTab)}
           subtitle="Projects, milestones, experiments, and reviews for the active lab."
+          baseUrl={APP_BASE_URL}
         />
       }
       subbar={subbar}

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -2115,6 +2115,7 @@ export const App = () => {
           kicker="PROTOCOLS"
           title={topbarTitle}
           subtitle="Authoring, review, and rendering for the active lab's protocols."
+          baseUrl={APP_BASE_URL}
         />
       }
       subbar={subbar}

--- a/apps/scheduler/src/App.tsx
+++ b/apps/scheduler/src/App.tsx
@@ -147,6 +147,7 @@ export const App = () => {
           kicker="SCHEDULER"
           title={TAB_LABELS[tab]}
           subtitle="Plan lab work, meetings, and equipment usage."
+          baseUrl={APP_BASE_URL}
         />
       }
       subbar={

--- a/apps/scheduler/src/components/BookingCalendarPanel.tsx
+++ b/apps/scheduler/src/components/BookingCalendarPanel.tsx
@@ -220,9 +220,11 @@ export const BookingCalendarPanel = ({ bookings, resources }: BookingCalendarPan
                     }}
                     title={`${labelTitle} • ${entry.booking.status} • ${formatTime(entry.start)} – ${formatTime(entry.end)}`}
                   >
-                    <span className="sch-cal-event-title">{labelTitle}</span>
-                    <span className="sch-cal-event-meta">
-                      {formatTime(entry.start)} – {formatTime(entry.end)}
+                    <span className="sch-cal-event-card">
+                      <span className="sch-cal-event-title">{labelTitle}</span>
+                      <span className="sch-cal-event-meta">
+                        {formatTime(entry.start)} – {formatTime(entry.end)}
+                      </span>
                     </span>
                   </div>
                 );

--- a/apps/scheduler/src/components/CalendarView.tsx
+++ b/apps/scheduler/src/components/CalendarView.tsx
@@ -202,13 +202,15 @@ export const CalendarView = ({
                   onClick={() => onSelectEvent(entry.event)}
                   aria-label={`${entry.event.title} at ${formatTime(entry.start)}`}
                 >
-                  <span className="sch-cal-event-title">{entry.event.title}</span>
-                  <span className="sch-cal-event-meta">
-                    {formatTime(entry.start)} – {formatTime(entry.end)}
+                  <span className="sch-cal-event-card">
+                    <span className="sch-cal-event-title">{entry.event.title}</span>
+                    <span className="sch-cal-event-meta">
+                      {formatTime(entry.start)} – {formatTime(entry.end)}
+                    </span>
+                    <Badge tone={EVENT_TYPE_TONES[entry.event.event_type]}>
+                      {entry.event.event_type}
+                    </Badge>
                   </span>
-                  <Badge tone={EVENT_TYPE_TONES[entry.event.event_type]}>
-                    {entry.event.event_type}
-                  </Badge>
                 </button>
               ))}
             </div>

--- a/apps/scheduler/src/styles.css
+++ b/apps/scheduler/src/styles.css
@@ -235,27 +235,63 @@
   border-bottom: 1px dashed var(--rl-border-soft, var(--rl-border));
 }
 
+/* The outer event block is sized exactly to the event's duration and
+   carries only the colored edge marker; the inner card overlays the
+   block, has a fixed minimum height, and is vertically centered so
+   short events still show a fully readable label without truncation. */
 .sch-cal-event {
   position: absolute;
   left: 4px;
   right: 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  padding: 0.4rem 0.5rem;
-  border-radius: 5px;
-  border: 1px solid var(--rl-border);
-  background: var(--rl-surface);
+  display: block;
+  padding: 0;
+  background: transparent;
+  border: none;
   text-align: left;
   cursor: pointer;
   font: inherit;
   color: var(--rl-ink);
-  overflow: hidden;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+  overflow: visible;
+  z-index: 1;
 }
 
 .sch-cal-event:hover {
+  z-index: 4;
+}
+
+.sch-cal-event::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-left: 3px solid currentColor;
+  border-radius: 4px;
+  background: var(--sch-cal-event-bg, transparent);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.sch-cal-event-card {
+  position: absolute;
+  left: 6px;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  min-height: calc(var(--sch-cal-row) * 0.85);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.15rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 5px;
+  border: 1px solid var(--rl-border);
+  background: var(--rl-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  z-index: 2;
+}
+
+.sch-cal-event:hover .sch-cal-event-card {
   border-color: var(--rl-accent);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 }
 
 .sch-cal-event-title {
@@ -271,26 +307,26 @@
   color: var(--rl-muted);
 }
 
-.sch-cal-event--meeting     { border-left: 3px solid #4080c0; }
-.sch-cal-event--experiment  { border-left: 3px solid #1f9d6c; }
-.sch-cal-event--reminder    { border-left: 3px solid #8a8a8a; }
-.sch-cal-event--deadline    { border-left: 3px solid #c0392b; }
-.sch-cal-event--maintenance { border-left: 3px solid #d39e00; }
-.sch-cal-event--general     { border-left: 3px solid #555;   }
+.sch-cal-event--meeting     { color: #4080c0; --sch-cal-event-bg: #eaf2fa; }
+.sch-cal-event--experiment  { color: #1f9d6c; --sch-cal-event-bg: #e9f6f0; }
+.sch-cal-event--reminder    { color: #8a8a8a; --sch-cal-event-bg: #f1f1f3; }
+.sch-cal-event--deadline    { color: #c0392b; --sch-cal-event-bg: #fbeae8; }
+.sch-cal-event--maintenance { color: #d39e00; --sch-cal-event-bg: #fff5da; }
+.sch-cal-event--general     { color: #555;    --sch-cal-event-bg: #ececec; }
 
 /* Booking blocks reuse the .sch-cal-event grid positioning but key off
    booking status instead of event type. Inactive (completed / cancelled
    / no_show / denied) renders gray so the historical context stays
    visible without competing with active reservations. */
-.sch-cal-booking--requested { border-left: 3px solid #d39e00; background: #fff8e6; }
-.sch-cal-booking--approved  { border-left: 3px solid #1f9d6c; background: #e9f6f0; }
-.sch-cal-booking--active    { border-left: 3px solid #1a7048; background: #d6efdf; }
+.sch-cal-booking--requested { color: #d39e00; --sch-cal-event-bg: #fff8e6; }
+.sch-cal-booking--approved  { color: #1f9d6c; --sch-cal-event-bg: #e9f6f0; }
+.sch-cal-booking--active    { color: #1a7048; --sch-cal-event-bg: #d6efdf; }
 .sch-cal-booking--completed,
 .sch-cal-booking--cancelled,
 .sch-cal-booking--no_show,
 .sch-cal-booking--denied {
-  border-left: 3px solid #c0c4ca;
-  background: #f1f3f6;
+  color: #c0c4ca;
+  --sch-cal-event-bg: #f1f3f6;
 }
 
 .sch-cal-event.is-inactive {

--- a/apps/supply-manager/src/App.tsx
+++ b/apps/supply-manager/src/App.tsx
@@ -1286,6 +1286,7 @@ export const App = () => {
           kicker="INVENTORY"
           title={statusLabel(sidebarTab.replace(/-/g, " "))}
           subtitle="Items, vendor orders, and inventory checks for the active lab."
+          baseUrl={APP_BASE_URL}
           meta={
             <Button size="sm" onClick={() => void refresh()} disabled={status === "loading"}>
               {status === "loading" ? "Refreshing…" : "Refresh"}

--- a/apps/supply-manager/src/lib/cloudAdapter.ts
+++ b/apps/supply-manager/src/lib/cloudAdapter.ts
@@ -204,7 +204,8 @@ export async function listSupplyWorkspace(
     ordersResult,
     stockLotsResult,
     projectsResult,
-    myProjectsResult,
+    myProjectMembersResult,
+    myProjectLeadsResult,
     fundingSourcesResult,
     fundingDefaultsResult,
   ] = await Promise.all([
@@ -217,6 +218,7 @@ export async function listSupplyWorkspace(
     client().from("stock_lots").select(STOCK_LOT_FIELDS).order("received_at", { ascending: false }),
     client().from("projects").select("id, name").eq("lab_id", labId).order("name", { ascending: true }),
     client().from("project_members").select("project_id").eq("user_id", userId),
+    client().from("project_leads").select("project_id").eq("user_id", userId),
     client().rpc("list_funding_sources", { p_lab_id: labId }),
     // funding_defaults is admin-only at the SQL boundary; members get an
     // empty list back (RLS suppresses rows) and the suggestion engine
@@ -232,14 +234,19 @@ export async function listSupplyWorkspace(
   if (ordersResult.error) throw ordersResult.error;
   if (stockLotsResult.error) throw stockLotsResult.error;
   if (projectsResult.error) throw projectsResult.error;
-  if (myProjectsResult.error) throw myProjectsResult.error;
+  if (myProjectMembersResult.error) throw myProjectMembersResult.error;
+  if (myProjectLeadsResult.error) throw myProjectLeadsResult.error;
   if (fundingSourcesResult.error) throw fundingSourcesResult.error;
   // funding_defaults selection failure is non-fatal — members can't read it
   // and the suggestion engine handles an empty list gracefully.
 
-  const myProjectIds = ((myProjectsResult.data ?? []) as Array<{ project_id: string }>).map(
+  const memberProjectIds = ((myProjectMembersResult.data ?? []) as Array<{ project_id: string }>).map(
     (row) => row.project_id
   );
+  const leadProjectIds = ((myProjectLeadsResult.data ?? []) as Array<{ project_id: string }>).map(
+    (row) => row.project_id
+  );
+  const myProjectIds = Array.from(new Set([...memberProjectIds, ...leadProjectIds]));
 
   return {
     items: (itemsResult.data as ItemRecord[]) ?? [],

--- a/packages/ui/src/GlobalSearch.tsx
+++ b/packages/ui/src/GlobalSearch.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { CSSProperties, KeyboardEvent } from "react";
+import { appUrl } from "./AppSwitcher";
+
+// Static page registry. Each entry is a navigable destination — either a
+// top-level app or a major subtab inside one. Keep this in sync when an app
+// adds or removes a top-level tab. The hash strings here must match the
+// values each app's `useState` initializer accepts (see e.g.
+// apps/protocol-manager/src/App.tsx).
+type AppKey =
+  | "home"
+  | "project-manager"
+  | "protocol-manager"
+  | "supply-manager"
+  | "funding-manager"
+  | "data-hub"
+  | "scheduler";
+
+type PageEntry = {
+  id: string;
+  label: string;
+  group: string;
+  keywords?: string[];
+  app: AppKey;
+  hash?: string;
+};
+
+const PAGES: PageEntry[] = [
+  { id: "home/overview", label: "Overview", group: "Home", app: "home" },
+  { id: "home/team", label: "Team", group: "Home", app: "home", hash: "team", keywords: ["members", "lab"] },
+  { id: "home/settings", label: "Settings", group: "Home", app: "home", hash: "settings", keywords: ["preferences", "account"] },
+  { id: "home/analytics", label: "Analytics", group: "Home", app: "home", hash: "analytics" },
+  { id: "home/reports", label: "Reports", group: "Home", app: "home", hash: "reports" },
+
+  { id: "projects/overview", label: "Projects · Overview", group: "Projects", app: "project-manager", hash: "overview" },
+  { id: "projects/library", label: "Projects · Library", group: "Projects", app: "project-manager", hash: "library", keywords: ["browse"] },
+  { id: "projects/review", label: "Projects · Review", group: "Projects", app: "project-manager", hash: "review", keywords: ["approval"] },
+
+  { id: "protocols/overview", label: "Protocols · Overview", group: "Protocols", app: "protocol-manager", hash: "overview" },
+  { id: "protocols/library", label: "Protocols · Library", group: "Protocols", app: "protocol-manager", hash: "library" },
+  { id: "protocols/reviews", label: "Protocols · Reviews", group: "Protocols", app: "protocol-manager", hash: "reviews", keywords: ["approval"] },
+  { id: "protocols/recycle", label: "Protocols · Recycle Bin", group: "Protocols", app: "protocol-manager", hash: "recycle", keywords: ["trash", "deleted"] },
+
+  { id: "inventory/warehouse", label: "Inventory · Warehouse", group: "Inventory", app: "supply-manager", hash: "warehouse", keywords: ["catalog", "items", "supplies"] },
+  { id: "inventory/orders", label: "Inventory · Orders", group: "Inventory", app: "supply-manager", hash: "orders", keywords: ["purchase"] },
+  { id: "inventory/review", label: "Inventory · Order Review", group: "Inventory", app: "supply-manager", hash: "review", keywords: ["approval"] },
+  { id: "inventory/my-items", label: "Inventory · My Items", group: "Inventory", app: "supply-manager", hash: "my-items" },
+
+  { id: "funding", label: "Funding Directory", group: "Funding", app: "funding-manager", keywords: ["grants", "alias"] },
+
+  { id: "data-hub/library", label: "Data Hub · Library", group: "Data Hub", app: "data-hub", keywords: ["datasets", "browse"] },
+  { id: "data-hub/my", label: "Data Hub · My Datasets", group: "Data Hub", app: "data-hub", hash: "my-datasets", keywords: ["mine", "owner"] },
+  { id: "data-hub/requests", label: "Data Hub · Access Requests", group: "Data Hub", app: "data-hub", hash: "requests", keywords: ["share"] },
+
+  { id: "schedule/calendar", label: "Schedule · Calendar", group: "Schedule", app: "scheduler", hash: "calendar" },
+  { id: "schedule/bookings", label: "Schedule · Bookings", group: "Schedule", app: "scheduler", hash: "bookings", keywords: ["reservations"] },
+  { id: "schedule/unscheduled", label: "Schedule · Unscheduled", group: "Schedule", app: "scheduler", hash: "unscheduled", keywords: ["tasks"] },
+  { id: "schedule/resources", label: "Schedule · Resources", group: "Schedule", app: "scheduler", hash: "resources", keywords: ["equipment"] },
+];
+
+const APP_HREF: Record<AppKey, string> = {
+  "home": "",
+  "project-manager": "project-manager/",
+  "protocol-manager": "protocol-manager/",
+  "supply-manager": "supply-manager/",
+  "funding-manager": "funding-manager/",
+  "data-hub": "data-hub/",
+  "scheduler": "scheduler/",
+};
+
+const buildPageHref = (page: PageEntry, baseUrl: string) => {
+  const root = appUrl(APP_HREF[page.app], baseUrl);
+  return page.hash ? `${root}#/${page.hash}` : root;
+};
+
+const matchScore = (page: PageEntry, queryLower: string): number => {
+  if (!queryLower) return 0;
+  const haystack = [page.label, page.group, ...(page.keywords ?? [])]
+    .join(" ")
+    .toLowerCase();
+  if (!haystack.includes(queryLower)) return -1;
+  // Prefer matches that hit the start of the label.
+  if (page.label.toLowerCase().startsWith(queryLower)) return 0;
+  if (page.group.toLowerCase().startsWith(queryLower)) return 1;
+  return 2;
+};
+
+const navigateTo = (href: string) => {
+  if (typeof window === "undefined") return;
+  const target = new URL(href, window.location.href);
+  const samePath =
+    target.origin === window.location.origin && target.pathname === window.location.pathname;
+  if (samePath) {
+    // Same SPA — push hash and reload so the app re-reads it on mount. The
+    // apps only parse the hash at startup, so a soft hash change wouldn't
+    // switch tabs.
+    if (target.hash !== window.location.hash) {
+      window.location.hash = target.hash;
+    }
+    window.location.reload();
+  } else {
+    window.location.href = target.toString();
+  }
+};
+
+export interface GlobalSearchProps {
+  /** Pass `import.meta.env.BASE_URL` from the host app. */
+  baseUrl: string;
+  placeholder?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export const GlobalSearch = ({
+  baseUrl,
+  placeholder = "Search projects, protocols, inventory…",
+  className,
+  style,
+}: GlobalSearchProps) => {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listboxId = useId();
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [] as PageEntry[];
+    const scored = PAGES.map((page) => ({ page, score: matchScore(page, q) }))
+      .filter((entry) => entry.score >= 0)
+      .sort((a, b) => a.score - b.score || a.page.label.localeCompare(b.page.label));
+    return scored.slice(0, 12).map((entry) => entry.page);
+  }, [query]);
+
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const choose = (page: PageEntry) => {
+    const href = buildPageHref(page, baseUrl);
+    navigateTo(href);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (matches.length === 0) return;
+      setActiveIdx((idx) => (idx + 1) % matches.length);
+      setOpen(true);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (matches.length === 0) return;
+      setActiveIdx((idx) => (idx - 1 + matches.length) % matches.length);
+      setOpen(true);
+    } else if (event.key === "Enter") {
+      const target = matches[activeIdx];
+      if (target) {
+        event.preventDefault();
+        choose(target);
+      }
+    } else if (event.key === "Escape") {
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  return (
+    <div
+      className={["ils-search ils-search--live", className].filter(Boolean).join(" ")}
+      role="search"
+      ref={containerRef}
+      style={style}
+    >
+      <input
+        ref={inputRef}
+        type="search"
+        className="ils-search-input"
+        placeholder={placeholder}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => {
+          if (query) setOpen(true);
+        }}
+        onKeyDown={onKeyDown}
+        role="combobox"
+        aria-expanded={open && matches.length > 0}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && matches[activeIdx] ? `${listboxId}-${activeIdx}` : undefined
+        }
+      />
+      <span className="ils-search-glyph" aria-hidden="true">⌕</span>
+      {open && query.trim().length > 0 ? (
+        <ul className="ils-search-results" id={listboxId} role="listbox">
+          {matches.length === 0 ? (
+            <li className="ils-search-empty" role="presentation">
+              No matching pages.
+            </li>
+          ) : (
+            matches.map((page, idx) => (
+              <li
+                key={page.id}
+                id={`${listboxId}-${idx}`}
+                role="option"
+                aria-selected={idx === activeIdx}
+                className={[
+                  "ils-search-result",
+                  idx === activeIdx ? "is-active" : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                onMouseEnter={() => setActiveIdx(idx)}
+                onMouseDown={(event) => {
+                  // mousedown so the click fires before blur dismisses the list
+                  event.preventDefault();
+                  choose(page);
+                }}
+              >
+                <span className="ils-search-result-label">{page.label}</span>
+                <span className="ils-search-result-group">{page.group}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/ui/src/LabShell.tsx
+++ b/packages/ui/src/LabShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { appUrl } from "./AppSwitcher";
 import { useAuth } from "./auth/AuthProvider";
+import { GlobalSearch } from "./GlobalSearch";
 
 // Single source of truth for the product + OS branding. The sidebar brand
 // mark reads PRODUCT_NAME; the brand-tag and topbar pill read OS_NAME /
@@ -221,11 +222,17 @@ export interface LabTopbarProps {
   subtitle?: ReactNode;
   /** Replaces the search field on the right. Passing null hides it entirely. */
   search?: ReactNode | null;
+  /**
+   * App's base URL (typically `import.meta.env.BASE_URL`). When provided,
+   * the default search slot renders an interactive global page-search.
+   * Without it, the slot falls back to a placeholder.
+   */
+  baseUrl?: string;
   /** Far-right slot. Defaults to the active lab name + the {@link OS_LABEL} pill. */
   meta?: ReactNode;
 }
 
-export const LabTopbar = ({ kicker, title, subtitle, search, meta }: LabTopbarProps) => {
+export const LabTopbar = ({ kicker, title, subtitle, search, baseUrl, meta }: LabTopbarProps) => {
   const defaultMeta = (
     <div className="ils-org">
       <strong>{PRODUCT_NAME}</strong>
@@ -233,7 +240,9 @@ export const LabTopbar = ({ kicker, title, subtitle, search, meta }: LabTopbarPr
     </div>
   );
 
-  const defaultSearch = (
+  const defaultSearch = baseUrl ? (
+    <GlobalSearch baseUrl={baseUrl} />
+  ) : (
     <div className="ils-search" role="search">
       <span>Search projects, protocols, inventory…</span>
       <span aria-hidden="true">⌕</span>

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -17,4 +17,5 @@ export {
   type LabTopbarProps,
 } from "./LabShell";
 export { SubmissionHistoryLink, type SubmissionHistoryEntry } from "./SubmissionHistoryLink";
+export { GlobalSearch, type GlobalSearchProps } from "./GlobalSearch";
 export { LabSettingsPanel } from "./admin/LabSettingsPanel";

--- a/packages/ui/src/lab-shell.css
+++ b/packages/ui/src/lab-shell.css
@@ -430,6 +430,97 @@ body {
   font-size: 0.78rem;
 }
 
+.ils-search--live {
+  position: relative;
+  padding: 0;
+  min-width: 280px;
+}
+
+.ils-search-input {
+  flex: 1;
+  height: 100%;
+  padding: 0 2rem 0 0.8rem;
+  background: transparent;
+  border: none;
+  outline: none;
+  font: inherit;
+  color: var(--ilm-ink);
+}
+
+.ils-search-input::placeholder {
+  color: var(--ilm-fg-4);
+}
+
+.ils-search--live:focus-within {
+  border-color: var(--ilm-ink);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.ils-search-glyph {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ilm-fg-4);
+  pointer-events: none;
+  font-size: 0.95rem;
+}
+
+.ils-search-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid var(--ilm-line);
+  border-radius: var(--rl-radius-sm);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 50;
+}
+
+.ils-search-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--ilm-ink);
+}
+
+.ils-search-result.is-active,
+.ils-search-result:hover {
+  background: var(--ilm-line);
+}
+
+.ils-search-result-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ils-search-result-group {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ilm-muted);
+}
+
+.ils-search-empty {
+  padding: 0.55rem 0.8rem;
+  font-size: 0.78rem;
+  color: var(--ilm-muted);
+  font-style: italic;
+}
+
 .ils-org {
   text-align: right;
   font-family: var(--rl-font-display);

--- a/supabase/migrations/20260507000000_data_hub_dataset_owner_contact_null.sql
+++ b/supabase/migrations/20260507000000_data_hub_dataset_owner_contact_null.sql
@@ -1,0 +1,98 @@
+-- create_dataset previously coalesced p_owner_user_id / p_contact_user_id to
+-- the calling user, which made it impossible to create a dataset with no
+-- owner / no contact (the form's "None" option had no effect — the calling
+-- user was always written back). The columns are nullable
+-- (`on delete set null`), so honor an explicit null instead of substituting
+-- the caller. Callers that genuinely want a default still get one — the
+-- client passes args.userId for that case.
+
+create or replace function public.create_dataset(
+  p_lab_id uuid,
+  p_name text,
+  p_description text default null,
+  p_dataset_type text default 'other',
+  p_source_type text default 'internal-generated',
+  p_status text default 'planned',
+  p_access_level text default 'request-required',
+  p_owner_user_id uuid default null,
+  p_contact_user_id uuid default null,
+  p_organism text default null,
+  p_sample_type text default null,
+  p_assay_platform text default null,
+  p_external_accession text default null,
+  p_citation text default null,
+  p_license text default null,
+  p_usage_conditions text default null,
+  p_recommended_use text default null,
+  p_not_recommended_use text default null,
+  p_qc_summary text default null,
+  p_notes text default null,
+  p_tags text[] default '{}',
+  p_project_links jsonb default '[]'::jsonb,
+  p_storage_uri text default null
+) returns public.datasets
+language plpgsql security definer set search_path = public as $$
+declare
+  v_uid uuid := auth.uid();
+  v_name text := nullif(btrim(coalesce(p_name, '')), '');
+  v_storage_uri text := nullif(btrim(coalesce(p_storage_uri, '')), '');
+  v_external_accession text := nullif(btrim(coalesce(p_external_accession, '')), '');
+  v_citation text := nullif(btrim(coalesce(p_citation, '')), '');
+  v_row public.datasets%rowtype;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '42501';
+  end if;
+  if not public.is_lab_member(p_lab_id) then
+    raise exception 'not a member of this lab' using errcode = '42501';
+  end if;
+  if v_name is null then
+    raise exception 'dataset name is required' using errcode = '22023';
+  end if;
+  if v_storage_uri is null and v_external_accession is null and v_citation is null then
+    raise exception 'add at least one storage URI, external accession, or citation' using errcode = '22023';
+  end if;
+
+  insert into public.datasets (
+    lab_id, name, description, dataset_type, source_type, status, access_level,
+    owner_user_id, contact_user_id, organism, sample_type, assay_platform,
+    primary_storage_uri, external_accession, citation, license, usage_conditions,
+    recommended_use, not_recommended_use, qc_summary, notes, created_by, updated_by
+  ) values (
+    p_lab_id,
+    v_name,
+    nullif(btrim(coalesce(p_description, '')), ''),
+    coalesce(p_dataset_type, 'other'),
+    coalesce(p_source_type, 'internal-generated'),
+    coalesce(p_status, 'planned'),
+    coalesce(p_access_level, 'request-required'),
+    p_owner_user_id,
+    p_contact_user_id,
+    nullif(btrim(coalesce(p_organism, '')), ''),
+    nullif(btrim(coalesce(p_sample_type, '')), ''),
+    nullif(btrim(coalesce(p_assay_platform, '')), ''),
+    null,
+    v_external_accession,
+    v_citation,
+    nullif(btrim(coalesce(p_license, '')), ''),
+    nullif(btrim(coalesce(p_usage_conditions, '')), ''),
+    nullif(btrim(coalesce(p_recommended_use, '')), ''),
+    nullif(btrim(coalesce(p_not_recommended_use, '')), ''),
+    nullif(btrim(coalesce(p_qc_summary, '')), ''),
+    nullif(btrim(coalesce(p_notes, '')), ''),
+    v_uid,
+    v_uid
+  )
+  returning * into v_row;
+
+  perform public._replace_dataset_children(
+    p_lab_id, v_row.id, p_tags, p_project_links, v_storage_uri
+  );
+  perform public._log_audit(p_lab_id, 'dataset', v_row.id, 'create', '{}'::jsonb);
+  return v_row;
+end;
+$$;
+
+grant execute on function public.create_dataset(
+  uuid, text, text, text, text, text, text, uuid, uuid, text, text, text, text, text, text, text, text, text, text, text, text[], jsonb, text
+) to authenticated;


### PR DESCRIPTION
## Summary
- Closes #87, closes #88.
- Supply Manager **My Items** now includes items linked to projects where the user is a project lead, not just `project_members`.
- Data Hub: choosing **None** for dataset owner / contact is now honored end-to-end (client passes null through; migration drops the SQL `coalesce(p_owner_user_id, v_uid)` that was overwriting the choice with the caller).
- Scheduler calendar: short events no longer truncate. The colored edge follows the event duration while a fixed-size, vertically-centered card overlays it so the title and time stay readable.
- Topbar search is now interactive: a `GlobalSearch` component filters a registry of pages (apps + main subtabs) and jumps directly on click / Enter. Wired into all six app shells via `LabTopbar baseUrl`.

## Test plan
- [ ] `npm run typecheck` (passes locally)
- [ ] `npm run build` (all 7 apps build clean)
- [ ] Apply migration `20260507000000_data_hub_dataset_owner_contact_null.sql` to dev DB and verify creating a dataset with owner=None / contact=None persists null.
- [ ] As a user who is a project lead but not a project_member, open Supply Manager → My Items and confirm items linked to that project appear.
- [ ] Open Scheduler calendar with a 15-minute event and confirm the title/time are visible (card extends past the colored slice).
- [ ] In the topbar, type "library" / "warehouse" / "team" and confirm the dropdown lists matching pages and Enter navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)