### PR TITLE
Print: put section 1 on its own page

### DIFF
--- a/apps/project-manager/src/lib/printRoadmap.ts
+++ b/apps/project-manager/src/lib/printRoadmap.ts
@@ -86,10 +86,12 @@ const PRINT_STYLES = `
     margin-top: 22px;
     page-break-inside: avoid;
   }
-  /* Each milestone (and the unassigned-experiments tail) starts on a new
-     page when printed. The first roadmap section follows the document
-     header on page 1; the adjacent-sibling selector skips it. */
-  .roadmap-section + .roadmap-section {
+  /* Every milestone (and the unassigned-experiments tail) starts on its
+     own page when printed — including the first one, so the cover page
+     (project title + metadata + summary) stays clean. Browsers ignore
+     `break-before: page` on the very first node of the print job, so
+     this is also safe for single-section prints. */
+  .roadmap-section {
     margin-top: 0;
     break-before: page;
     page-break-before: always;

--- a/apps/protocol-manager/src/lib/printProtocol.ts
+++ b/apps/protocol-manager/src/lib/printProtocol.ts
@@ -216,12 +216,14 @@ const PRINT_STYLES = `
     page-break-inside: auto;
   }
   .section + .section { margin-top: 26px; }
-  /* Each top-level section starts on a fresh page when printed. The
-     adjacent-sibling selector skips the very first section (it follows
-     the TOC on page 1) and only matches the 2nd, 3rd, … top-level
-     sections. Nested subsections do not get the break — they flow
-     inside their parent section. */
-  .section-top + .section-top {
+  /* Every top-level section starts on its own page when printed —
+     including the first one, so the cover page (title + metadata +
+     materials + TOC) is never crowded by the first section. Browsers
+     ignore `break-before: page` on the very first node in a print job,
+     so this also produces clean output if the user prints from a single
+     section without the cover. Nested subsections do not get the break
+     — they flow inside their parent section. */
+  .section-top {
     break-before: page;
     page-break-before: always;
     margin-top: 0;


### PR DESCRIPTION
Follow-up on #97. The previous rule (`.section-top + .section-top`) skipped the very first section, so the cover page was crowded with the title block + materials + TOC + section 1. The user wants section 1 to start on its own page too.

Changed to a single-class selector that targets every top-level section, including the first:

```css
.section-top {
  break-before: page;
  page-break-before: always;
  margin-top: 0;
}
```

Browsers ignore `break-before: page` on the very first node of the print job, so single-section prints (no cover) still render without a leading blank page.

Same change applied to the project roadmap (`.roadmap-section`) so the two printable views stay consistent.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Print a multi-section protocol — confirm page 1 holds the title block + materials + TOC, page 2 starts with section 1, page 3+ each open with their own section.
- [ ] Print a project roadmap with multiple milestones — confirm milestone 1 lands on page 2, milestone 2 on page 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)