### PR TITLE
Print: start each top-level section on a new page

### DIFF
--- a/apps/project-manager/src/lib/printRoadmap.ts
+++ b/apps/project-manager/src/lib/printRoadmap.ts
@@ -86,7 +86,14 @@ const PRINT_STYLES = `
     margin-top: 22px;
     page-break-inside: avoid;
   }
-  .roadmap-section + .roadmap-section { margin-top: 28px; }
+  /* Each milestone (and the unassigned-experiments tail) starts on a new
+     page when printed. The first roadmap section follows the document
+     header on page 1; the adjacent-sibling selector skips it. */
+  .roadmap-section + .roadmap-section {
+    margin-top: 0;
+    break-before: page;
+    page-break-before: always;
+  }
   .section-head {
     border-left: 4px solid #1f9d6c;
     padding: 4px 0 4px 12px;

--- a/apps/protocol-manager/src/lib/printProtocol.ts
+++ b/apps/protocol-manager/src/lib/printProtocol.ts
@@ -216,6 +216,16 @@ const PRINT_STYLES = `
     page-break-inside: auto;
   }
   .section + .section { margin-top: 26px; }
+  /* Each top-level section starts on a fresh page when printed. The
+     adjacent-sibling selector skips the very first section (it follows
+     the TOC on page 1) and only matches the 2nd, 3rd, … top-level
+     sections. Nested subsections do not get the break — they flow
+     inside their parent section. */
+  .section-top + .section-top {
+    break-before: page;
+    page-break-before: always;
+    margin-top: 0;
+  }
   .section-head {
     border-left: 4px solid #1f9d6c;
     padding: 4px 0 4px 12px;
@@ -511,8 +521,11 @@ const renderSection = (section: ProtocolSection, path: string, depth: number): s
     ? `<p class="section-description">${escapeHtml(section.description)}</p>`
     : "";
   const anchorId = `section-${escapeHtml(section.id)}`;
+  // Mark depth-0 sections so the print stylesheet can put each one on its
+  // own page. Subsections share the parent's page by design.
+  const className = depth === 0 ? "section section-top" : "section";
   return `
-    <section class="section" id="${anchorId}">
+    <section class="${className}" id="${anchorId}">
       <header class="section-head">
         <div class="section-marker">${escapeHtml(marker)}</div>
         <${headingTag}>${escapeHtml(path)} ${escapeHtml(section.title || "Untitled section")}</${headingTag}>


### PR DESCRIPTION
Per feedback on the new printable views — each top-level section now begins on a fresh page when printed. The first section stays on page 1 alongside the document header (and, in the protocol case, the TOC); pages 2+ each open with their own section.

Implementation: an adjacent-sibling rule with the modern `break-before: page` and the legacy `page-break-before: always`. Skipping the first section is automatic because the selector requires a previous-sibling section of the same kind.

- **Protocol**: `printProtocol.ts` now marks depth-0 sections with `section section-top`. Nested subsections still flow inside the parent page so they don't wastefully eat a page each.
- **Project roadmap**: `printRoadmap.ts` applies the same break to milestones (and the unassigned-experiments tail) so the two printable views behave consistently.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Print a multi-section protocol and confirm the title block + materials + TOC + section 1 land on page 1, then sections 2…N each open a new page.
- [ ] Print a project roadmap with multiple milestones and confirm the second milestone starts on page 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)