### PR TITLE
Fix: escape backticks in PRINT_STYLES comments (deploy fix)

### DIFF
--- a/apps/project-manager/src/lib/printRoadmap.ts
+++ b/apps/project-manager/src/lib/printRoadmap.ts
@@ -89,7 +89,7 @@ const PRINT_STYLES = `
   /* Every milestone (and the unassigned-experiments tail) starts on its
      own page when printed — including the first one, so the cover page
      (project title + metadata + summary) stays clean. Browsers ignore
-     `break-before: page` on the very first node of the print job, so
+     break-before:page on the very first node of the print job, so
      this is also safe for single-section prints. */
   .roadmap-section {
     margin-top: 0;

--- a/apps/protocol-manager/src/lib/printProtocol.ts
+++ b/apps/protocol-manager/src/lib/printProtocol.ts
@@ -219,7 +219,7 @@ const PRINT_STYLES = `
   /* Every top-level section starts on its own page when printed —
      including the first one, so the cover page (title + metadata +
      materials + TOC) is never crowded by the first section. Browsers
-     ignore `break-before: page` on the very first node in a print job,
+     ignore break-before:page on the very first node in a print job,
      so this also produces clean output if the user prints from a single
      section without the cover. Nested subsections do not get the break
      — they flow inside their parent section. */


### PR DESCRIPTION
PR #98 added a CSS comment with backticks inside the \`PRINT_STYLES\` template literal:

\`\`\`ts
const PRINT_STYLES = \`
  ...
  /* Browsers ignore \`break-before: page\` on the very first node ... */
  ...
\`;
\`\`\`

Those inner backticks terminated the outer template literal early, breaking the JavaScript parse and failing the **Deploy ILM Apps to GitHub Pages** workflow on the merge of #98 with \`TS1005\` / \`TS1003\` syntax errors at \`printProtocol.ts:222\` (and the matching site in \`printRoadmap.ts\`).

Local incremental builds had cached an earlier valid \`.tsbuildinfo\`, so \`npm run build\` looked clean here even though a fresh CI build saw the actual error.

Fix: drop the inner backticks — plain \`break-before:page\` inside the CSS block comment doesn't need them. No behavior change. Verified with \`npm run build -w @ilm/protocol-manager\` and \`-w @ilm/project-manager\` (both clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)