### PR TITLE
Account / lab delete: Danger zone in Settings

### DIFF
--- a/apps/account/src/styles.css
+++ b/apps/account/src/styles.css
@@ -931,6 +931,67 @@
 .acct-danger-button:hover:not(:disabled) { background: var(--ilm-red-soft); }
 .acct-danger-button:disabled { opacity: 0.5; cursor: not-allowed; }
 
+/* ---------- Danger zone (mirrors GitHub's settings layout) -------- */
+.acct-danger-zone {
+  border: 1px solid var(--ilm-red, #c0392b);
+  background: #fff8f7;
+  box-shadow: 0 0 0 1px rgba(192, 57, 43, 0.05) inset;
+}
+.acct-danger-zone .acct-card-header h2 {
+  color: var(--ilm-red, #c0392b);
+}
+.acct-danger-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 0.85rem 0;
+  border-top: 1px solid rgba(192, 57, 43, 0.18);
+}
+.acct-danger-row:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+.acct-danger-copy {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+.acct-danger-copy strong {
+  display: block;
+  font-size: 0.95rem;
+  color: var(--ilm-ink, #14181d);
+  margin-bottom: 0.2rem;
+}
+.acct-danger-copy p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--ilm-muted, #5b6470);
+  line-height: 1.45;
+}
+.acct-danger-copy em {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--ilm-ink, #14181d);
+}
+.acct-danger-confirm {
+  flex: 1 1 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: #fff;
+  border: 1px dashed #d89593;
+  border-radius: 6px;
+  padding: 0.75rem 0.85rem;
+}
+.acct-danger-confirm .acct-field span code {
+  background: #fbeae8;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 0.78rem;
+  color: var(--ilm-red, #c0392b);
+}
+
 .acct-text-button {
   appearance: none;
   border: 1px solid var(--ilm-line);

--- a/apps/account/src/views/SettingsView.tsx
+++ b/apps/account/src/views/SettingsView.tsx
@@ -66,6 +66,8 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
     updateProfile,
     updatePassword,
     renameLab,
+    deleteLab,
+    deleteMyAccount,
     refreshLabs,
   } = useAuth();
   const tier: MembershipTier = (activeLab?.role as MembershipTier | undefined) ?? "member";
@@ -93,6 +95,27 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
   const [passwordBusy, setPasswordBusy] = useState(false);
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [passwordNotice, setPasswordNotice] = useState<string | null>(null);
+
+  // Danger-zone state. We split delete-lab and delete-account into two
+  // independent rows, each with a separate confirmation step. The user
+  // must type the lab name (or the literal word "delete") before the
+  // destructive RPC fires, mirroring GitHub's pattern.
+  const [labDeleteOpen, setLabDeleteOpen] = useState(false);
+  const [labDeleteText, setLabDeleteText] = useState("");
+  const [labDeleteBusy, setLabDeleteBusy] = useState(false);
+  const [labDeleteError, setLabDeleteError] = useState<string | null>(null);
+  const [accountDeleteOpen, setAccountDeleteOpen] = useState(false);
+  const [accountDeleteText, setAccountDeleteText] = useState("");
+  const [accountDeleteBusy, setAccountDeleteBusy] = useState(false);
+  const [accountDeleteError, setAccountDeleteError] = useState<string | null>(null);
+
+  // Reset danger-zone confirmations whenever the active lab changes — a stale
+  // confirmation typed against the previous lab should not auto-apply here.
+  useEffect(() => {
+    setLabDeleteOpen(false);
+    setLabDeleteText("");
+    setLabDeleteError(null);
+  }, [activeLab?.id]);
 
   // Re-sync local state when the underlying profile/lab changes.
   useEffect(() => {
@@ -197,6 +220,45 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
       setLabError(errorMessage(err));
     } finally {
       setLabBusy(false);
+    }
+  };
+
+  const labDeleteConfirmationOk =
+    !!activeLab && labDeleteText.trim() === activeLab.name.trim() && activeLab.name.trim().length > 0;
+
+  const handleDeleteLab = async () => {
+    if (!activeLab || !labDeleteConfirmationOk) return;
+    setLabDeleteError(null);
+    setLabDeleteBusy(true);
+    try {
+      await deleteLab(activeLab.id);
+      await refreshLabs();
+      setLabDeleteOpen(false);
+      setLabDeleteText("");
+    } catch (err) {
+      setLabDeleteError(errorMessage(err));
+    } finally {
+      setLabDeleteBusy(false);
+    }
+  };
+
+  const ACCOUNT_DELETE_PHRASE = "delete my account";
+  const accountDeleteConfirmationOk =
+    accountDeleteText.trim().toLowerCase() === ACCOUNT_DELETE_PHRASE;
+
+  const handleDeleteAccount = async () => {
+    if (!accountDeleteConfirmationOk) return;
+    setAccountDeleteError(null);
+    setAccountDeleteBusy(true);
+    try {
+      await deleteMyAccount();
+      // The auth provider already reset session/profile state; the
+      // protected-route guard will surface the sign-in screen on the next
+      // render. Nothing left for this view to do.
+    } catch (err) {
+      setAccountDeleteError(errorMessage(err));
+    } finally {
+      setAccountDeleteBusy(false);
     }
   };
 
@@ -408,6 +470,144 @@ export const SettingsView = ({ onOpenLabPicker }: { onOpenLabPicker: () => void 
             ) : null}
           </form>
         )}
+      </section>
+
+      <section className="acct-card acct-danger-zone" aria-label="Danger zone">
+        <div className="acct-card-header">
+          <div>
+            <h2>Danger zone</h2>
+            <p>Irreversible actions. Read the warning text and confirm carefully.</p>
+          </div>
+        </div>
+
+        {isOwner && activeLab ? (
+          <div className="acct-danger-row">
+            <div className="acct-danger-copy">
+              <strong>Delete this lab</strong>
+              <p>
+                Permanently removes <em>{activeLab.name}</em> and every project, protocol,
+                inventory item, dataset, schedule entry, and funding record scoped to it.
+                Co-workers in this lab will lose access immediately. This cannot be undone.
+              </p>
+            </div>
+            {!labDeleteOpen ? (
+              <button
+                type="button"
+                className="acct-danger-button"
+                onClick={() => {
+                  setLabDeleteOpen(true);
+                  setLabDeleteError(null);
+                  setLabDeleteText("");
+                }}
+              >
+                Delete lab…
+              </button>
+            ) : (
+              <div className="acct-danger-confirm">
+                <label className="acct-field">
+                  <span>
+                    Type the lab name <code>{activeLab.name}</code> to confirm.
+                  </span>
+                  <input
+                    type="text"
+                    value={labDeleteText}
+                    onChange={(event) => setLabDeleteText(event.target.value)}
+                    placeholder={activeLab.name}
+                    disabled={labDeleteBusy}
+                    autoFocus
+                  />
+                </label>
+                {labDeleteError ? <p className="acct-error">{labDeleteError}</p> : null}
+                <div className="acct-row-actions">
+                  <button
+                    type="button"
+                    className="acct-text-button"
+                    onClick={() => {
+                      setLabDeleteOpen(false);
+                      setLabDeleteText("");
+                      setLabDeleteError(null);
+                    }}
+                    disabled={labDeleteBusy}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="acct-danger-button"
+                    onClick={() => void handleDeleteLab()}
+                    disabled={labDeleteBusy || !labDeleteConfirmationOk}
+                  >
+                    {labDeleteBusy ? "Deleting…" : "I understand — delete this lab"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        <div className="acct-danger-row">
+          <div className="acct-danger-copy">
+            <strong>Delete your account</strong>
+            <p>
+              Permanently removes your sign-in, profile, and lab memberships. You will be
+              signed out immediately and will not be able to recover this account. Labs you
+              co-own with other admins keep working; labs you are the sole owner of must be
+              deleted (or transferred) first.
+            </p>
+          </div>
+          {!accountDeleteOpen ? (
+            <button
+              type="button"
+              className="acct-danger-button"
+              onClick={() => {
+                setAccountDeleteOpen(true);
+                setAccountDeleteError(null);
+                setAccountDeleteText("");
+              }}
+            >
+              Delete account…
+            </button>
+          ) : (
+            <div className="acct-danger-confirm">
+              <label className="acct-field">
+                <span>
+                  Type <code>{ACCOUNT_DELETE_PHRASE}</code> to confirm.
+                </span>
+                <input
+                  type="text"
+                  value={accountDeleteText}
+                  onChange={(event) => setAccountDeleteText(event.target.value)}
+                  placeholder={ACCOUNT_DELETE_PHRASE}
+                  disabled={accountDeleteBusy}
+                  autoFocus
+                />
+              </label>
+              {accountDeleteError ? <p className="acct-error">{accountDeleteError}</p> : null}
+              <div className="acct-row-actions">
+                <button
+                  type="button"
+                  className="acct-text-button"
+                  onClick={() => {
+                    setAccountDeleteOpen(false);
+                    setAccountDeleteText("");
+                    setAccountDeleteError(null);
+                  }}
+                  disabled={accountDeleteBusy}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="acct-danger-button"
+                  onClick={() => void handleDeleteAccount()}
+                  disabled={accountDeleteBusy || !accountDeleteConfirmationOk}
+                >
+                  {accountDeleteBusy ? "Deleting…" : "I understand — delete my account"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </section>
     </div>
   );

--- a/packages/ui/src/auth/AuthProvider.tsx
+++ b/packages/ui/src/auth/AuthProvider.tsx
@@ -37,7 +37,11 @@ type AuthContextValue = {
   selectLab: (labId: string | null) => void;
   createLab: (name: string, slug?: string) => Promise<LabWithRole>;
   renameLab: (labId: string, name: string) => Promise<LabWithRole>;
+  deleteLab: (labId: string) => Promise<void>;
   refreshLabs: () => Promise<void>;
+
+  // Destructive account action
+  deleteMyAccount: () => Promise<void>;
 };
 
 const ACTIVE_LAB_STORAGE_KEY = "ilm.activeLabId";
@@ -363,6 +367,44 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     [labs, supabase, user]
   );
 
+  const deleteLab = useCallback(
+    async (labId: string): Promise<void> => {
+      if (!user) throw new Error("Not signed in");
+      setError(null);
+      const { error: err } = await supabase.rpc("delete_lab", { p_lab_id: labId });
+      if (err) {
+        setError(err.message);
+        throw err;
+      }
+      setLabs((prev) => prev.filter((entry) => entry.id !== labId));
+      if (activeLabId === labId) setActiveLabId(null);
+    },
+    [activeLabId, supabase, user]
+  );
+
+  const deleteMyAccount = useCallback(async (): Promise<void> => {
+    if (!user) throw new Error("Not signed in");
+    setError(null);
+    const { error: err } = await supabase.rpc("delete_my_account");
+    if (err) {
+      setError(err.message);
+      throw err;
+    }
+    // The user row is gone; the existing session token is no longer valid.
+    // signOut clears local state so the auth shell drops back to the
+    // landing page rather than spinning on a stale session.
+    try {
+      await supabase.auth.signOut();
+    } catch {
+      // Ignore — we'll clear local state regardless.
+    }
+    setActiveLabId(null);
+    setLabs([]);
+    setProfile(null);
+    setSession(null);
+    setStatus("signed-out");
+  }, [supabase, user]);
+
   const value: AuthContextValue = {
     status,
     session,
@@ -380,7 +422,9 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     selectLab,
     createLab,
     renameLab,
+    deleteLab,
     refreshLabs,
+    deleteMyAccount,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/supabase/migrations/20260508010000_account_and_lab_delete.sql
+++ b/supabase/migrations/20260508010000_account_and_lab_delete.sql
@@ -1,0 +1,115 @@
+-- Account & lab destructive actions
+--
+-- Issue: users had no in-app way to permanently remove their own account or
+-- to dissolve a lab they own. Adds two SECURITY DEFINER RPCs that the new
+-- "Danger zone" panel in SettingsView calls. Both are intentionally blunt:
+-- we rely on FK ON DELETE CASCADE chains established in earlier migrations
+-- (lab_memberships → labs / users; projects/items/datasets/etc. → labs;
+-- profiles → users) so a single delete tears down the dependent rows.
+--
+-- Safety rules:
+--   * delete_lab requires the caller be that lab's owner.
+--   * delete_my_account refuses if the caller is the sole owner of any lab,
+--     so no lab ever ends up orphaned. The user must delete the lab (or
+--     promote another owner — already supported via lab_memberships UPDATE)
+--     before they can dispose of their own account.
+
+-- ---------------------------------------------------------------------------
+-- delete_lab — owner-only, cascades to every lab-scoped row.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.delete_lab(p_lab_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_role text;
+begin
+  if v_uid is null then
+    raise exception 'Not authenticated' using errcode = '42501';
+  end if;
+  if p_lab_id is null then
+    raise exception 'Lab id is required' using errcode = '22023';
+  end if;
+
+  select role into v_role
+  from public.lab_memberships
+  where lab_id = p_lab_id
+    and user_id = v_uid
+  limit 1;
+
+  if v_role is null or v_role <> 'owner' then
+    raise exception 'Only the lab owner can delete the lab' using errcode = '42501';
+  end if;
+
+  -- Lab cascades take care of memberships, projects, milestones,
+  -- experiments, items, item_projects, inventory_checks, order_requests,
+  -- order_request_items, orders, stock_lots, calendar_events, bookings,
+  -- planned_tasks, datasets, dataset_*, funding_sources, etc. (every
+  -- domain table is `references public.labs(id) on delete cascade`).
+  delete from public.labs where id = p_lab_id;
+end;
+$$;
+
+grant execute on function public.delete_lab(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- delete_my_account — wipes the calling user from auth.users. The cascade
+-- removes profile + memberships; orphan-protection blocks the call if the
+-- user is the sole owner of any lab.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_orphan_count integer;
+  v_orphan_names text;
+begin
+  if v_uid is null then
+    raise exception 'Not authenticated' using errcode = '42501';
+  end if;
+
+  -- Find labs the caller solely owns. A lab is "sole-owned" by the caller
+  -- when there's exactly one membership with role='owner' and it belongs
+  -- to the caller.
+  with caller_owner_labs as (
+    select lab_id
+    from public.lab_memberships
+    where user_id = v_uid and role = 'owner'
+  ),
+  sole_owner_labs as (
+    select col.lab_id
+    from caller_owner_labs col
+    where (
+      select count(*) from public.lab_memberships m2
+      where m2.lab_id = col.lab_id and m2.role = 'owner'
+    ) = 1
+  )
+  select count(*),
+         string_agg(l.name, ', ' order by l.name)
+    into v_orphan_count, v_orphan_names
+  from sole_owner_labs s
+  join public.labs l on l.id = s.lab_id;
+
+  if coalesce(v_orphan_count, 0) > 0 then
+    raise exception
+      'Cannot delete account while you are the sole owner of: %. Delete the lab(s) or promote another owner first.',
+      v_orphan_names
+      using errcode = '42501';
+  end if;
+
+  -- Drop the user. Cascades remove profile + memberships; lab.created_by
+  -- columns are `on delete set null` so co-owned labs keep functioning.
+  delete from auth.users where id = v_uid;
+end;
+$$;
+
+grant execute on function public.delete_my_account() to authenticated;


### PR DESCRIPTION
Closes #100.

Adds in-app, owner-gated destructive actions for lab dissolution and account deletion, surfaced in a GitHub-style **Danger zone** card at the bottom of the Settings page. Each action requires an explicit text confirmation before the button enables.

## Backend

New migration [20260508010000_account_and_lab_delete.sql](supabase/migrations/20260508010000_account_and_lab_delete.sql) adds two SECURITY DEFINER RPCs:

- **\`delete_lab(p_lab_id)\`** — owner-only. Drops the lab; existing FK cascades dispose of every lab-scoped row (memberships, projects, milestones, experiments, items, item_projects, inventory_checks, order_requests, orders, stock_lots, calendar_events, bookings, planned_tasks, datasets, funding_sources, …).
- **\`delete_my_account()\`** — wipes the calling user from \`auth.users\`. Refuses if the caller is the sole owner of any lab (so no lab is orphaned); the user must delete the lab(s) or promote another owner first. \`profiles\` + \`lab_memberships\` are removed via the existing \`on delete cascade\`. \`labs.created_by\` is \`on delete set null\`, so co-owned labs keep functioning.

## Frontend

- \`AuthProvider\` exposes \`deleteLab(labId)\` and \`deleteMyAccount()\`. The account-delete also calls \`auth.signOut()\` and clears local session/profile/labs state, so the protected-route guard drops back to the sign-in screen on the next render.
- \`SettingsView\` gets a **Danger zone** section. Two independent rows:
  - **Delete this lab** (only rendered for owners) — confirmation requires typing the lab's exact name.
  - **Delete your account** — confirmation requires typing the literal phrase \`delete my account\`.
- Buttons stay disabled until the confirmation field matches; an inline error surfaces RLS / orphan-protection failures from the RPC.
- Red-bordered card styling in [styles.css](apps/account/src/styles.css) (\`.acct-danger-zone\`, \`.acct-danger-row\`, \`.acct-danger-confirm\`).

## Test plan
- [x] \`npm run typecheck\`, \`npm run build\`
- [ ] Apply the migration. As a lab owner, open Settings → Danger zone, click **Delete lab…**, type the wrong name (button stays disabled), then the right name (button enables, click confirms, lab disappears, returns to lab picker).
- [ ] As the sole owner of a lab, click **Delete account…** — the RPC should reject with \"sole owner of …\" and the inline error should show.
- [ ] As a non-sole-owner (or non-owner) account, **Delete account…** succeeds, the session is cleared, and the app drops back to the sign-in screen.
- [ ] As a non-owner member, the lab row should not render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)