### PR TITLE
Dashboard gaps + global record search + project JSON transfer

### DIFF
--- a/apps/account/src/lib/dashboardData.ts
+++ b/apps/account/src/lib/dashboardData.ts
@@ -1,6 +1,88 @@
 import { useCallback, useEffect, useState } from "react";
 import { getSupabaseClient } from "@ilm/utils";
 
+// ---------------------------------------------------------------------------
+// Recurrence — minimal v1, mirrors apps/scheduler/src/lib/datetime.ts so the
+// dashboard can expand recurring calendar events without depending on the
+// scheduler app. If new frequencies are added there, mirror them here.
+// ---------------------------------------------------------------------------
+
+type RecurrenceFreq = "none" | "daily" | "weekly" | "biweekly" | "monthly";
+
+const ruleToFreq = (rule: string | null | undefined): RecurrenceFreq => {
+  if (!rule) return "none";
+  const upper = rule.toUpperCase();
+  if (upper.includes("BIWEEKLY")) return "biweekly";
+  if (upper.includes("DAILY")) return "daily";
+  if (upper.includes("WEEKLY")) return "weekly";
+  if (upper.includes("MONTHLY")) return "monthly";
+  return "none";
+};
+
+const advance = (date: Date, freq: RecurrenceFreq): Date => {
+  const next = new Date(date);
+  switch (freq) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      return next;
+    case "weekly":
+      next.setDate(next.getDate() + 7);
+      return next;
+    case "biweekly":
+      next.setDate(next.getDate() + 14);
+      return next;
+    case "monthly":
+      next.setMonth(next.getMonth() + 1);
+      return next;
+    default:
+      return next;
+  }
+};
+
+const expandRecurrence = (args: {
+  rule: string | null | undefined;
+  baseStartIso: string;
+  baseEndIso: string | null;
+  windowStart: Date;
+  windowEnd: Date;
+  exceptions?: string[];
+  maxInstances?: number;
+}): Array<{ start: string; end: string }> => {
+  const freq = ruleToFreq(args.rule);
+  const baseStart = new Date(args.baseStartIso);
+  const baseEnd = args.baseEndIso ? new Date(args.baseEndIso) : new Date(baseStart.getTime() + 30 * 60_000);
+  const span = baseEnd.getTime() - baseStart.getTime();
+  if (Number.isNaN(span) || span <= 0) return [];
+
+  const exceptions = new Set((args.exceptions ?? []).map((iso) => new Date(iso).getTime()));
+  const out: Array<{ start: string; end: string }> = [];
+
+  if (freq === "none") {
+    if (
+      baseEnd.getTime() > args.windowStart.getTime() &&
+      baseStart.getTime() < args.windowEnd.getTime()
+    ) {
+      out.push({ start: baseStart.toISOString(), end: baseEnd.toISOString() });
+    }
+    return out;
+  }
+
+  const cap = args.maxInstances ?? 64;
+  let cursor = new Date(baseStart);
+  for (let i = 0; i < cap; i += 1) {
+    const cursorEnd = new Date(cursor.getTime() + span);
+    if (cursor.getTime() >= args.windowEnd.getTime()) break;
+    if (
+      cursorEnd.getTime() > args.windowStart.getTime() &&
+      !exceptions.has(cursor.getTime())
+    ) {
+      out.push({ start: cursor.toISOString(), end: cursorEnd.toISOString() });
+    }
+    cursor = advance(cursor, freq);
+  }
+  return out;
+};
+
 export type ProjectStateCounts = {
   draft: number;
   published: number;
@@ -62,7 +144,7 @@ export type ScheduleEntry = {
 
 export type ActivityEntry = {
   id: string;
-  kind: "protocol" | "project" | "item" | "order" | "booking";
+  kind: "protocol" | "project" | "item" | "order" | "booking" | "dataset" | "event";
   label: string;
   context: string;
   timestamp: string;
@@ -179,8 +261,11 @@ export const useDashboardData = (
           pendingBookingsRes,
           pendingDatasetRequestsRes,
           eventsRes,
+          recurringEventsRes,
           bookingsRes,
           recentOrdersRes,
+          recentBookingsRes,
+          recentDatasetsRes,
           projectLeadRes,
           inOrderItemsRes,
         ] = await Promise.all([
@@ -234,12 +319,25 @@ export const useDashboardData = (
             .limit(200),
           supabase
             .from("calendar_events")
-            .select("id, title, start_time, end_time, location, status")
+            .select("id, title, start_time, end_time, location, status, recurrence_rule, recurrence_exceptions")
             .eq("lab_id", labId)
             .gte("start_time", nowIso)
             .neq("status", "cancelled")
             .order("start_time", { ascending: true })
-            .limit(8),
+            .limit(16),
+          // Recurring events whose first instance has already happened need
+          // separate fetching — `gte("start_time", nowIso)` would filter them
+          // out even though the rule still produces upcoming instances. We
+          // expand them client-side against a 14-day window below.
+          supabase
+            .from("calendar_events")
+            .select("id, title, start_time, end_time, location, status, recurrence_rule, recurrence_exceptions, updated_at")
+            .eq("lab_id", labId)
+            .lt("start_time", nowIso)
+            .neq("status", "cancelled")
+            .not("recurrence_rule", "is", null)
+            .order("start_time", { ascending: false })
+            .limit(64),
           supabase
             .from("bookings")
             .select("id, title, start_time, end_time, status")
@@ -252,6 +350,19 @@ export const useDashboardData = (
             .from("order_requests")
             .select("id, reason, status, updated_at")
             .eq("lab_id", labId)
+            .order("updated_at", { ascending: false })
+            .limit(6),
+          supabase
+            .from("bookings")
+            .select("id, title, status, updated_at")
+            .eq("lab_id", labId)
+            .order("updated_at", { ascending: false })
+            .limit(6),
+          supabase
+            .from("datasets")
+            .select("id, name, updated_at, archived_at")
+            .eq("lab_id", labId)
+            .is("archived_at", null)
             .order("updated_at", { ascending: false })
             .limit(6),
           userId
@@ -419,6 +530,9 @@ export const useDashboardData = (
           end_time: string | null;
           location: string | null;
           status: string;
+          recurrence_rule?: string | null;
+          recurrence_exceptions?: string[] | null;
+          updated_at?: string;
         };
         type BookingRow = {
           id: string;
@@ -428,15 +542,51 @@ export const useDashboardData = (
           status: string;
         };
         const eventRows = (eventsRes.data as EventRow[] | null) ?? [];
+        const recurringEventRows = (recurringEventsRes.data as EventRow[] | null) ?? [];
         const bookingRows = (bookingsRes.data as BookingRow[] | null) ?? [];
+
+        // Expand recurring events whose first instance is in the past — only
+        // their next-future occurrences should land in the upcoming list.
+        const now = new Date();
+        const windowEnd = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
+        type ExpandedEvent = {
+          row: EventRow;
+          startIso: string;
+          endIso: string | null;
+        };
+        const expandedRecurringEvents: ExpandedEvent[] = [];
+        for (const row of recurringEventRows) {
+          if (!row.recurrence_rule) continue;
+          const instances = expandRecurrence({
+            rule: row.recurrence_rule,
+            baseStartIso: row.start_time,
+            baseEndIso: row.end_time,
+            windowStart: now,
+            windowEnd,
+            exceptions: row.recurrence_exceptions ?? undefined,
+          });
+          for (const inst of instances) {
+            if (new Date(inst.start).getTime() < now.getTime()) continue;
+            expandedRecurringEvents.push({ row, startIso: inst.start, endIso: inst.end });
+          }
+        }
+
         const schedule: ScheduleEntry[] = [
           ...eventRows.map((e) => ({
-            id: `event-${e.id}`,
+            id: `event-${e.id}-${e.start_time}`,
             title: e.title,
             startTime: e.start_time,
             endTime: e.end_time,
             kind: "event" as const,
             location: e.location,
+          })),
+          ...expandedRecurringEvents.map((e) => ({
+            id: `event-${e.row.id}-${e.startIso}`,
+            title: e.row.title,
+            startTime: e.startIso,
+            endTime: e.endIso,
+            kind: "event" as const,
+            location: e.row.location,
           })),
           ...bookingRows.map((b) => ({
             id: `booking-${b.id}`,
@@ -450,9 +600,15 @@ export const useDashboardData = (
           .sort((a, b) => a.startTime.localeCompare(b.startTime))
           .slice(0, 5);
 
-        // Activity feed: union recent updates across protocols/projects/items/orders/bookings
+        // Activity feed: union recent updates across every domain that has a
+        // user-visible "updated_at". Bookings and datasets used to be missing
+        // even though they're part of the type union — they're now included.
         type OrderRow = { id: string; reason: string | null; status: string; updated_at: string };
+        type BookingActivityRow = { id: string; title: string | null; status: string; updated_at: string };
+        type DatasetActivityRow = { id: string; name: string; updated_at: string; archived_at: string | null };
         const orderRows = (recentOrdersRes.data as OrderRow[] | null) ?? [];
+        const bookingActivityRows = (recentBookingsRes.data as BookingActivityRow[] | null) ?? [];
+        const datasetActivityRows = (recentDatasetsRes.data as DatasetActivityRow[] | null) ?? [];
         const stream: ActivityEntry[] = [];
         for (const r of protocolRows.slice(0, 6)) {
           stream.push({
@@ -490,6 +646,24 @@ export const useDashboardData = (
             timestamp: r.updated_at,
           });
         }
+        for (const r of bookingActivityRows) {
+          stream.push({
+            id: `booking-${r.id}`,
+            kind: "booking",
+            label: `Booking "${r.title ?? "resource"}" ${r.status}`,
+            context: formatRelative(r.updated_at),
+            timestamp: r.updated_at,
+          });
+        }
+        for (const r of datasetActivityRows) {
+          stream.push({
+            id: `dataset-${r.id}`,
+            kind: "dataset",
+            label: `Dataset "${r.name}" updated`,
+            context: formatRelative(r.updated_at),
+            timestamp: r.updated_at,
+          });
+        }
         stream.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
         // Project lead?
@@ -503,7 +677,7 @@ export const useDashboardData = (
           team,
           pending,
           schedule,
-          activity: stream.slice(0, 6),
+          activity: stream.slice(0, 8),
           isProjectLead: leadRows.length > 0,
           loading: false,
           refreshing: false,
@@ -539,6 +713,20 @@ export const useDashboardData = (
     };
     document.addEventListener("visibilitychange", onVisible);
     return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [labId, load]);
+
+  // Periodic background refresh so the dashboard reflects writes from other
+  // sessions / apps without the user manually clicking refresh. Skipped while
+  // the tab is hidden — the visibilitychange listener above picks it up when
+  // the user returns.
+  useEffect(() => {
+    if (typeof window === "undefined" || !labId) return;
+    const intervalMs = 60_000;
+    const id = window.setInterval(() => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      void load("refresh");
+    }, intervalMs);
+    return () => window.clearInterval(id);
   }, [labId, load]);
 
   const refresh = useCallback(async () => {

--- a/apps/data-hub/src/App.tsx
+++ b/apps/data-hub/src/App.tsx
@@ -199,7 +199,17 @@ export const App = () => {
     if (hash === "my-datasets" || hash === "requests") return hash;
     return "library";
   });
-  const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null);
+  // Honor `#dataset/{id}` deep links from the global search by pre-selecting
+  // the dataset on first mount; the existing detail view handles the rest.
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    const hash = window.location.hash.replace(/^#\/?/, "");
+    if (hash.startsWith("dataset/")) {
+      const id = hash.slice("dataset/".length);
+      return id ? decodeURIComponent(id) : null;
+    }
+    return null;
+  });
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
   const [modal, setModal] = useState<ModalState>({ kind: "none" });
   const [actionError, setActionError] = useState<string | null>(null);

--- a/apps/project-manager/package.json
+++ b/apps/project-manager/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@ilm/ai-import": "file:../../packages/ai-import",
     "@ilm/ui": "file:../../packages/ui",
     "@ilm/utils": "file:../../packages/utils",
     "react": "^18.3.1",

--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import {
   LabShell,
   LabTopbar,
@@ -26,6 +26,12 @@ import {
   ProjectOutlinePanel,
   type ProjectOutlineSelection,
 } from "./components/ProjectOutlinePanel";
+import {
+  buildProjectExport,
+  parseProjectImportFromText,
+  stringifyProjectExport,
+  type NormalizedProjectImportPlan,
+} from "./lib/projectIO";
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
@@ -474,6 +480,109 @@ const NewProjectModal = ({
 };
 
 // ---------------------------------------------------------------------------
+// Import Project modal — paste JSON or upload a file. The parsed plan is
+// handed back to the App which re-creates the project + milestones +
+// experiments under the active lab.
+// ---------------------------------------------------------------------------
+
+const ImportProjectModal = ({
+  onClose,
+  onImport,
+}: {
+  onClose: () => void;
+  onImport: (plan: NormalizedProjectImportPlan) => Promise<ProjectRecord>;
+}) => {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (rawText: string) => {
+    setError(null);
+    setBusy(true);
+    try {
+      const plan = parseProjectImportFromText(rawText);
+      await onImport(plan);
+      onClose();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFile = async (file: File) => {
+    try {
+      const contents = await file.text();
+      setText(contents);
+      await submit(contents);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!text.trim()) {
+      setError("Paste JSON or upload a file before importing.");
+      return;
+    }
+    await submit(text);
+  };
+
+  return (
+    <div className="pm-modal-backdrop" role="dialog" aria-modal="true">
+      <form className="pm-modal" onSubmit={handleSubmit}>
+        <div className="pm-modal-head">
+          <h2>Import project from JSON</h2>
+          <button type="button" className="pm-text-button" onClick={onClose} disabled={busy}>
+            Close
+          </button>
+        </div>
+        <p className="pm-modal-note">
+          Paste a JSON payload exported from another project, or upload a <code>.project.json</code>{" "}
+          file. A new draft project is created in the active lab; you'll be added as a project lead.
+        </p>
+        {error ? <p className="pm-inline-error">{error}</p> : null}
+        <label className="pm-field">
+          <span>Project JSON</span>
+          <textarea
+            rows={12}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            placeholder='{"version":1,"kind":"ilm.project", ... }'
+            disabled={busy}
+          />
+        </label>
+        <div className="pm-form-footer">
+          <label className="pm-text-button" style={{ cursor: busy ? "not-allowed" : "pointer" }}>
+            Upload file
+            <input
+              type="file"
+              accept="application/json,.json"
+              hidden
+              disabled={busy}
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                event.target.value = "";
+                if (file) void handleFile(file);
+              }}
+            />
+          </label>
+          <div className="pm-inline-actions">
+            <button type="button" className="pm-text-button" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+            <button type="submit" className="pm-primary-button" disabled={busy}>
+              {busy ? "Importing…" : "Import"}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // App root
 // ---------------------------------------------------------------------------
 
@@ -517,12 +626,23 @@ export const App = () => {
     reorderExperiments,
   } = workspace;
 
-  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(() => {
-    if (typeof window === "undefined") return "overview";
-    const hash = window.location.hash.replace(/^#\/?/, "").toLowerCase();
-    if (hash === "review" || hash === "library" || hash === "overview") return hash as SidebarTab;
-    return "overview";
-  });
+  // Hash supports both bare tabs (e.g. `#/library`) and deep links to a
+  // specific record (e.g. `#/library/{projectId}`) emitted by the global
+  // search. The ID part is stripped before the tab lookup.
+  const initialHashRef = useRef<{ tab: SidebarTab; selectId: string | null }>(
+    (() => {
+      if (typeof window === "undefined") return { tab: "overview" as SidebarTab, selectId: null };
+      const stripped = window.location.hash.replace(/^#\/?/, "");
+      const [primary = "", maybeId = ""] = stripped.split("/");
+      const lower = primary.toLowerCase();
+      const tab: SidebarTab =
+        lower === "review" || lower === "library" || lower === "overview"
+          ? (lower as SidebarTab)
+          : "overview";
+      return { tab, selectId: maybeId ? decodeURIComponent(maybeId) : null };
+    })()
+  );
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(initialHashRef.current.tab);
   const [viewSubTab, setViewSubTab] = useState<ViewSubTab>("info");
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
@@ -597,6 +717,26 @@ export const App = () => {
       setActiveProjectId(activePublishedProjects[0]?.id ?? publishedProjects[0]?.id ?? projects[0].id);
     }
   }, [sidebarTab, projects, activePublishedProjects, publishedProjects, activeProjectId]);
+
+  // Honor the global-search deep link `#/library/{projectId}` once the
+  // project list has hydrated. Runs once per initial selectId.
+  const initialSelectAppliedRef = useRef(false);
+  useEffect(() => {
+    if (initialSelectAppliedRef.current) return;
+    const targetId = initialHashRef.current.selectId;
+    if (!targetId) {
+      initialSelectAppliedRef.current = true;
+      return;
+    }
+    if (!projects.length) return;
+    if (projects.some((p) => p.id === targetId)) {
+      setActiveProjectId(targetId);
+      setSidebarTab("view");
+      setViewSubTab("info");
+      setOutlineSelection(null);
+    }
+    initialSelectAppliedRef.current = true;
+  }, [projects]);
 
   const activeProject = useMemo(
     () => projects.find((p) => p.id === activeProjectId) ?? null,
@@ -792,6 +932,87 @@ export const App = () => {
       openProject(created.id);
     },
     [createProjectDraft, openProject]
+  );
+
+  // ---------------------------------------------------------------------
+  // Project JSON import / export — mirrors the protocol-manager transfer
+  // feature. Export bundles the active project's metadata + milestones +
+  // experiments into a versioned JSON; import creates a fresh draft and
+  // recreates that hierarchy under the active lab.
+  // ---------------------------------------------------------------------
+
+  const [importOpen, setImportOpen] = useState(false);
+
+  const handleExportProject = useCallback(
+    (project: ProjectRecord) => {
+      try {
+        const payload = buildProjectExport({ project, milestones, experiments });
+        const text = stringifyProjectExport(payload);
+        const blob = new Blob([text], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        const slug = project.name.replace(/[^a-z0-9-_]+/gi, "-").replace(/^-+|-+$/g, "") || "project";
+        link.download = `${slug}.project.json`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        setActionError(errorMessage(err));
+      }
+    },
+    [milestones, experiments]
+  );
+
+  const handleImportProject = useCallback(
+    async (plan: NormalizedProjectImportPlan) => {
+      // Stage 1: create the draft project, so we get an id under RLS.
+      const created = await createProjectDraft({
+        name: plan.project.name,
+        description: plan.project.description ?? undefined,
+        status: plan.project.status,
+        approvalRequired: plan.project.approvalRequired,
+      });
+      // Stage 2: recreate milestones + their experiments. createMilestone /
+      // createExperiment auto-append sort_order in the workspace hook, so
+      // sequential calls preserve the JSON's intended order.
+      for (const milestone of plan.milestones) {
+        const createdMilestone = await createMilestone({
+          projectId: created.id,
+          title: milestone.title,
+          description: milestone.description ?? undefined,
+          dueDate: milestone.dueDate,
+          status: milestone.status,
+        });
+        for (const experiment of milestone.experiments) {
+          await createExperiment({
+            projectId: created.id,
+            milestoneId: createdMilestone.id,
+            title: experiment.title,
+            notes: experiment.notes ?? undefined,
+            status: experiment.status,
+            startedAt: experiment.startedAt,
+            completedAt: experiment.completedAt,
+          });
+        }
+      }
+      // Stage 3: ungrouped experiments (not attached to any milestone).
+      for (const experiment of plan.ungroupedExperiments) {
+        await createExperiment({
+          projectId: created.id,
+          milestoneId: null,
+          title: experiment.title,
+          notes: experiment.notes ?? undefined,
+          status: experiment.status,
+          startedAt: experiment.startedAt,
+          completedAt: experiment.completedAt,
+        });
+      }
+      openProject(created.id);
+      return created;
+    },
+    [createProjectDraft, createMilestone, createExperiment, openProject]
   );
 
   const handleWithdraw = useCallback(
@@ -1549,6 +1770,14 @@ export const App = () => {
             actorNames={memberNameById}
             linkLabel="Submission history"
           />
+          <button
+            type="button"
+            className="pm-text-button"
+            onClick={() => handleExportProject(activeProject)}
+            title="Download this project (info + milestones + experiments) as JSON."
+          >
+            Export JSON
+          </button>
           <div className="pm-tab-nav-right">{projectStateTag(activeProject)}</div>
         </nav>
 
@@ -1752,6 +1981,14 @@ export const App = () => {
       </button>
       <button
         type="button"
+        className="pm-text-button"
+        onClick={() => setImportOpen(true)}
+        title="Import a project from a previously-exported JSON file."
+      >
+        Import JSON
+      </button>
+      <button
+        type="button"
         className="pm-primary-button"
         onClick={() => setNewProjectOpen(true)}
       >
@@ -1788,6 +2025,13 @@ export const App = () => {
         <NewProjectModal
           onClose={() => setNewProjectOpen(false)}
           onCreate={handleCreateProject}
+        />
+      ) : null}
+
+      {importOpen ? (
+        <ImportProjectModal
+          onClose={() => setImportOpen(false)}
+          onImport={handleImportProject}
         />
       ) : null}
     </LabShell>

--- a/apps/project-manager/src/App.tsx
+++ b/apps/project-manager/src/App.tsx
@@ -32,6 +32,11 @@ import {
   stringifyProjectExport,
   type NormalizedProjectImportPlan,
 } from "./lib/projectIO";
+import {
+  AI_IMPORT_PROJECT_INSTRUCTIONS_TEXT,
+  AI_IMPORT_PROJECT_PANEL_TITLE,
+  AI_IMPORT_PROJECT_TEMPLATE,
+} from "@ilm/ai-import";
 
 const APP_BASE_URL = import.meta.env.BASE_URL;
 
@@ -485,6 +490,45 @@ const NewProjectModal = ({
 // experiments under the active lab.
 // ---------------------------------------------------------------------------
 
+const downloadJsonFile = (filename: string, content: string) => {
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to legacy path
+    }
+  }
+  if (typeof document === "undefined") return false;
+  const area = document.createElement("textarea");
+  area.value = text;
+  area.setAttribute("readonly", "");
+  area.style.position = "absolute";
+  area.style.left = "-9999px";
+  document.body.appendChild(area);
+  area.select();
+  try {
+    const ok = document.execCommand("copy");
+    document.body.removeChild(area);
+    return ok;
+  } catch {
+    document.body.removeChild(area);
+    return false;
+  }
+};
+
 const ImportProjectModal = ({
   onClose,
   onImport,
@@ -494,6 +538,7 @@ const ImportProjectModal = ({
 }) => {
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   const submit = async (rawText: string) => {
@@ -529,9 +574,22 @@ const ImportProjectModal = ({
     await submit(text);
   };
 
+  const handleCopyInstructions = async () => {
+    const ok = await copyToClipboard(AI_IMPORT_PROJECT_INSTRUCTIONS_TEXT);
+    setStatus(ok ? "AI instructions copied to clipboard." : "Could not copy — copy manually from the field below.");
+  };
+
+  const handleDownloadTemplate = () => {
+    downloadJsonFile(
+      "project-template.json",
+      JSON.stringify(AI_IMPORT_PROJECT_TEMPLATE, null, 2)
+    );
+    setStatus("Downloaded project-template.json.");
+  };
+
   return (
     <div className="pm-modal-backdrop" role="dialog" aria-modal="true">
-      <form className="pm-modal" onSubmit={handleSubmit}>
+      <form className="pm-modal pm-modal--wide" onSubmit={handleSubmit}>
         <div className="pm-modal-head">
           <h2>Import project from JSON</h2>
           <button type="button" className="pm-text-button" onClick={onClose} disabled={busy}>
@@ -543,16 +601,53 @@ const ImportProjectModal = ({
           file. A new draft project is created in the active lab; you'll be added as a project lead.
         </p>
         {error ? <p className="pm-inline-error">{error}</p> : null}
+        {status ? <p className="pm-modal-note" aria-live="polite">{status}</p> : null}
         <label className="pm-field">
           <span>Project JSON</span>
           <textarea
-            rows={12}
+            rows={10}
             value={text}
             onChange={(event) => setText(event.target.value)}
             placeholder='{"version":1,"kind":"ilm.project", ... }'
             disabled={busy}
           />
         </label>
+
+        <fieldset className="pm-field" style={{ border: "1px solid var(--rl-border, #d6d8dc)", padding: "0.6rem 0.8rem" }}>
+          <legend style={{ padding: "0 0.35rem", fontSize: "0.8rem", letterSpacing: "0.05em", textTransform: "uppercase" }}>
+            {AI_IMPORT_PROJECT_PANEL_TITLE}
+          </legend>
+          <p className="pm-modal-note" style={{ marginTop: 0 }}>
+            Copy these instructions into an AI assistant alongside your plain-language project
+            description (or an exported plan from another tool) to produce a valid Project Manager
+            JSON payload. Or download the template below to author one by hand.
+          </p>
+          <div className="pm-inline-actions" style={{ marginBottom: "0.5rem" }}>
+            <button
+              type="button"
+              className="pm-text-button"
+              onClick={() => void handleCopyInstructions()}
+              disabled={busy}
+            >
+              Copy AI instructions
+            </button>
+            <button
+              type="button"
+              className="pm-text-button"
+              onClick={handleDownloadTemplate}
+              disabled={busy}
+            >
+              Download template example
+            </button>
+          </div>
+          <textarea
+            readOnly
+            rows={10}
+            value={AI_IMPORT_PROJECT_INSTRUCTIONS_TEXT}
+            aria-label={AI_IMPORT_PROJECT_PANEL_TITLE}
+          />
+        </fieldset>
+
         <div className="pm-form-footer">
           <label className="pm-text-button" style={{ cursor: busy ? "not-allowed" : "pointer" }}>
             Upload file

--- a/apps/project-manager/src/lib/projectIO.ts
+++ b/apps/project-manager/src/lib/projectIO.ts
@@ -1,0 +1,299 @@
+import type {
+  ExperimentRecord,
+  ExperimentStatus,
+  MilestoneRecord,
+  MilestoneStatus,
+  ProjectRecord,
+  ProjectStatus,
+} from "./cloudAdapter";
+
+// Versioned JSON shape used by the Projects import/export feature. Mirrors
+// the protocol IO contract: stable schema with `version` + `kind` so future
+// changes can detect (and migrate) older payloads. We deliberately avoid
+// embedding lab-scoped IDs, created_by, or timestamps so a JSON exported
+// from one lab can be imported into another without leaking foreign keys.
+
+export const PROJECT_EXPORT_VERSION = 1 as const;
+export const PROJECT_EXPORT_KIND = "ilm.project" as const;
+
+export interface ExperimentExport {
+  title: string;
+  notes: string | null;
+  status: ExperimentStatus;
+  sortOrder: number;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface MilestoneExport {
+  title: string;
+  description: string | null;
+  dueDate: string | null;
+  status: MilestoneStatus;
+  sortOrder: number;
+  experiments: ExperimentExport[];
+}
+
+export interface ProjectExport {
+  version: typeof PROJECT_EXPORT_VERSION;
+  kind: typeof PROJECT_EXPORT_KIND;
+  exportedAt: string;
+  project: {
+    name: string;
+    description: string | null;
+    status: ProjectStatus;
+    approvalRequired: boolean;
+  };
+  milestones: MilestoneExport[];
+  /** Experiments not attached to any milestone — preserved as a sibling list. */
+  ungroupedExperiments: ExperimentExport[];
+}
+
+const MILESTONE_STATUSES: ReadonlyArray<MilestoneStatus> = [
+  "planned",
+  "in_progress",
+  "done",
+  "cancelled",
+];
+const EXPERIMENT_STATUSES: ReadonlyArray<ExperimentStatus> = [
+  "planned",
+  "running",
+  "completed",
+  "failed",
+];
+const PROJECT_STATUSES: ReadonlyArray<ProjectStatus> = [
+  "planning",
+  "active",
+  "blocked",
+  "completed",
+  "archived",
+];
+
+const isMilestoneStatus = (value: unknown): value is MilestoneStatus =>
+  typeof value === "string" && (MILESTONE_STATUSES as readonly string[]).includes(value);
+
+const isExperimentStatus = (value: unknown): value is ExperimentStatus =>
+  typeof value === "string" && (EXPERIMENT_STATUSES as readonly string[]).includes(value);
+
+const isProjectStatus = (value: unknown): value is ProjectStatus =>
+  typeof value === "string" && (PROJECT_STATUSES as readonly string[]).includes(value);
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+const toExperimentExport = (row: ExperimentRecord): ExperimentExport => ({
+  title: row.title,
+  notes: row.notes,
+  status: row.status,
+  sortOrder: row.sort_order,
+  startedAt: row.started_at,
+  completedAt: row.completed_at,
+});
+
+const toMilestoneExport = (
+  milestone: MilestoneRecord,
+  childExperiments: ExperimentRecord[]
+): MilestoneExport => ({
+  title: milestone.title,
+  description: milestone.description,
+  dueDate: milestone.due_date,
+  status: milestone.status,
+  sortOrder: milestone.sort_order,
+  experiments: childExperiments
+    .slice()
+    .sort((a, b) => a.sort_order - b.sort_order || a.created_at.localeCompare(b.created_at))
+    .map(toExperimentExport),
+});
+
+export const buildProjectExport = (args: {
+  project: ProjectRecord;
+  milestones: MilestoneRecord[];
+  experiments: ExperimentRecord[];
+}): ProjectExport => {
+  const projectStatus: ProjectStatus = isProjectStatus(args.project.status)
+    ? args.project.status
+    : "planning";
+  const milestonesByProject = args.milestones
+    .filter((m) => m.project_id === args.project.id)
+    .slice()
+    .sort((a, b) => a.sort_order - b.sort_order || a.created_at.localeCompare(b.created_at));
+  const projectExperiments = args.experiments.filter((e) => e.project_id === args.project.id);
+  const milestoneIds = new Set(milestonesByProject.map((m) => m.id));
+  const grouped: Record<string, ExperimentRecord[]> = {};
+  const ungrouped: ExperimentRecord[] = [];
+  for (const exp of projectExperiments) {
+    if (exp.milestone_id && milestoneIds.has(exp.milestone_id)) {
+      const list = grouped[exp.milestone_id] ?? [];
+      list.push(exp);
+      grouped[exp.milestone_id] = list;
+    } else {
+      ungrouped.push(exp);
+    }
+  }
+  return {
+    version: PROJECT_EXPORT_VERSION,
+    kind: PROJECT_EXPORT_KIND,
+    exportedAt: new Date().toISOString(),
+    project: {
+      name: args.project.name,
+      description: args.project.description,
+      status: projectStatus,
+      approvalRequired: args.project.approval_required,
+    },
+    milestones: milestonesByProject.map((m) => toMilestoneExport(m, grouped[m.id] ?? [])),
+    ungroupedExperiments: ungrouped
+      .slice()
+      .sort((a, b) => a.sort_order - b.sort_order || a.created_at.localeCompare(b.created_at))
+      .map(toExperimentExport),
+  };
+};
+
+export const stringifyProjectExport = (payload: ProjectExport): string =>
+  JSON.stringify(payload, null, 2);
+
+// ---------------------------------------------------------------------------
+// Import — strict schema validation. Returns a normalized "plan" the App can
+// hand to the cloud adapter (createProjectDraft → milestones → experiments).
+// ---------------------------------------------------------------------------
+
+export interface NormalizedExperimentPlan {
+  title: string;
+  notes: string | null;
+  status: ExperimentStatus;
+  sortOrder: number;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface NormalizedMilestonePlan {
+  title: string;
+  description: string | null;
+  dueDate: string | null;
+  status: MilestoneStatus;
+  sortOrder: number;
+  experiments: NormalizedExperimentPlan[];
+}
+
+export interface NormalizedProjectImportPlan {
+  project: {
+    name: string;
+    description: string | null;
+    status: ProjectStatus;
+    approvalRequired: boolean;
+  };
+  milestones: NormalizedMilestonePlan[];
+  ungroupedExperiments: NormalizedExperimentPlan[];
+}
+
+const requireString = (value: unknown, label: string): string => {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error(`${label} cannot be empty`);
+  return trimmed;
+};
+
+const optionalString = (value: unknown, label: string): string | null => {
+  if (value == null) return null;
+  if (typeof value !== "string") throw new Error(`${label} must be a string or null`);
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const optionalIso = (value: unknown, label: string): string | null => {
+  if (value == null) return null;
+  if (typeof value !== "string") throw new Error(`${label} must be an ISO date string or null`);
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`${label} is not a valid date`);
+  return trimmed;
+};
+
+const numberOr = (value: unknown, fallback: number): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return fallback;
+};
+
+const parseExperiment = (raw: unknown, idx: number): NormalizedExperimentPlan => {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`experiments[${idx}] must be an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  const status = r.status;
+  if (!isExperimentStatus(status)) {
+    throw new Error(`experiments[${idx}].status must be one of ${EXPERIMENT_STATUSES.join(", ")}`);
+  }
+  return {
+    title: requireString(r.title, `experiments[${idx}].title`),
+    notes: optionalString(r.notes, `experiments[${idx}].notes`),
+    status,
+    sortOrder: numberOr(r.sortOrder, (idx + 1) * 1024),
+    startedAt: optionalIso(r.startedAt, `experiments[${idx}].startedAt`),
+    completedAt: optionalIso(r.completedAt, `experiments[${idx}].completedAt`),
+  };
+};
+
+const parseMilestone = (raw: unknown, idx: number): NormalizedMilestonePlan => {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`milestones[${idx}] must be an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  const status = r.status;
+  if (!isMilestoneStatus(status)) {
+    throw new Error(`milestones[${idx}].status must be one of ${MILESTONE_STATUSES.join(", ")}`);
+  }
+  const experimentsRaw = Array.isArray(r.experiments) ? r.experiments : [];
+  return {
+    title: requireString(r.title, `milestones[${idx}].title`),
+    description: optionalString(r.description, `milestones[${idx}].description`),
+    dueDate: optionalIso(r.dueDate, `milestones[${idx}].dueDate`),
+    status,
+    sortOrder: numberOr(r.sortOrder, (idx + 1) * 1024),
+    experiments: experimentsRaw.map((row, i) => parseExperiment(row, i)),
+  };
+};
+
+export const parseProjectImport = (raw: unknown): NormalizedProjectImportPlan => {
+  if (!raw || typeof raw !== "object") throw new Error("Import payload must be a JSON object");
+  const r = raw as Record<string, unknown>;
+  if (r.kind !== PROJECT_EXPORT_KIND) {
+    throw new Error(`Expected kind "${PROJECT_EXPORT_KIND}", got "${String(r.kind)}"`);
+  }
+  if (typeof r.version !== "number") {
+    throw new Error("version must be a number");
+  }
+  if (r.version > PROJECT_EXPORT_VERSION) {
+    throw new Error(
+      `Unsupported export version ${r.version}; this client only knows up to v${PROJECT_EXPORT_VERSION}`
+    );
+  }
+  const projectRaw = r.project;
+  if (!projectRaw || typeof projectRaw !== "object") throw new Error("project object missing");
+  const p = projectRaw as Record<string, unknown>;
+  const status: ProjectStatus = isProjectStatus(p.status) ? p.status : "planning";
+  const milestonesRaw = Array.isArray(r.milestones) ? r.milestones : [];
+  const ungroupedRaw = Array.isArray(r.ungroupedExperiments) ? r.ungroupedExperiments : [];
+  return {
+    project: {
+      name: requireString(p.name, "project.name"),
+      description: optionalString(p.description, "project.description"),
+      status,
+      approvalRequired:
+        typeof p.approvalRequired === "boolean" ? p.approvalRequired : true,
+    },
+    milestones: milestonesRaw.map((row, idx) => parseMilestone(row, idx)),
+    ungroupedExperiments: ungroupedRaw.map((row, idx) => parseExperiment(row, idx)),
+  };
+};
+
+export const parseProjectImportFromText = (text: string): NormalizedProjectImportPlan => {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "invalid JSON";
+    throw new Error(`Could not parse JSON: ${message}`);
+  }
+  return parseProjectImport(raw);
+};

--- a/apps/protocol-manager/src/App.tsx
+++ b/apps/protocol-manager/src/App.tsx
@@ -251,14 +251,23 @@ export const App = () => {
   const [saveState, setSaveState] = useState<DraftSaveState>("idle");
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
   const [autosaveTick, setAutosaveTick] = useState(0);
-  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(() => {
-    if (typeof window === "undefined") return "overview";
-    const hash = window.location.hash.replace(/^#\/?/, "").toLowerCase();
-    if (hash === "reviews" || hash === "library" || hash === "overview" || hash === "recycle") {
-      return hash as SidebarTab;
-    }
-    return "overview";
-  });
+  // Hash supports bare tabs (`#/library`) and deep links to a specific
+  // protocol from the global search (`#/library/{protocolId}`). The id part
+  // is stripped before tab lookup and applied once the workspace hydrates.
+  const initialHashRef = useRef<{ tab: SidebarTab; selectId: string | null }>(
+    (() => {
+      if (typeof window === "undefined") return { tab: "overview" as SidebarTab, selectId: null };
+      const stripped = window.location.hash.replace(/^#\/?/, "");
+      const [primary = "", maybeId = ""] = stripped.split("/");
+      const lower = primary.toLowerCase();
+      const tab: SidebarTab =
+        lower === "reviews" || lower === "library" || lower === "overview" || lower === "recycle"
+          ? (lower as SidebarTab)
+          : "overview";
+      return { tab, selectId: maybeId ? decodeURIComponent(maybeId) : null };
+    })()
+  );
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(initialHashRef.current.tab);
   const [viewMode, setViewMode] = useState<ViewMode>("step");
   const [importMode, setImportMode] = useState<ValidationMode>("assisted");
   const [jsonText, setJsonText] = useState("");
@@ -902,6 +911,32 @@ export const App = () => {
       },
     });
   };
+
+  // Honor the global-search deep link `#/library/{protocolId}` once the
+  // workspace has hydrated — open the matching published protocol or draft.
+  const initialSelectAppliedRef = useRef(false);
+  useEffect(() => {
+    if (initialSelectAppliedRef.current) return;
+    const targetId = initialHashRef.current.selectId;
+    if (!targetId) {
+      initialSelectAppliedRef.current = true;
+      return;
+    }
+    if (!workspace) return;
+    const published = publishedProtocols.find((p) => p.id === targetId);
+    const draft = drafts.find((d) => d.id === targetId);
+    if (published) {
+      void openProtocolFromLibrary(targetId);
+      initialSelectAppliedRef.current = true;
+    } else if (draft) {
+      void openDraftFromLibrary(targetId);
+      initialSelectAppliedRef.current = true;
+    } else if (publishedProtocols.length > 0 || drafts.length > 0) {
+      // workspace is hydrated and the id was not found — give up.
+      initialSelectAppliedRef.current = true;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace, publishedProtocols, drafts]);
 
   const openProtocolFromLibrary = async (protocolId: string) => {
     try {

--- a/apps/scheduler/src/App.tsx
+++ b/apps/scheduler/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ErrorBanner,
   LabShell,
@@ -59,18 +59,45 @@ export const App = () => {
     userId: user?.id ?? null,
   });
 
-  const [tab, setTab] = useState<SchedulerTab>(() => {
-    if (typeof window === "undefined") return "calendar";
-    const hash = window.location.hash.replace(/^#\/?/, "").toLowerCase();
-    if (hash === "bookings" || hash === "calendar" || hash === "unscheduled" || hash === "resources") {
-      return hash as SchedulerTab;
-    }
-    return "calendar";
-  });
+  // Hash supports bare tabs (`#/calendar`) and deep links to a specific
+  // event (`#/calendar/{eventId}`) emitted by the global search.
+  const initialHashRef = useRef<{ tab: SchedulerTab; selectId: string | null }>(
+    (() => {
+      if (typeof window === "undefined") return { tab: "calendar" as SchedulerTab, selectId: null };
+      const stripped = window.location.hash.replace(/^#\/?/, "");
+      const [primary = "", maybeId = ""] = stripped.split("/");
+      const lower = primary.toLowerCase();
+      const tab: SchedulerTab =
+        lower === "bookings" || lower === "calendar" || lower === "unscheduled" || lower === "resources"
+          ? (lower as SchedulerTab)
+          : "calendar";
+      return { tab, selectId: maybeId ? decodeURIComponent(maybeId) : null };
+    })()
+  );
+  const [tab, setTab] = useState<SchedulerTab>(initialHashRef.current.tab);
   const [modal, setModal] = useState<ModalState>({ kind: "none" });
   const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
 
   const closeModal = () => setModal({ kind: "none" });
+
+  // Open the matching calendar event in its detail modal once the workspace
+  // has hydrated. Only fires once per initial selectId.
+  const initialSelectAppliedRef = useRef(false);
+  useEffect(() => {
+    if (initialSelectAppliedRef.current) return;
+    const targetId = initialHashRef.current.selectId;
+    if (!targetId) {
+      initialSelectAppliedRef.current = true;
+      return;
+    }
+    if (workspace.events.length === 0) return;
+    const match = workspace.events.find((event) => event.id === targetId);
+    if (match) {
+      setTab("calendar");
+      setModal({ kind: "event-form", event: match, startIso: null, endIso: null });
+    }
+    initialSelectAppliedRef.current = true;
+  }, [workspace.events]);
 
   const renderTab = () => {
     switch (tab) {

--- a/apps/supply-manager/src/App.tsx
+++ b/apps/supply-manager/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import {
   Badge,
   Button,
@@ -208,17 +208,45 @@ export const App = () => {
   const workspace = useSupplyWorkspace(activeLab?.id ?? null, user?.id ?? null);
   const { status, error, refresh } = workspace;
 
-  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(() => {
-    if (typeof window === "undefined") return "warehouse";
-    const hash = window.location.hash.replace(/^#\/?/, "").toLowerCase();
-    if (hash === "review" || hash === "orders" || hash === "warehouse" || hash === "my-items") {
-      return hash as SidebarTab;
-    }
-    return "warehouse";
-  });
+  // Hash supports bare tabs (`#/warehouse`) and deep links to a specific
+  // item from the global search (`#/warehouse/{itemId}`). The id part is
+  // stripped before tab lookup; the edit modal is opened once the workspace
+  // has hydrated.
+  const initialHashRef = useRef<{ tab: SidebarTab; selectId: string | null }>(
+    (() => {
+      if (typeof window === "undefined") return { tab: "warehouse" as SidebarTab, selectId: null };
+      const stripped = window.location.hash.replace(/^#\/?/, "");
+      const [primary = "", maybeId = ""] = stripped.split("/");
+      const lower = primary.toLowerCase();
+      const tab: SidebarTab =
+        lower === "review" || lower === "orders" || lower === "warehouse" || lower === "my-items"
+          ? (lower as SidebarTab)
+          : "warehouse";
+      return { tab, selectId: maybeId ? decodeURIComponent(maybeId) : null };
+    })()
+  );
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>(initialHashRef.current.tab);
   const [modal, setModal] = useState<ModalState>({ kind: "none" });
   const [actionError, setActionError] = useState<string | null>(null);
   const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(new Set());
+
+  // Honor the global-search deep link `#/warehouse/{itemId}` once the
+  // workspace has hydrated — open the matching item in its edit modal.
+  const initialSelectAppliedRef = useRef(false);
+  useEffect(() => {
+    if (initialSelectAppliedRef.current) return;
+    const targetId = initialHashRef.current.selectId;
+    if (!targetId) {
+      initialSelectAppliedRef.current = true;
+      return;
+    }
+    if (status !== "ready") return;
+    if (workspace.items.some((item) => item.id === targetId)) {
+      setSidebarTab("warehouse");
+      setModal({ kind: "edit-item", itemId: targetId });
+    }
+    initialSelectAppliedRef.current = true;
+  }, [status, workspace.items]);
 
   const toggleItemSelected = (id: string) => {
     setSelectedItemIds((prev) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@ilm/ai-import": "file:../../packages/ai-import",
         "@ilm/ui": "file:../../packages/ui",
         "@ilm/utils": "file:../../packages/utils",
         "react": "^18.3.1",

--- a/packages/ai-import/src/index.ts
+++ b/packages/ai-import/src/index.ts
@@ -20,3 +20,80 @@ export const AI_IMPORT_RULES = [
 ] as const;
 
 export const AI_IMPORT_INSTRUCTIONS_TEXT = AI_IMPORT_RULES.map((rule, index) => `${index + 1}. ${rule}`).join("\n");
+
+// ---------------------------------------------------------------------------
+// Project Manager — JSON transfer instructions
+//
+// Used by the "Import project from JSON" modal so users can copy a single
+// prompt into an LLM along with their plain-language project description and
+// receive a ready-to-import payload. The schema mirrors `projectIO.ts` in
+// apps/project-manager.
+// ---------------------------------------------------------------------------
+
+export const AI_IMPORT_PROJECT_PANEL_TITLE =
+  "Instructions for AI-assisted project import";
+
+export const AI_IMPORT_PROJECT_RULES = [
+  "Output one complete valid JSON object only. No markdown fences. No commentary.",
+  "The output must be saved directly as a downloadable .json file.",
+  "Use exactly these top-level fields: version (number), kind (string), exportedAt (ISO timestamp), project (object), milestones (array), ungroupedExperiments (array).",
+  "Set kind to \"ilm.project\" and version to 1.",
+  "project must include: name (non-empty string), description (string or null), status (one of: planning, active, blocked, completed, archived), approvalRequired (boolean).",
+  "Each milestone must include: title (non-empty string), description (string or null), dueDate (ISO date string or null), status (one of: planned, in_progress, done, cancelled), sortOrder (number, ascending), experiments (array).",
+  "Each experiment must include: title (non-empty string), notes (string or null), status (one of: planned, running, completed, failed), sortOrder (number, ascending), startedAt (ISO timestamp or null), completedAt (ISO timestamp or null).",
+  "Use sortOrder values that ascend in steps of 1024 (1024, 2048, 3072 …) so future inserts have room.",
+  "Group related experiments under their owning milestone via the milestone's experiments array. Put any experiment that has no parent milestone into ungroupedExperiments.",
+  "Do not invent owner, lab, or user IDs — they are stripped on export and reassigned on import.",
+  "If information is missing or ambiguous, preserve it in the description / notes fields instead of inventing details.",
+  "Return the final answer as a single self-contained JSON file payload.",
+] as const;
+
+export const AI_IMPORT_PROJECT_INSTRUCTIONS_TEXT = AI_IMPORT_PROJECT_RULES
+  .map((rule, index) => `${index + 1}. ${rule}`)
+  .join("\n");
+
+/**
+ * Minimal but complete example payload, useful both as a template the user
+ * can download and edit, and as the canonical reference for the AI prompt.
+ * Mirrors the ProjectExport shape in apps/project-manager/src/lib/projectIO.ts.
+ */
+export const AI_IMPORT_PROJECT_TEMPLATE = {
+  version: 1,
+  kind: "ilm.project",
+  exportedAt: "2026-01-01T00:00:00.000Z",
+  project: {
+    name: "Example project",
+    description: "Short description of the project's goal and scope.",
+    status: "planning",
+    approvalRequired: true,
+  },
+  milestones: [
+    {
+      title: "Milestone 1 — feasibility",
+      description: "Decide whether the approach is worth scaling up.",
+      dueDate: null,
+      status: "planned",
+      sortOrder: 1024,
+      experiments: [
+        {
+          title: "Pilot run",
+          notes: "Replace with the experiment description you want to anchor here.",
+          status: "planned",
+          sortOrder: 1024,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+    },
+  ],
+  ungroupedExperiments: [
+    {
+      title: "Standalone experiment",
+      notes: "Use this list for experiments not yet attached to a milestone.",
+      status: "planned",
+      sortOrder: 1024,
+      startedAt: null,
+      completedAt: null,
+    },
+  ],
+} as const;

--- a/packages/ui/src/GlobalSearch.tsx
+++ b/packages/ui/src/GlobalSearch.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent } from "react";
+import { getSupabaseClient } from "@ilm/utils";
 import { appUrl } from "./AppSwitcher";
+import { useAuth } from "./auth/AuthProvider";
 
 // Static page registry. Each entry is a navigable destination — either a
 // top-level app or a major subtab inside one. Keep this in sync when an app
@@ -103,6 +105,169 @@ const navigateTo = (href: string) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Record search — query the active lab's tables by name and surface direct
+// links to the matching record. Each result navigates to the parent app with
+// a `#/{tab}/{id}` deep link; the apps below opt-in to that route shape and
+// open the record on mount.
+// ---------------------------------------------------------------------------
+
+type RecordKind = "project" | "protocol" | "item" | "dataset" | "event";
+
+type RecordEntry = {
+  id: string;
+  recordId: string;
+  kind: RecordKind;
+  label: string;
+  group: string;
+  href: string;
+};
+
+const RECORD_GROUP_LABEL: Record<RecordKind, string> = {
+  project: "Project",
+  protocol: "Protocol",
+  item: "Item",
+  dataset: "Dataset",
+  event: "Event",
+};
+
+const buildRecordHref = (kind: RecordKind, recordId: string, baseUrl: string): string => {
+  const escaped = encodeURIComponent(recordId);
+  switch (kind) {
+    case "project":
+      return `${appUrl(APP_HREF["project-manager"], baseUrl)}#/library/${escaped}`;
+    case "protocol":
+      return `${appUrl(APP_HREF["protocol-manager"], baseUrl)}#/library/${escaped}`;
+    case "item":
+      return `${appUrl(APP_HREF["supply-manager"], baseUrl)}#/warehouse/${escaped}`;
+    case "dataset":
+      return `${appUrl(APP_HREF["data-hub"], baseUrl)}#dataset/${escaped}`;
+    case "event":
+      return `${appUrl(APP_HREF["scheduler"], baseUrl)}#/calendar/${escaped}`;
+  }
+};
+
+const escapeIlikeWildcards = (value: string) =>
+  value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+
+async function searchRecords(
+  query: string,
+  labId: string,
+  baseUrl: string
+): Promise<RecordEntry[]> {
+  const trimmed = query.trim();
+  if (!trimmed || !labId) return [];
+  const supabase = getSupabaseClient();
+  const pattern = `%${escapeIlikeWildcards(trimmed)}%`;
+  const limit = 5;
+
+  type ProjectRow = { id: string; name: string };
+  type ProtocolRow = { id: string; title: string };
+  type ItemRow = { id: string; name: string };
+  type DatasetRow = { id: string; name: string };
+  type EventRow = { id: string; title: string };
+
+  const [projectsRes, protocolsRes, itemsRes, datasetsRes, eventsRes] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select("id, name")
+        .eq("lab_id", labId)
+        .neq("state", "deleted")
+        .ilike("name", pattern)
+        .order("updated_at", { ascending: false })
+        .limit(limit),
+      supabase
+        .from("protocols")
+        .select("id, title")
+        .eq("lab_id", labId)
+        .ilike("title", pattern)
+        .order("updated_at", { ascending: false })
+        .limit(limit),
+      supabase
+        .from("items")
+        .select("id, name")
+        .eq("lab_id", labId)
+        .eq("is_active", true)
+        .ilike("name", pattern)
+        .order("updated_at", { ascending: false })
+        .limit(limit),
+      supabase
+        .from("datasets")
+        .select("id, name")
+        .eq("lab_id", labId)
+        .is("archived_at", null)
+        .ilike("name", pattern)
+        .order("updated_at", { ascending: false })
+        .limit(limit),
+      supabase
+        .from("calendar_events")
+        .select("id, title")
+        .eq("lab_id", labId)
+        .neq("status", "cancelled")
+        .ilike("title", pattern)
+        .order("start_time", { ascending: false })
+        .limit(limit),
+    ]);
+
+  const out: RecordEntry[] = [];
+  for (const row of (projectsRes.data as ProjectRow[] | null) ?? []) {
+    out.push({
+      id: `record-project-${row.id}`,
+      recordId: row.id,
+      kind: "project",
+      label: row.name,
+      group: RECORD_GROUP_LABEL.project,
+      href: buildRecordHref("project", row.id, baseUrl),
+    });
+  }
+  for (const row of (protocolsRes.data as ProtocolRow[] | null) ?? []) {
+    out.push({
+      id: `record-protocol-${row.id}`,
+      recordId: row.id,
+      kind: "protocol",
+      label: row.title,
+      group: RECORD_GROUP_LABEL.protocol,
+      href: buildRecordHref("protocol", row.id, baseUrl),
+    });
+  }
+  for (const row of (itemsRes.data as ItemRow[] | null) ?? []) {
+    out.push({
+      id: `record-item-${row.id}`,
+      recordId: row.id,
+      kind: "item",
+      label: row.name,
+      group: RECORD_GROUP_LABEL.item,
+      href: buildRecordHref("item", row.id, baseUrl),
+    });
+  }
+  for (const row of (datasetsRes.data as DatasetRow[] | null) ?? []) {
+    out.push({
+      id: `record-dataset-${row.id}`,
+      recordId: row.id,
+      kind: "dataset",
+      label: row.name,
+      group: RECORD_GROUP_LABEL.dataset,
+      href: buildRecordHref("dataset", row.id, baseUrl),
+    });
+  }
+  for (const row of (eventsRes.data as EventRow[] | null) ?? []) {
+    out.push({
+      id: `record-event-${row.id}`,
+      recordId: row.id,
+      kind: "event",
+      label: row.title,
+      group: RECORD_GROUP_LABEL.event,
+      href: buildRecordHref("event", row.id, baseUrl),
+    });
+  }
+  return out;
+}
+
+type SearchEntry =
+  | ({ entryKind: "page" } & PageEntry)
+  | ({ entryKind: "record" } & RecordEntry);
+
 export interface GlobalSearchProps {
   /** Pass `import.meta.env.BASE_URL` from the host app. */
   baseUrl: string;
@@ -113,25 +278,69 @@ export interface GlobalSearchProps {
 
 export const GlobalSearch = ({
   baseUrl,
-  placeholder = "Search projects, protocols, inventory…",
+  placeholder = "Search records, projects, protocols, inventory…",
   className,
   style,
 }: GlobalSearchProps) => {
+  const { activeLab } = useAuth();
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
+  const [records, setRecords] = useState<RecordEntry[]>([]);
+  const [recordsLoading, setRecordsLoading] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const listboxId = useId();
 
-  const matches = useMemo(() => {
+  const pageMatches = useMemo<PageEntry[]>(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return [] as PageEntry[];
-    const scored = PAGES.map((page) => ({ page, score: matchScore(page, q) }))
+    if (!q) return [];
+    return PAGES.map((page) => ({ page, score: matchScore(page, q) }))
       .filter((entry) => entry.score >= 0)
-      .sort((a, b) => a.score - b.score || a.page.label.localeCompare(b.page.label));
-    return scored.slice(0, 12).map((entry) => entry.page);
+      .sort((a, b) => a.score - b.score || a.page.label.localeCompare(b.page.label))
+      .slice(0, 8)
+      .map((entry) => entry.page);
   }, [query]);
+
+  // Debounced record search. We keep the previous results visible while a
+  // new query is in flight to avoid the dropdown collapsing on each keystroke.
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed || !activeLab?.id) {
+      setRecords([]);
+      setRecordsLoading(false);
+      return;
+    }
+    setRecordsLoading(true);
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      void searchRecords(trimmed, activeLab.id, baseUrl)
+        .then((results) => {
+          if (cancelled) return;
+          setRecords(results);
+          setRecordsLoading(false);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setRecords([]);
+          setRecordsLoading(false);
+        });
+    }, 220);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [query, activeLab?.id, baseUrl]);
+
+  const entries = useMemo<SearchEntry[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    const list: SearchEntry[] = [];
+    // Records first — they're the more specific match for a name query.
+    for (const r of records) list.push({ entryKind: "record", ...r });
+    for (const p of pageMatches) list.push({ entryKind: "page", ...p });
+    return list;
+  }, [pageMatches, records, query]);
 
   useEffect(() => {
     setActiveIdx(0);
@@ -147,24 +356,25 @@ export const GlobalSearch = ({
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);
 
-  const choose = (page: PageEntry) => {
-    const href = buildPageHref(page, baseUrl);
+  const choose = (entry: SearchEntry) => {
+    const href =
+      entry.entryKind === "page" ? buildPageHref(entry, baseUrl) : entry.href;
     navigateTo(href);
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      if (matches.length === 0) return;
-      setActiveIdx((idx) => (idx + 1) % matches.length);
+      if (entries.length === 0) return;
+      setActiveIdx((idx) => (idx + 1) % entries.length);
       setOpen(true);
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
-      if (matches.length === 0) return;
-      setActiveIdx((idx) => (idx - 1 + matches.length) % matches.length);
+      if (entries.length === 0) return;
+      setActiveIdx((idx) => (idx - 1 + entries.length) % entries.length);
       setOpen(true);
     } else if (event.key === "Enter") {
-      const target = matches[activeIdx];
+      const target = entries[activeIdx];
       if (target) {
         event.preventDefault();
         choose(target);
@@ -174,6 +384,11 @@ export const GlobalSearch = ({
       inputRef.current?.blur();
     }
   };
+
+  const trimmed = query.trim();
+  const showDropdown = open && trimmed.length > 0;
+  const showLoading = recordsLoading && entries.length === 0;
+  const showEmpty = !recordsLoading && entries.length === 0;
 
   return (
     <div
@@ -197,30 +412,35 @@ export const GlobalSearch = ({
         }}
         onKeyDown={onKeyDown}
         role="combobox"
-        aria-expanded={open && matches.length > 0}
+        aria-expanded={showDropdown && entries.length > 0}
         aria-controls={listboxId}
         aria-autocomplete="list"
         aria-activedescendant={
-          open && matches[activeIdx] ? `${listboxId}-${activeIdx}` : undefined
+          showDropdown && entries[activeIdx] ? `${listboxId}-${activeIdx}` : undefined
         }
       />
       <span className="ils-search-glyph" aria-hidden="true">⌕</span>
-      {open && query.trim().length > 0 ? (
+      {showDropdown ? (
         <ul className="ils-search-results" id={listboxId} role="listbox">
-          {matches.length === 0 ? (
+          {showLoading ? (
             <li className="ils-search-empty" role="presentation">
-              No matching pages.
+              Searching records…
+            </li>
+          ) : showEmpty ? (
+            <li className="ils-search-empty" role="presentation">
+              No matching records or pages.
             </li>
           ) : (
-            matches.map((page, idx) => (
+            entries.map((entry, idx) => (
               <li
-                key={page.id}
+                key={entry.id}
                 id={`${listboxId}-${idx}`}
                 role="option"
                 aria-selected={idx === activeIdx}
                 className={[
                   "ils-search-result",
                   idx === activeIdx ? "is-active" : null,
+                  entry.entryKind === "record" ? "is-record" : "is-page",
                 ]
                   .filter(Boolean)
                   .join(" ")}
@@ -228,11 +448,11 @@ export const GlobalSearch = ({
                 onMouseDown={(event) => {
                   // mousedown so the click fires before blur dismisses the list
                   event.preventDefault();
-                  choose(page);
+                  choose(entry);
                 }}
               >
-                <span className="ils-search-result-label">{page.label}</span>
-                <span className="ils-search-result-group">{page.group}</span>
+                <span className="ils-search-result-label">{entry.label}</span>
+                <span className="ils-search-result-group">{entry.group}</span>
               </li>
             ))
           )}


### PR DESCRIPTION
Closes #90, closes #92.

## Issue #90 — additional things to look into

1. **Activity feed missed datasets and bookings.** Both kinds were in the `ActivityEntry` type union but never pushed into the stream. Now both fetch their 6 most-recent updates and merge into the feed. Visible slice bumped to 8 to absorb the new kinds.
2. **Upcoming schedule didn't show recurrent events.** The dashboard query was `gte('start_time', nowIso)`, which excluded events whose first instance was already in the past even though their recurrence rule would generate future ones. We now also fetch events with a non-null `recurrence_rule` whose `start_time < now` and expand instances client-side over the next 14 days using the same rule semantics as the scheduler app.
3. **Homepage refresh didn't feel real-time.** The manual button already re-fetched everything; we now also auto-refresh once a minute while the tab is visible.
4. **Global search wasn't useful.** Search now hits the active lab's `projects`, `protocols`, `items`, `datasets`, and `calendar_events` (name/title ILIKE) and lists matches above the page-navigation matches. Selecting a record jumps to its parent app and opens it: protocol-manager loads it into the editor, project-manager opens the project view, supply-manager opens the edit modal, scheduler opens the event detail modal, data-hub pre-selects the dataset. Each app's hash parser was extended to read `#/{tab}/{id}` (or `#dataset/{id}` for the data hub) on mount.

## Issue #92 — project JSON transfer

New `apps/project-manager/src/lib/projectIO.ts` defines a versioned export + strict import schema mirroring the protocol-manager IO contract:

- `kind: \"ilm.project\"`, `version: 1`
- Preserves project metadata (name, description, status, approvalRequired), all milestones with their experiments, ungrouped experiments, and sort order
- Strips lab-scoped IDs, created_by, and timestamps so an export from one lab can be imported into another

Project Manager UI:
- View tab: \"Export JSON\" button next to the project state tag
- Library subbar: \"Import JSON\" button next to \"+ New project\" — opens a paste-or-upload modal that creates a fresh draft project, then re-creates milestones + experiments under it

## Test plan
- [x] `npm run typecheck` passes locally
- [x] `npm run build` passes locally (all 7 apps)
- [ ] Apply on a lab with at least one recurring weekly event whose first occurrence is in the past — confirm it appears in the homepage \"upcoming\" list
- [ ] Update a dataset; confirm the change appears in the homepage activity feed within ~1 minute
- [ ] In the topbar global search, type a project / protocol / item name and confirm the match navigates straight to that record
- [ ] Export a project, import the JSON back; confirm the new draft contains the same milestones, experiments, and sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)